### PR TITLE
修复PhysicsComponent enable状态处理不正确导致崩溃

### DIFF
--- a/src/layaAir/laya/d3/component/SimpleSingletonList.ts
+++ b/src/layaAir/laya/d3/component/SimpleSingletonList.ts
@@ -43,7 +43,7 @@ export class SimpleSingletonList extends SingletonList<ISingletonElement> {
 	 */
 	clear(): void {
 		var elements: ISingletonElement[] = this.elements;
-		for (var i: number, n: number = this.length; i < n; i++)
+		for (var i: number = 0, n: number = this.length; i < n; i++)
 			elements[i]._setIndexInList(-1);
 		this.length = 0;
 	}

--- a/src/layaAir/laya/d3/physics/PhysicsComponent.ts
+++ b/src/layaAir/laya/d3/physics/PhysicsComponent.ts
@@ -271,32 +271,6 @@ export class PhysicsComponent extends Component {
 	}
 
 	/**
-	 * @inheritDoc
-	 * @override
-	 */
-	get enabled(): boolean {
-		return super.enabled;
-	}
-
-	/**
-	 * @inheritDoc
-	 * @override
-	 */
-	set enabled(value: boolean) {
-		if (this._enabled != value) {
-			if (this._simulation && this._colliderShape) {
-				if (value) {
-					this._derivePhysicsTransformation(true);
-					this._addToSimulation();
-				} else {
-					this._removeFromSimulation();
-				}
-			}
-			super.enabled = value;
-		}
-	}
-
-	/**
 	 * 碰撞形状。
 	 */
 	get colliderShape(): ColliderShape {
@@ -421,7 +395,7 @@ export class PhysicsComponent extends Component {
 	protected _onEnable(): void {
 		this._simulation = ((<Scene3D>this.owner._scene)).physicsSimulation;
 		Physics3D._bullet.btCollisionObject_setContactProcessingThreshold(this._btColliderObject, 1e30);
-		if (this._colliderShape && this._enabled) {
+		if (this._colliderShape) {
 			this._derivePhysicsTransformation(true);
 			this._addToSimulation();
 		}
@@ -433,7 +407,7 @@ export class PhysicsComponent extends Component {
 	 * @override
 	 */
 	protected _onDisable(): void {
-		if (this._colliderShape && this._enabled) {
+		if (this._colliderShape) {
 			this._removeFromSimulation();
 			(this._inPhysicUpdateListIndex !== -1) && (this._simulation._physicsUpdateList.remove(this));//销毁前一定会调用 _onDisable()
 		}


### PR DESCRIPTION
PhysicsComponent._onDisable处理this._simulation._physicsUpdateList.remove(this)的条件之一是this._enabled为true，而_onDisable被调用之前Component.set enabled已经将this._enable置为false。

这导致了下面情况的崩溃：
1、enable状态下修改transform，PhysicsComponent._onTransformChanged将自己加入_physicsUpdateList
2、disable，这里_onDisable无法将自己从_physicsUpdateList中移除
3、destroy，销毁对象
4、下一帧物理更新_derivePhysicsTransformation崩溃