### PR TITLE
fix: Node节点激活bug

### DIFF
--- a/src/layaAir/laya/display/Node.ts
+++ b/src/layaAir/laya/display/Node.ts
@@ -760,7 +760,7 @@ export class Node extends EventDispatcher {
         this._onActive();
         for (i = 0, n = this._children.length; i < n; i++) {
             var child: Node = this._children[i];
-            (!child._getBit(Const.NOT_ACTIVE)) && (child._activeHierarchy(activeChangeScripts));
+            (!child._getBit(Const.NOT_ACTIVE) && !child._getBit(Const.NOT_READY)) && (child._activeHierarchy(activeChangeScripts));
         }
         if (!this._getBit(Const.AWAKED)) {
             this._setBit(Const.AWAKED, true);


### PR DESCRIPTION
### 问题
Node层级激活，遍历子节点存在条件漏判情况

### 描述
当一个节点激活的时候，也就是执行 `_activeHierarchy` 方法，会遍历调用子节点的 `_activeHierarchy` 方法，调用的时候只检查了字节点的 `ACTIVE` 状态，没有检查 `READY` 状态，可能会遇到激活子节点的时候其仍未加载完成的情况，这样子节点的 `onAwake` 会提前执行。

### 复现例子
现在有一个场景（Scene） `mainScene`，场景上挂载了控制器（Script） `mainController`，然后在 `mainController` 的 `onAwake` 中实例化另一个 View，然后挂载到场景中
``` ts
// mainController
public onAwake() {
    const menu = new MenuView();
    this.owner.addChild(menu);
}
```
因为 `mainController` 脚本的激活是在 `mainScene` 遍历层级激活之前，所以这时候 MenuView 的实例已经被挂载到 `mainScene` 上了，但是它自己仍在异步加载中。

由于层级激活判断条件缺少 `READY` 判断，所以 `mainScene` 层级激活时也会调用 MenuView 实例的 `_activeHierarchy`，最终导致它的 `onAwake` 提前被调用，里面拿到的组件引用也就是都 `undefined`