### PR TITLE
修复当音频切后台时间过长，再恢复前台时会报错的问题

### DIFF
--- a/src/layaAir/laya/media/h5audio/AudioSoundChannel.ts
+++ b/src/layaAir/laya/media/h5audio/AudioSoundChannel.ts
@@ -143,12 +143,19 @@ export class AudioSoundChannel extends SoundChannel {
      * @override
      */
     resume(): void {
-        if (!this._audio)
+        var audio = this._audio;
+        if (!audio)
             return;
         this.isStopped = false;
+        if (audio.readyState == 0) { //当音频放到后台一定时间后，会被卸载，音频会断开连接，并将readyState重置为0
+            audio.src = this.url;
+            audio.addEventListener("canplay", this._resumePlay as any);
+            audio.load();
+        }
         ILaya.SoundManager.addChannel(this);
-        if ("play" in this._audio)
-            this._audio.play();
+        if ("play" in audio) {
+            audio.play();
+        }
     }
 
     /**


### PR DESCRIPTION
当游戏切后台以后，时间如果过长，Chrome，FireFox，Safari浏览器会将音频卸载，并抛出`abort`事件  
此时，游戏切回前台时，并未判断channel状态，会导致调用`play`报错 DOMException: Failed to load because no supported source was found