### PR TITLE
SimpleAnimator

### DIFF
--- a/src/layaAir/laya/d3/core/SimpleSkinnedMeshRenderer.ts
+++ b/src/layaAir/laya/d3/core/SimpleSkinnedMeshRenderer.ts
@@ -1,0 +1,222 @@
+import { Event } from "../../events/Event";
+import { SkinnedMeshRenderer } from "./SkinnedMeshRenderer";
+import { RenderContext3D } from "./render/RenderContext3D";
+import { Transform3D } from "./Transform3D";
+import { SubMeshRenderElement } from "./render/SubMeshRenderElement";
+import { Sprite3D } from "./Sprite3D";
+import { RenderElement } from "./render/RenderElement";
+import { Animator } from "../component/Animator";
+import { SkinnedMeshSprite3DShaderDeclaration } from "./SkinnedMeshSprite3DShaderDeclaration";
+import { RenderableSprite3D } from "./RenderableSprite3D";
+import { Matrix4x4 } from "../math/Matrix4x4";
+import { Mesh } from "../resource/models/Mesh";
+import { Texture2D } from "../../resource/Texture2D";
+import { Vector4 } from "../math/Vector4";
+import { Vector2 } from "../math/Vector2";
+import { SubMeshInstanceBatch } from "../graphics/SubMeshInstanceBatch";
+import { SingletonList } from "../component/SingletonList";
+import { VertexBuffer3D } from "../graphics/VertexBuffer3D";
+import { MeshSprite3DShaderDeclaration } from "./MeshSprite3DShaderDeclaration";
+import { Utils3D } from "../utils/Utils3D";
+import { SimpleSkinnedMeshSprite3D } from "./SimpleSkinnedMeshSprite3D";
+
+export class SimpleSkinnedMeshRenderer extends SkinnedMeshRenderer{
+    /**@internal */
+    private _simpleAnimatorTexture:Texture2D;
+    /**@internal */
+    private _simpleAnimatorParams:Vector4;
+    /**@internal */
+    private _simpleAnimatorTextureSize:number;
+    /**@internal  x simpleAnimation offset,y simpleFrameOffset*/
+    private _simpleAnimatorOffset:Vector2;
+    /**@internal */
+    private _bonesNums:number;
+    
+    /**
+	 * 动画贴图
+	 */
+    get simpleAnimatorTexture():Texture2D{
+        return this._simpleAnimatorTexture;
+    }
+
+    set simpleAnimatorTexture(value:Texture2D){
+        this._simpleAnimatorTexture = value;
+        this._simpleAnimatorTextureSize = value.width;
+        this._shaderValues.setTexture(SimpleSkinnedMeshSprite3D.SIMPLE_SIMPLEANIMATORTEXTURE,value);
+        this._shaderValues.setNumber(SimpleSkinnedMeshSprite3D.SIMPLE_SIMPLEANIMATORTEXTURESIZE,this._simpleAnimatorTextureSize);
+    }
+
+    /**
+     * 动画帧数
+     */
+    get simpleAnimatorOffset():Vector2{
+        return this._simpleAnimatorOffset;
+    }
+    set simpleAnimatorOffset(value:Vector2){
+        value.cloneTo(this._simpleAnimatorOffset);
+    }
+
+    
+    /**
+	 * 创建一个 <code>SkinnedMeshRender</code> 实例。
+	 */
+	constructor(owner: RenderableSprite3D) {
+        super(owner);
+        this._simpleAnimatorParams = new Vector4();
+        this._simpleAnimatorOffset = new Vector2();
+        //TODO:
+        this._shaderValues.addDefine(SkinnedMeshSprite3DShaderDeclaration.SHADERDEFINE_SIMPLEBONE);
+        this._shaderValues.addDefine(SkinnedMeshSprite3DShaderDeclaration.SHADERDEFINE_BONE);
+    }
+
+    /**
+	 * @internal
+	 */
+	private _computeAnimatorParamsData(): void {
+        if(this._cacheMesh){
+            this._bonesNums = this.bones.length;
+            this._simpleAnimatorParams.x = this._simpleAnimatorOffset.x;
+            this._simpleAnimatorParams.y =Math.ceil(this._simpleAnimatorOffset.y)*this._bonesNums*4;
+            //this._simpleAnimatorParams.y =Math.ceil(this._simpleAnimatorOffset.y%75)*19*4;
+        }
+    }
+
+    /**
+	 *@inheritDoc
+	 *@override
+	 *@internal
+	 */
+	_createRenderElement(): SubMeshRenderElement {
+		return new SubMeshRenderElement();
+    }
+    /**
+	 * @internal
+	 */
+	_setCacheAnimator(animator: Animator): void {
+		this._cacheAnimator = animator;
+		this._shaderValues.addDefine(SkinnedMeshSprite3DShaderDeclaration.SHADERDEFINE_SIMPLEBONE);
+    }
+    
+    /**
+	*@inheritDoc
+	*@override
+	*@internal
+	*/
+	_onMeshChange(value: Mesh): void {
+        super._onMeshChange(value);
+        this._cacheMesh = (<Mesh>value);
+        //TODO:
+    }
+    /**
+	 * @inheritDoc
+	 * @override
+	 * @internal
+	 */
+	_renderUpdate(context: RenderContext3D, transform: Transform3D): void {
+        var element: SubMeshRenderElement = <SubMeshRenderElement>context.renderElement;
+        switch (element.renderType) {
+            case RenderElement.RENDERTYPE_NORMAL:
+                if(this._cacheAnimator){
+                    var worldMat:Matrix4x4 = (this._cacheAnimator.owner as Sprite3D).transform.worldMatrix;
+                    this._shaderValues.setMatrix4x4(Sprite3D.WORLDMATRIX, worldMat);
+                }else{
+                    this._shaderValues.setMatrix4x4(Sprite3D.WORLDMATRIX, transform.worldMatrix);
+                }
+                this._computeAnimatorParamsData();
+                this._shaderValues.setVector(SimpleSkinnedMeshSprite3D.SIMPLE_SIMPLEANIMATORPARAMS,this._simpleAnimatorParams);
+                break;
+            case RenderElement.RENDERTYPE_INSTANCEBATCH:
+                var worldMatrixData: Float32Array = SubMeshInstanceBatch.instance.instanceWorldMatrixData;
+				var insBatches: SingletonList<SubMeshRenderElement> = element.instanceBatchElementList;
+				var elements: SubMeshRenderElement[] = insBatches.elements;
+                var count: number = insBatches.length;
+                if(this._cacheAnimator){
+                    for (var i: number = 0; i < count; i++){
+                        var mat:Matrix4x4 = (((elements[i].render) as SimpleSkinnedMeshRenderer)._cacheAnimator.owner as Sprite3D)._transform.worldMatrix;
+                        worldMatrixData.set(mat.elements, i * 16);
+                    }
+                }
+                else{
+                    for (var i: number = 0; i < count; i++)
+                        worldMatrixData.set(elements[i]._transform.worldMatrix.elements, i * 16);
+                }
+				var worldBuffer: VertexBuffer3D = SubMeshInstanceBatch.instance.instanceWorldMatrixBuffer;
+				worldBuffer.orphanStorage();// prphan the memory block to avoid sync problem.can improve performance in HUAWEI P10.   TODO:"WebGL's bufferData(target, size, usage) call is guaranteed to initialize the buffer to 0"
+				worldBuffer.setData(worldMatrixData.buffer, 0, 0, count * 16 * 4);
+                this._shaderValues.addDefine(MeshSprite3DShaderDeclaration.SHADERDEFINE_GPU_INSTANCE);
+                //TODO:new Instance
+               
+                var simpleAnimatorData:Float32Array = SubMeshInstanceBatch.instance.instanceSimpleAnimatorData;
+                if(this._cacheAnimator){
+                    for (var i: number = 0; i < count; i++){
+                        var render:SimpleSkinnedMeshRenderer = (elements[i].render) as SimpleSkinnedMeshRenderer;
+                        render._computeAnimatorParamsData();
+                        var simpleAnimatorParams:Vector4 = render._simpleAnimatorParams;
+                        var offset:number = i*4;
+                        simpleAnimatorData[offset] = simpleAnimatorParams.x;
+                        simpleAnimatorData[offset+1] = simpleAnimatorParams.y;
+                    }
+                }
+                else{
+                    for (var i: number = 0; i < count; i++){
+                        simpleAnimatorData[offset] =0;
+                        simpleAnimatorData[offset+1] = 0;
+                    }
+                }
+                var simpleAnimatorBuffer:VertexBuffer3D = SubMeshInstanceBatch.instance.instanceSimpleAnimatorBuffer;
+                simpleAnimatorBuffer.orphanStorage();
+                simpleAnimatorBuffer.setData(simpleAnimatorData.buffer, 0, 0, count * 4 * 4);
+                break;
+        }
+    }
+    /**
+	 * @inheritDoc
+	 * @override
+	 * @internal
+	 */
+	_renderUpdateWithCamera(context: RenderContext3D, transform: Transform3D): void {
+        var projectionView: Matrix4x4 = context.projectionViewMatrix;
+        if (projectionView) {
+            var element: SubMeshRenderElement = (<SubMeshRenderElement>context.renderElement);
+            switch (element.renderType) {
+                case RenderElement.RENDERTYPE_NORMAL:
+                    if(this._cacheAnimator){
+                        var mat:Matrix4x4 = (this._cacheAnimator.owner as Sprite3D)._transform.worldMatrix;
+                        Matrix4x4.multiply(projectionView, mat, this._projectionViewWorldMatrix);
+                        this._shaderValues.setMatrix4x4(Sprite3D.MVPMATRIX, this._projectionViewWorldMatrix);
+                    }else{
+                        Matrix4x4.multiply(projectionView, transform.worldMatrix, this._projectionViewWorldMatrix);
+			            this._shaderValues.setMatrix4x4(Sprite3D.MVPMATRIX, this._projectionViewWorldMatrix);
+                    }
+                    break;
+                case RenderElement.RENDERTYPE_INSTANCEBATCH:
+                    var mvpMatrixData: Float32Array = SubMeshInstanceBatch.instance.instanceMVPMatrixData;
+					var insBatches: SingletonList<SubMeshRenderElement> = element.instanceBatchElementList;
+					var elements: SubMeshRenderElement[] = insBatches.elements;
+                    var count: number = insBatches.length;
+                    if(this._cacheAnimator){
+                        for (var i: number = 0; i < count; i++) {
+                            var worldMat: Matrix4x4 = (((elements[i].render) as SimpleSkinnedMeshRenderer)._cacheAnimator.owner as Sprite3D)._transform.worldMatrix;
+                            Utils3D.mulMatrixByArray(projectionView.elements, 0, worldMat.elements, 0, mvpMatrixData, i * 16);
+                        }
+                    }else{
+                        for (var i: number = 0; i < count; i++) {
+                            var worldMat: Matrix4x4 = elements[i]._transform.worldMatrix;
+                            Utils3D.mulMatrixByArray(projectionView.elements, 0, worldMat.elements, 0, mvpMatrixData, i * 16);
+                        }
+                    }
+				
+					var mvpBuffer: VertexBuffer3D = SubMeshInstanceBatch.instance.instanceMVPMatrixBuffer;
+					mvpBuffer.orphanStorage();// prphan the memory block to avoid sync problem.can improve performance in HUAWEI P10.  TODO:"WebGL's bufferData(target, size, usage) call is guaranteed to initialize the buffer to 0"
+					mvpBuffer.setData(mvpMatrixData.buffer, 0, 0, count * 16 * 4);
+                    break;
+            }
+        }
+    }
+
+    _destroy():void{
+        if (this._cacheRootBone)
+        (!this._cacheRootBone.destroyed) && (this._cacheRootBone.transform.off(Event.TRANSFORM_CHANGED, this, this._onWorldMatNeedChange));
+    }
+
+}

