### PR TITLE
修复在动画事件里播放其他动画时，新动画的事件可能不触发的BUG

### DIFF
--- a/src/layaAir/laya/d3/component/Animator.ts
+++ b/src/layaAir/laya/d3/component/Animator.ts
@@ -324,16 +324,22 @@ export class Animator extends Component {
 			}
 
 			if (frontPlay) {
-				playStateInfo._playEventIndex = this._eventScript(scripts, events, playStateInfo._playEventIndex, loopCount > 0 ? clipDuration : time, true);
+				this._eventScript(scripts, events, playStateInfo._playEventIndex, loopCount > 0 ? clipDuration : time, true);
 				for (var i: number = 0, n: number = loopCount - 1; i < n; i++)
 					this._eventScript(scripts, events, 0, clipDuration, true);
-				(loopCount > 0 && time > 0) && (playStateInfo._playEventIndex = this._eventScript(scripts, events, 0, time, true));//if need cross loop,'time' must large than 0
+				if(loopCount > 0 && time > 0){  //if need cross loop,'time' must large than 0
+					playStateInfo._playEventIndex = 0;
+					this._eventScript(scripts, events, 0, time, true);
+				} 
 			} else {
-				playStateInfo._playEventIndex = this._eventScript(scripts, events, playStateInfo._playEventIndex, loopCount > 0 ? 0 : time, false);
+				this._eventScript(scripts, events, playStateInfo._playEventIndex, loopCount > 0 ? 0 : time, false);
 				var eventIndex: number = events.length - 1;
 				for (i = 0, n = loopCount - 1; i < n; i++)
 					this._eventScript(scripts, events, eventIndex, 0, false);
-				(loopCount > 0 && time > 0) && (playStateInfo._playEventIndex = this._eventScript(scripts, events, eventIndex, time, false));//if need cross loop,'time' must large than 0
+				if(loopCount > 0 && time > 0){  //if need cross loop,'time' must large than 0
+					playStateInfo._playEventIndex = eventIndex;
+					this._eventScript(scripts, events, playStateInfo._playEventIndex, time, true);
+				}					
 			}
 		}
 	}


### PR DESCRIPTION
1.BUG表现
     play动画1，在动画1的事件里播放第二个动画，动画2的动画事件不能触发
2.问题原因
     在_eventScript函数调用完以后会给playStateInfo._playEventIndex重新赋值。播放第二个动画的时候重置_playEventIndex在前，动画1 给_playEventIndex赋值在后，导致播放动画2的时候_playEventIndex是第一个动画的
3. 修改
     通过传参的方式直接修改_playEventIndex，防止第二个动画重置_playEventIndex以后再被上一个动画修改
     
