### PR TITLE
fix九宫格渲染bug

### DIFF
--- a/src/layaAir/laya/resource/Context.ts
+++ b/src/layaAir/laya/resource/Context.ts
@@ -2479,12 +2479,8 @@ export class Context {
 
 		var top: number = sizeGrid[0];
 		var left: number = sizeGrid[3];
-		var d_top: number = top / h;
-		var d_left: number = left / w;
 		var right: number = sizeGrid[1];
 		var bottom: number = sizeGrid[2];
-		var d_right: number = right / w;
-		var d_bottom: number = bottom / h;
 		var repeat: boolean = sizeGrid[4];
 		var needClip: boolean = false;
 
@@ -2494,6 +2490,11 @@ export class Context {
 		if (height == h) {
 			top = bottom = 0;
 		}
+
+		var d_top: number = top / h;
+		var d_left: number = left / w;
+		var d_right: number = right / w;
+		var d_bottom: number = bottom / h;
 
 		//处理进度条不好看的问题
 		if (left + right > width) {


### PR DESCRIPTION
1.问题描述
当图片的sizeGrid设置为上下左右全部需要拉伸时，但是实际设置图片的宽高只有一个方向需要拉伸，这时候会必现拉伸错乱的bug。
2.问题原因
在文件LayaAir/src/layaAir/laya/resource/Context.ts的函数drawTextureWithSizeGrid中，
在得到拉伸位置top，left， right， bottom后会设置拉伸比例:
```
            var d_top = top / h;
            var d_left = left / w;
            var d_right = right / w;
            var d_bottom = bottom / h;
```
但是这时如果设置的宽或高等于图片的原始宽或高时，会重置对应的位置，代码如下:
```
            if (width == w) {
                left = right = 0;
            }
            if (height == h) {
                top = bottom = 0;
            }
```
但是在重置之前已经设置了对应的d_top，d_left，d_right，d_bottom，现在把位置重置了又没有重置位置比例，导致问题出现。
3.问题解决
把位置比例初始化放到重置位置的代码之后:
```
            if (width == w) {
                left = right = 0;
            }
            if (height == h) {
                top = bottom = 0;
            }
            var d_top = top / h;
            var d_left = left / w;
            var d_right = right / w;
            var d_bottom = bottom / h;
```