### PR TITLE
在复用DrawTextureCmd时可能会带着前面一次留下的colorFlt，导致着色异常

### DIFF
--- a/src/layaAir/laya/display/cmd/DrawTextureCmd.ts
+++ b/src/layaAir/laya/display/cmd/DrawTextureCmd.ts
@@ -80,6 +80,7 @@ export class DrawTextureCmd {
         this.texture && this.texture._removeReference();
         this.texture = null;
         this.matrix = null;
+        this.colorFlt = null;
         Pool.recover("DrawTextureCmd", this);
     }
 


### PR DESCRIPTION
在用到RenderTexture和fairygui的bitmapfont时，bitmapfont会设置DrawTextureCmd的colorFlt属性，而我将3D转2D纹理的时候会直接绘制纹理，不带颜色参数，导致用到了bitmapfont留下来的colorFlt，出现着色异常