### PR TITLE
修复当scrollRect.height或者scrollRect.width为0时的显示错误问题

### DIFF
--- a/src/layaAir/laya/renders/RenderSprite.ts
+++ b/src/layaAir/laya/renders/RenderSprite.ts
@@ -204,8 +204,13 @@ export class RenderSprite {
 		var next: RenderSprite = this._next;
 		if (next == RenderSprite.NORENDER) return;
 		var r: Rectangle = sprite._style.scrollRect;
+		var width = r.width;
+		var height = r.height;
+		if (width === 0 || height === 0) {
+			return;
+		}
 		context.save();
-		context.clipRect(x, y, r.width, r.height);
+		context.clipRect(x, y, width, height);
 		next._fun.call(next, sprite, context, x - r.x, y - r.y);
 		context.restore();
 	}


### PR DESCRIPTION
当`scrollRect.height=0`或者`scrollRect.width=0`时
https://github.com/layabox/LayaAir/blob/master/src/layaAir/laya/webgl/shader/d2/files/texture.vs.glsl#L58
中
```glsl
cliped=vec2( dot(clippos,clipMatDir.xy)/clipw/clipw, dot(clippos,clipMatDir.zw)/cliph/cliph);
```
其中`clipw`或者`cliph`会相应的为`0`，导致出现`除0`问题。
最终导致显示效果达不到预期
也可在此处进行判定，改为
```glsl
		if(cliph>0.){
			cliph = dot(clippos,clipMatDir.zw)/cliph/cliph;
		}
		if(clipw>0.){
			clipw=dot(clippos,clipMatDir.xy)/clipw/clipw;
		}
		
		cliped=vec2( clipw, cliph);
```
不过这样会浪费一次`drawcall`，我认为直接改掉`RenderSprite`的`_clip`方法更省