### PR TITLE
修复BaseRender可见性标识不正确导致Animator更新不正确的问题

### DIFF
--- a/src/layaAir/laya/d3/component/Animator.ts
+++ b/src/layaAir/laya/d3/component/Animator.ts
@@ -877,7 +877,7 @@ export class Animator extends Component {
 		if (this.cullingMode === Animator.CULLINGMODE_CULLCOMPLETELY) {//所有渲染精灵不可见时
 			needRender = false;
 			for (var i: number = 0, n: number = this._renderableSprites.length; i < n; i++) {
-				if (this._renderableSprites[i]._render._visible) {
+				if (this._renderableSprites[i]._render._anyCameraVisible) {
 					needRender = true;
 					break;
 				}

--- a/src/layaAir/laya/d3/core/render/BaseRender.ts
+++ b/src/layaAir/laya/d3/core/render/BaseRender.ts
@@ -71,6 +71,8 @@ export class BaseRender extends EventDispatcher implements ISingletonElement, IO
 	_distanceForSort: number;
 	/**@internal */
 	_visible: boolean = true;//初始值为默认可见,否则会造成第一帧动画不更新等，TODO:还有个包围盒更新好像浪费了
+	/**@internal */
+	_anyCameraVisible: boolean = false;	// _visible只针对当前Camera的preCulling有效，假设有两个Camera先后处理，BaseRender对前一个可见、后一个不可见，则_visible不准
 	/** @internal */
 	_octreeNode: BoundsOctreeNode;
 	/** @internal */
@@ -271,6 +273,13 @@ export class BaseRender extends EventDispatcher implements ISingletonElement, IO
 	 */
 	get isPartOfStaticBatch(): boolean {
 		return this._isPartOfStaticBatch;
+	}
+
+	/**
+	 * 是否任一相机可见
+	 */
+	get anyCameraVisible(): boolean {
+		return this._anyCameraVisible;
 	}
 
 	/**

--- a/src/layaAir/laya/d3/core/scene/Scene3D.ts
+++ b/src/layaAir/laya/d3/core/scene/Scene3D.ts
@@ -1061,6 +1061,16 @@ export class Scene3D extends Sprite implements ISubmit, ICreateResource {
 	/**
 	 * @internal
 	 */
+	_clearRenderFlag(): void {
+		for (var i = 0, iMax = this._renders.length; i < iMax; ++i) {
+			var render = <BaseRender>(this._renders.elements[i]);
+			render._anyCameraVisible = false;
+		}
+	}
+
+	/**
+	 * @internal
+	 */
 	_getRenderQueue(index: number): RenderQueue {
 		if (index <= 2500)//2500作为队列临界点
 			return this._opaqueQueue;
@@ -1140,6 +1150,8 @@ export class Scene3D extends Sprite implements ISubmit, ICreateResource {
 	renderSubmit(): number {
 		var gl: any = LayaGL.instance;
 		this._prepareSceneToRender();
+
+		this._clearRenderFlag();
 
 		var i: number, n: number, n1: number;
 		for (i = 0, n = this._cameraPool.length, n1 = n - 1; i < n; i++) {

--- a/src/layaAir/laya/d3/graphics/FrustumCulling.ts
+++ b/src/layaAir/laya/d3/graphics/FrustumCulling.ts
@@ -83,6 +83,7 @@ export class FrustumCulling {
 				Stat.frustumCulling++;
 				if (!camera.useOcclusionCulling || render._needRender(boundFrustum, context)) {
 					render._visible = true;
+					render._anyCameraVisible = true;
 					render._distanceForSort = Vector3.distance(render.bounds.getCenter(), camPos);//TODO:合并计算浪费,或者合并后取平均值
 					var elements: RenderElement[] = render._renderElements;
 					for (var j: number = 0, m: number = elements.length; j < m; j++)
@@ -173,6 +174,7 @@ export class FrustumCulling {
 			var render: BaseRender = (<BaseRender>renders[i]);
 			if (!camera.useOcclusionCulling || (camera._isLayerVisible(render._owner._layer) && render._enable && scene._cullingBufferResult[i])) {//TODO:需要剥离部分函数
 				render._visible = true;
+				render._anyCameraVisible = true;
 				render._distanceForSort = Vector3.distance(render.bounds.getCenter(), camPos);//TODO:合并计算浪费,或者合并后取平均值
 				var elements: RenderElement[] = render._renderElements;
 				for (j = 0, m = elements.length; j < m; j++) {


### PR DESCRIPTION
BaseRender中的_visible可见性标识是在Camera做FrustumCulling的时候设置的，如果有两个Camera渲染不同的Layer，被渲染的物体属于第一个Camera的层，那么_visible标识会在第二个Camera渲染时被置为false。
这导致Animator根据_visible来更新是错误的。这里增加_anyCameraVisible标识来表示该物体在一帧中是否可见的状态。