--- a/src/layaAir/laya/d3/core/SimpleSkinnedMeshSprite3D.ts
+++ b/src/layaAir/laya/d3/core/SimpleSkinnedMeshSprite3D.ts
@@ -6,28 +6,26 @@ import { Vector4 } from "../math/Vector4";
 import { Mesh } from "../resource/models/Mesh";
 import { Shader3D } from "../shader/Shader3D";
 import { Utils3D } from "../utils/Utils3D";
-import { Avatar } from "./Avatar";
 import { Bounds } from "./Bounds";
 import { MeshFilter } from "./MeshFilter";
 import { MeshSprite3D } from "./MeshSprite3D";
 import { RenderableSprite3D } from "./RenderableSprite3D";
-import { SkinnedMeshRenderer } from "./SkinnedMeshRenderer";
 import { Sprite3D } from "./Sprite3D";
 import { Material } from "./material/Material";
 import { SkinnedMeshSprite3DShaderDeclaration } from "./SkinnedMeshSprite3DShaderDeclaration";
+import { SimpleSkinnedMeshRenderer } from "./SimpleSkinnedMeshRenderer";
+import { Texture2D } from "../../resource/Texture2D";
 
 
 
 /**
  * <code>SkinnedMeshSprite3D</code> 类用于创建网格。
  */
