### PR TITLE
fix

### DIFF
--- a/src/layaAir/laya/physics/ColliderBase.ts
+++ b/src/layaAir/laya/physics/ColliderBase.ts
@@ -46,7 +46,12 @@ export class ColliderBase extends Component {
      * @override
      */
     protected _onEnable(): void {
-        this.rigidBody || Laya.systemTimer.callLater(this, this._checkRigidBody);
+        if(this.rigidBody){
+            this.refresh();
+        }
+        else{
+            Laya.systemTimer.callLater(this, this._checkRigidBody);
+        }
     }
 
     private _checkRigidBody(): void {


### PR DESCRIPTION
When the IDE exports 2DCollider.enabled = false, setting the enabled to true is invalid.