### PR TITLE
添加npm构建命令

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "layaAir.config.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "build": "cd src && gulp build"
   },
   "author": "LayaAir Team",
   "license": "ISC",
@@ -23,6 +23,7 @@
     "rollup": "^1.16.7",
     "rollup-plugin-glsl": "^1.3.0",
     "rollup-plugin-typescript": "^1.0.1",
-    "rollup-plugin-typescript2": "^0.21.2"
+    "rollup-plugin-typescript2": "^0.21.2",
+    "tsc": "^1.20150623.0"
   }
 }


### PR DESCRIPTION
添加npm构建命令, 使用该命令构建laya库无需全局安装gulp和tsc
通过命令`npm run build` 或者 `yarn build` 可以执行构建
通过最新的VSCode可以一键执行构建命令而无需进行任何附加配置
![image](https://user-images.githubusercontent.com/6964556/66918091-2da02d00-f051-11e9-8b23-cdd85ce23253.png)


移除无用的test命令
Fix #64 