-export class SkinnedMeshSprite3D extends RenderableSprite3D {
+export class SimpleSkinnedMeshSprite3D extends RenderableSprite3D {
 	/**@internal */
 	static _tempArray0: any[] = [];
 
-	/**着色器变量名，蒙皮动画。*/
-	static BONES: number = Shader3D.propertyNameToID("u_Bones");
-	/**简单动画变量名，贴图蒙皮动画*/
+	/** */
 	static SIMPLE_SIMPLEANIMATORTEXTURE:number = Shader3D.propertyNameToID("u_SimpleAnimatorTexture");
 	static SIMPLE_SIMPLEANIMATORPARAMS:number = Shader3D.propertyNameToID("u_SimpleAnimatorParams");
 	static SIMPLE_SIMPLEANIMATORTEXTURESIZE:number = Shader3D.propertyNameToID("u_SimpleAnimatorTextureSize");
@@ -35,7 +33,6 @@ export class SkinnedMeshSprite3D extends RenderableSprite3D {
 	 * @internal
 	 */
 	static __init__(): void {
-		SkinnedMeshSprite3DShaderDeclaration.SHADERDEFINE_BONE = Shader3D.getDefineByName("BONE");
 		SkinnedMeshSprite3DShaderDeclaration.SHADERDEFINE_SIMPLEBONE = Shader3D.getDefineByName("SIMPLEBONE");
 	}
 
@@ -52,8 +49,8 @@ export class SkinnedMeshSprite3D extends RenderableSprite3D {
 	/**
 	 * 网格渲染器。
 	 */
-	get skinnedMeshRenderer(): SkinnedMeshRenderer {
-		return (<SkinnedMeshRenderer>this._render);
+	get simpleSkinnedMeshRenderer(): SimpleSkinnedMeshRenderer {
+		return (<SimpleSkinnedMeshRenderer>this._render);
 	}
 
 	/**
@@ -64,7 +61,7 @@ export class SkinnedMeshSprite3D extends RenderableSprite3D {
 	constructor(mesh: Mesh = null, name: string = null) {
 		super(name);
 		this._meshFilter = new MeshFilter(this);
-		this._render = new SkinnedMeshRenderer(this);
+		this._render = new SimpleSkinnedMeshRenderer(this);
 		(mesh) && (this._meshFilter.sharedMesh = mesh);
 	}
 
@@ -75,7 +72,7 @@ export class SkinnedMeshSprite3D extends RenderableSprite3D {
 	 */
 	_parse(data: any, spriteMap: any): void {
 		super._parse(data, spriteMap);
-		var render: SkinnedMeshRenderer = this.skinnedMeshRenderer;
+		var render: SimpleSkinnedMeshRenderer = this.simpleSkinnedMeshRenderer;
 		var lightmapIndex: any = data.lightmapIndex;
 		(lightmapIndex != null) && (render.lightmapIndex = lightmapIndex);
 		var lightmapScaleOffsetArray: any[] = data.lightmapScaleOffset;
@@ -117,6 +114,12 @@ export class SkinnedMeshSprite3D extends RenderableSprite3D {
 		} else {//[兼容代码]
 			(data.rootBone) && (render._setRootBone(data.rootBone));//[兼容性]
 		}
+		var animatorTexture:string = data.animatorTexture;
+		if(animatorTexture)
+		{
+			var animatortexture:Texture2D = Loader.getRes(animatorTexture);
+			(render as SimpleSkinnedMeshRenderer).simpleAnimatorTexture = animatortexture;
+		}
 	}
 
 	/**
@@ -126,17 +129,9 @@ export class SkinnedMeshSprite3D extends RenderableSprite3D {
 	 */
 	protected _changeHierarchyAnimator(animator: Animator): void {
 		super._changeHierarchyAnimator(animator);
-		this.skinnedMeshRenderer._setCacheAnimator(animator);
+		this.simpleSkinnedMeshRenderer._setCacheAnimator(animator);
 	}
 
-	/**
-	 * @inheritDoc
-	 * @override
-	 * @internal
-	 */
-	protected _changeAnimatorAvatar(avatar: Avatar): void {
-		this.skinnedMeshRenderer._setCacheAvatar(avatar);
-	}
 
 	/**
 	 * @inheritDoc
@@ -146,8 +141,8 @@ export class SkinnedMeshSprite3D extends RenderableSprite3D {
 	_cloneTo(destObject: any, srcRoot: Node, dstRoot: Node): void {
 		var meshSprite3D: MeshSprite3D = (<MeshSprite3D>destObject);
 		meshSprite3D.meshFilter.sharedMesh = this.meshFilter.sharedMesh;
-		var meshRender: SkinnedMeshRenderer = (<SkinnedMeshRenderer>this._render);
-		var destMeshRender: SkinnedMeshRenderer = (<SkinnedMeshRenderer>meshSprite3D._render);
+		var meshRender: SimpleSkinnedMeshRenderer = (<SimpleSkinnedMeshRenderer>this._render);
+		var destMeshRender: SimpleSkinnedMeshRenderer = (<SimpleSkinnedMeshRenderer>meshSprite3D._render);
 		destMeshRender.enable = meshRender.enable;
 		destMeshRender.sharedMaterials = meshRender.sharedMaterials;
 		destMeshRender.castShadow = meshRender.castShadow;
@@ -164,7 +159,7 @@ export class SkinnedMeshSprite3D extends RenderableSprite3D {
 
 		var rootBone: Sprite3D = meshRender.rootBone;
 		if (rootBone) {
-			var pathes: any[] = Utils3D._getHierarchyPath(srcRoot, rootBone, SkinnedMeshSprite3D._tempArray0);
+			var pathes: any[] = Utils3D._getHierarchyPath(srcRoot, rootBone, SimpleSkinnedMeshSprite3D._tempArray0);
 			if (pathes)
 				destMeshRender.rootBone = (<Sprite3D>Utils3D._getNodeByHierarchyPath(dstRoot, pathes));
 			else
@@ -172,7 +167,7 @@ export class SkinnedMeshSprite3D extends RenderableSprite3D {
 		}
 
 		for (var i: number = 0; i < bones.length; i++) {
-			pathes = Utils3D._getHierarchyPath(srcRoot, bones[i], SkinnedMeshSprite3D._tempArray0);
+			pathes = Utils3D._getHierarchyPath(srcRoot, bones[i], SimpleSkinnedMeshSprite3D._tempArray0);
 			if (pathes)
 				destBones[i] = (<Sprite3D>Utils3D._getNodeByHierarchyPath(dstRoot, pathes));
 			else
@@ -181,6 +176,9 @@ export class SkinnedMeshSprite3D extends RenderableSprite3D {
 
 		var lbb: Bounds = meshRender.localBounds;
 		(lbb) && (lbb.cloneTo(destMeshRender.localBounds));
+		
+		destMeshRender.simpleAnimatorTexture = meshRender.simpleAnimatorTexture;
+
 		super._cloneTo(destObject, srcRoot, dstRoot);//父类函数在最后,组件应该最后赋值，否则获取材质默认值等相关函数会有问题
 	}
 
@@ -199,7 +197,7 @@ export class SkinnedMeshSprite3D extends RenderableSprite3D {
 	 * @internal
 	 */
 	protected _create(): Node {
-		return new SkinnedMeshSprite3D();
+		return new SimpleSkinnedMeshSprite3D();
 	}
 
 }

--- a/src/layaAir/laya/d3/core/SkinnedMeshRenderer.ts
+++ b/src/layaAir/laya/d3/core/SkinnedMeshRenderer.ts
@@ -27,19 +27,19 @@ export class SkinnedMeshRenderer extends MeshRenderer {
 	private static _tempMatrix4x4: Matrix4x4 = new Matrix4x4();
 
 	/**@internal */
-	private _cacheMesh: Mesh;
+	protected _cacheMesh: Mesh;
 	/** @internal */
-	private _bones: Sprite3D[] = [];
+	protected _bones: Sprite3D[] = [];
 	/** @internal */
 	_skinnedData: any[];
 	/** @internal */
 	private _skinnedDataLoopMarks: number[] = [];
 	/**@internal */
-	private _localBounds: Bounds = new Bounds(Vector3._ZERO, Vector3._ZERO);
+	protected _localBounds: Bounds = new Bounds(Vector3._ZERO, Vector3._ZERO);
 	/**@internal */
-	private _cacheAnimator: Animator;
+	protected _cacheAnimator: Animator;
 	/**@internal */
-	private _cacheRootBone: Sprite3D;
+	protected _cacheRootBone: Sprite3D;
 
 	/**
 	 * 局部边界。
@@ -322,7 +322,7 @@ export class SkinnedMeshRenderer extends MeshRenderer {
 	/**
 	 * @internal
 	 */
-	private _setRootNode(): void {//[兼容性API]
+	protected _setRootNode(): void {//[兼容性API]
 		var rootNode: AnimationNode;
 		if (this._cacheAnimator && this._rootBone && this._cacheAvatar)
 			rootNode = this._cacheAnimator._avatarNodeMap[this._rootBone];

--- a/src/layaAir/laya/d3/core/SkinnedMeshSprite3DShaderDeclaration.ts
+++ b/src/layaAir/laya/d3/core/SkinnedMeshSprite3DShaderDeclaration.ts
@@ -4,4 +4,5 @@ import { ShaderDefine } from "../shader/ShaderDefine";
 export class SkinnedMeshSprite3DShaderDeclaration {
 	/**精灵级着色器宏定义,蒙皮动画。*/
 	static SHADERDEFINE_BONE: ShaderDefine;
+	static SHADERDEFINE_SIMPLEBONE:ShaderDefine;
 }

--- a/src/layaAir/laya/d3/graphics/SubMeshInstanceBatch.ts
+++ b/src/layaAir/laya/d3/graphics/SubMeshInstanceBatch.ts
@@ -33,6 +33,13 @@ export class SubMeshInstanceBatch extends GeometryElement {
 	/** @internal */
 	instanceMVPMatrixBuffer: VertexBuffer3D;
 
+	/**SimpleAnimator */
+	/** @internal */
+	instanceSimpleAnimatorData:Float32Array;
+	/** @internal */
+	instanceSimpleAnimatorBuffer:VertexBuffer3D;
+
+
 	/**
 	 * 创建一个 <code>InstanceSubMesh</code> 实例。
 	 */
@@ -60,6 +67,19 @@ export class SubMeshInstanceBatch extends GeometryElement {
 		Stat.renderBatches++;
 		Stat.savedRenderBatches += count - 1;
 		Stat.trianglesFaces += indexCount * count / 3;
+	}
+
+	/**
+	 * @inheritDoc
+	 * @override
+	 */
+	creatInstanceSimpleAnimatorBuffer(){
+		if(this.instanceSimpleAnimatorData)
+			return;
+		var gl: WebGLRenderingContext = LayaGL.instance;
+		this.instanceSimpleAnimatorData = new Float32Array(this.maxInstanceCount * 4);
+		this.instanceSimpleAnimatorBuffer = new VertexBuffer3D(this.instanceSimpleAnimatorData.length*4,gl.DYNAMIC_DRAW);
+		this.instanceSimpleAnimatorBuffer.vertexDeclaration = VertexMesh.instanceSimpleAnimatorDeclaration;
 	}
 }
 

--- a/src/layaAir/laya/d3/resource/models/Mesh.ts
+++ b/src/layaAir/laya/d3/resource/models/Mesh.ts
@@ -43,6 +43,10 @@ export class skinnedMatrixCache {
 export class Mesh extends Resource implements IClone {
 	/**Mesh资源。*/
 	static MESH: string = "MESH";
+	
+	static MESH_INSTANCEBUFFER_TYPE_NORMAL:number = 0;
+
+	static MESH_INSTANCEBUFFER_TYPE_SIMPLEANIMATOR:number = 1;
 
 	/** @internal */
 	private _tempVector30: Vector3 = new Vector3()
@@ -96,6 +100,8 @@ export class Mesh extends Resource implements IClone {
 	_bufferState: BufferState = new BufferState();
 	/** @internal */
 	_instanceBufferState: BufferState = new BufferState();
+	/** @internal */
+	_instanceBufferStateType:number = 0;
 	/** @internal */
 	_subMeshes: SubMesh[];
 	/** @internal */
@@ -366,6 +372,12 @@ export class Mesh extends Resource implements IClone {
 		instanceBufferState.applyVertexBuffer(vertexBuffer);
 		instanceBufferState.applyInstanceVertexBuffer(SubMeshInstanceBatch.instance.instanceWorldMatrixBuffer);
 		instanceBufferState.applyInstanceVertexBuffer(SubMeshInstanceBatch.instance.instanceMVPMatrixBuffer);
+		switch(this._instanceBufferStateType){
+			case Mesh.MESH_INSTANCEBUFFER_TYPE_SIMPLEANIMATOR:
+				SubMeshInstanceBatch.instance.creatInstanceSimpleAnimatorBuffer();
+				instanceBufferState.applyInstanceVertexBuffer(SubMeshInstanceBatch.instance.instanceSimpleAnimatorBuffer)
+			break;
+		}
 		instanceBufferState.applyIndexBuffer(indexBuffer);
 		instanceBufferState.unBind();
 	}

--- a/src/layaAir/laya/d3/shader/Shader3D.ts
+++ b/src/layaAir/laya/d3/shader/Shader3D.ts
@@ -150,6 +150,28 @@ export class Shader3D {
 	}
 
 	/**
+	 * 通过宏属性动态修改AttributeMap
+	 * @param defineString 
+	 * @param attributeMap 
+	 */
+	static getAttributeMapByDefine(defineString:string[],attributeMap:any):any{
+		var newAttributeMap:any = {};
+		for(var value in attributeMap){
+			newAttributeMap[value] = attributeMap[value];
+		}	
+		for ( var i = 0, n: number = defineString.length; i < n; i++) {
+			var def: string = defineString[i];
+			switch(def){
+				case "SIMPLEBONE":
+				newAttributeMap["a_SimpleTextureParams"] = attributeMap["a_Texcoord1"];
+				delete newAttributeMap["a_Texcoord1"];
+				break;
+			}
+		}
+		return newAttributeMap;
+	}
+
+	/**
 	 * 添加函数库引用。
 	 * @param fileName 文件名字。
 	 * @param txt 文件内容

--- a/src/layaAir/laya/d3/shader/ShaderInit3D.ts
+++ b/src/layaAir/laya/d3/shader/ShaderInit3D.ts
@@ -153,6 +153,10 @@ export class ShaderInit3D {
 			'u_AmbientSHBg': Shader3D.PERIOD_SCENE,
 			'u_AmbientSHBb': Shader3D.PERIOD_SCENE,
 			'u_AmbientSHC': Shader3D.PERIOD_SCENE,
+			
+			 'u_SimpleAnimatorTexture':Shader3D.PERIOD_SPRITE,
+			 'u_SimpleAnimatorParams':Shader3D.PERIOD_SPRITE,
+			 'u_SimpleAnimatorTextureSize':Shader3D.PERIOD_SPRITE,
 
 			//legacy lighting
 			'u_DirectionLight.color': Shader3D.PERIOD_SCENE,

--- a/src/layaAir/laya/d3/shader/ShaderPass.ts
+++ b/src/layaAir/laya/d3/shader/ShaderPass.ts
@@ -313,7 +313,9 @@ export class ShaderPass extends ShaderCompile {
 			psVersion = ps[0] + '\n';
 			ps.shift();
 		}
-		shader = new ShaderInstance(vsVersion + vertexHead + defineStr + vs.join('\n'), psVersion + fragmentHead + defineStr + ps.join('\n'), this._owner._attributeMap || this._owner._owner._attributeMap, this._owner._uniformMap || this._owner._owner._uniformMap, this);
+
+		var attibuteMap = Shader3D.getAttributeMapByDefine(defineString,this._owner._attributeMap);
+		shader = new ShaderInstance(vsVersion + vertexHead + defineStr + vs.join('\n'), psVersion + fragmentHead + defineStr + ps.join('\n'),attibuteMap , this._owner._uniformMap || this._owner._owner._uniformMap, this);
 
 		cacheShaders[cacheKey] = shader;
 

--- a/src/layaAir/laya/d3/shader/files/Mesh-BlinnPhong.vs
+++ b/src/layaAir/laya/d3/shader/files/Mesh-BlinnPhong.vs
@@ -70,19 +70,58 @@ varying vec3 v_Normal;
 #ifdef TILINGOFFSET
 	uniform vec4 u_TilingOffset;
 #endif
+#ifdef SIMPLEBONE
+	uniform sampler2D u_SimpleAnimatorTexture;
+	uniform vec4 u_SimpleAnimatorParams;
+	uniform float u_SimpleAnimatorTextureSize; 
+#endif
 
+#ifdef SIMPLEBONE
+mat4 loadMatFromTexture(float FramePos,int boneIndices,float offset)
+{
+	vec2 uv;
+	float PixelPos = FramePos+float(boneIndices)*4.0;
+	float halfOffset = offset * 0.5;
+	float uvoffset = PixelPos/u_SimpleAnimatorTextureSize;
+	uv.y = floor(uvoffset)*offset+halfOffset;
+	uv.x = mod(float(PixelPos),u_SimpleAnimatorTextureSize)*offset+halfOffset;
+	vec4 mat0row = texture2D(u_SimpleAnimatorTexture,uv);
+	uv.x+=offset;
+	vec4 mat1row = texture2D(u_SimpleAnimatorTexture,uv);
+	uv.x+=offset;
+	vec4 mat2row = texture2D(u_SimpleAnimatorTexture,uv);
+	uv.x+=offset;
+	vec4 mat3row = texture2D(u_SimpleAnimatorTexture,uv);
+	mat4 m =mat4(mat0row.x,mat0row.y,mat0row.z,mat0row.w,
+			  mat1row.x,mat1row.y,mat1row.z,mat1row.w,
+			  mat2row.x,mat2row.y,mat2row.z,mat2row.w,
+			  mat3row.x,mat3row.y,mat3row.z,mat3row.w);
+	return m;
+}
+#endif
 void main()
 {
 	vec4 position;
 	#ifdef BONE
-		mat4 skinTransform = u_Bones[int(a_BoneIndices.x)] * a_BoneWeights.x;
-		skinTransform += u_Bones[int(a_BoneIndices.y)] * a_BoneWeights.y;
-		skinTransform += u_Bones[int(a_BoneIndices.z)] * a_BoneWeights.z;
-		skinTransform += u_Bones[int(a_BoneIndices.w)] * a_BoneWeights.w;
+		mat4 skinTransform;
+	 	#ifdef SIMPLEBONE
+			float currentPixelPos = u_SimpleAnimatorParams.x+u_SimpleAnimatorParams.y;
+			float offset = 1.0/u_SimpleAnimatorTextureSize;
+			skinTransform =  loadMatFromTexture(currentPixelPos,int(a_BoneIndices.x),offset) * a_BoneWeights.x;
+			skinTransform += loadMatFromTexture(currentPixelPos,int(a_BoneIndices.y),offset) * a_BoneWeights.y;
+			skinTransform += loadMatFromTexture(currentPixelPos,int(a_BoneIndices.z),offset) * a_BoneWeights.z;
+			skinTransform += loadMatFromTexture(currentPixelPos,int(a_BoneIndices.w),offset) * a_BoneWeights.w;
+		#else
+			skinTransform =  u_Bones[int(a_BoneIndices.x)] * a_BoneWeights.x;
+			skinTransform += u_Bones[int(a_BoneIndices.y)] * a_BoneWeights.y;
+			skinTransform += u_Bones[int(a_BoneIndices.z)] * a_BoneWeights.z;
+			skinTransform += u_Bones[int(a_BoneIndices.w)] * a_BoneWeights.w;
+		#endif
 		position=skinTransform*a_Position;
-	#else
+	 #else
 		position=a_Position;
 	#endif
+
 	#ifdef GPU_INSTANCE
 		gl_Position = a_MvpMatrix * position;
 	#else

--- a/src/layaAir/laya/d3/utils/Scene3DUtils.ts
+++ b/src/layaAir/laya/d3/utils/Scene3DUtils.ts
@@ -14,6 +14,7 @@ import { Sprite3D } from "../core/Sprite3D";
 import { TrailSprite3D } from "../core/trail/TrailSprite3D";
 import { StaticBatchManager } from "../graphics/StaticBatchManager";
 import { ClassUtils } from "../../utils/ClassUtils";
+import { SimpleSkinnedMeshSprite3D } from "../core/SimpleSkinnedMeshSprite3D";
 
 
 
@@ -36,6 +37,9 @@ export class Scene3DUtils {
 				break;
 			case "SkinnedMeshSprite3D":
 				node = new SkinnedMeshSprite3D();
+				break;
+			case "SimpleSkinnedMeshSprite3D":
+				node = new SimpleSkinnedMeshSprite3D();
 				break;
 			case "ShuriKenParticle3D":
 				node = new ShuriKenParticle3D();


### PR DESCRIPTION
1、Modify some properties in skinnedmeshrender to inheritable data

2、Add simplebone macro, add U_ SimpleAnimatorTexture,u_ SimpleAnimatorParams,u_ SimpleAnimatorTextureSize

3、Add instancebuffer and instancesimpleanimatordata data of simpleanimator, and add functions for creating instancebuffer

4、Creating instancebuffer in mesh class

5、The method of dynamically modifying macro attributes in shader3d

6、Add the uniform attribute of simpleanimator in blinnphoneholder

7、Add a function to replace attribute dynamically in shaderpass

8、Mesh- BlinnPhong.vs Add skin code of simpleanimator in

9、Add the node of simpleskinnedmeshsprite