### PR TITLE
1、增加ReflectionProbe节点加载

### DIFF
--- a/src/layaAir/Laya3D.ts
+++ b/src/layaAir/Laya3D.ts
@@ -536,6 +536,10 @@ export class Laya3D {
 			case "Terrain":
 				Laya3D._addHierarchyInnerUrls(fourthLelUrls, subUrls, urlVersion, hierarchyBasePath, props.dataPath, Laya3D.TERRAINRES);
 				break;
+			case "ReflectionProbe":
+				var reflection = props.reflection;
+				(reflection) && (props.reflection = Laya3D._addHierarchyInnerUrls(firstLevelUrls, subUrls, urlVersion, hierarchyBasePath, reflection, Laya3D.TEXTURECUBEBIN));
+				break;
 		}
 
 		var components: any[] = node.components;

--- a/src/layaAir/laya/d3/core/Bounds.ts
+++ b/src/layaAir/laya/d3/core/Bounds.ts
@@ -221,12 +221,14 @@ export class Bounds implements IClone {
 		var calMin:Vector3 = bounds.getMin();
 		var tempV0:Vector3 = Bounds.TEMP_VECTOR3_MAX0;
 		var tempV1:Vector3 = Bounds.TEMP_VECTOR3_MAX1;
+		var thisExtends:Vector3 = this.getExtent();
+		var boundExtends:Vector3 =bounds.getExtent();
 		tempV0.setValue(Math.max(ownMax.x,calMax.x)-Math.min(ownMin.x,calMin.x),
 			Math.max(ownMax.y,calMax.y)-Math.min(ownMin.y,calMin.y),
 			Math.max(ownMax.z,calMax.z)-Math.min(ownMin.z,calMin.z));
-		tempV1.setValue(this._extent.x+bounds._extent.x,
-			this._extent.y+bounds._extent.y,
-			this._extent.z+bounds._extent.z); 
+		tempV1.setValue((thisExtends.x+boundExtends.x)*2.0,
+			(thisExtends.y+boundExtends.y)*2.0,
+			(thisExtends.z+boundExtends.z)*2.0); 
 		if((tempV0.x)>=(tempV1.x)) return -1;
 		if((tempV0.y)>=(tempV1.y)) return -1;
 		if((tempV0.z)>=(tempV1.z)) return -1;

--- a/src/layaAir/laya/d3/core/MeshRenderer.ts
+++ b/src/layaAir/laya/d3/core/MeshRenderer.ts
@@ -19,10 +19,9 @@ import { SubMeshRenderElement } from "./render/SubMeshRenderElement";
 import { RenderableSprite3D } from "./RenderableSprite3D";
 import { Sprite3D } from "./Sprite3D";
 import { Transform3D } from "./Transform3D";
-import { LayaGPU } from "../../webgl/LayaGPU";
-import { LayaGL } from "../../layagl/LayaGL";
 import { VertexBuffer3D } from "../graphics/VertexBuffer3D";
-import { VertexMesh } from "../graphics/Vertex/VertexMesh";
+import { ReflectionProbeMode, ReflectionProbe } from "./reflectionProbe/ReflectionProbe";
+import { TextureCube } from "../resource/TextureCube";
 
 /**
  * <code>MeshRenderer</code> 类用于网格渲染器。
@@ -150,6 +149,29 @@ export class MeshRenderer extends BaseRender {
 				worldBuffer.setData(worldMatrixData.buffer, 0, 0, count * 16 * 4);
 				this._shaderValues.addDefine(MeshSprite3DShaderDeclaration.SHADERDEFINE_GPU_INSTANCE);
 				break;
+		}
+		//更新反射探针
+		if(!this._probReflection)
+		return;
+		if(this._reflectionMode==ReflectionProbeMode.off){
+			this._shaderValues.removeDefine(MeshSprite3DShaderDeclaration.SHADERDEFINE_SPECCUBE_BOX_PROJECTION);
+			this._shaderValues.setVector(RenderableSprite3D.REFLECTIONCUBE_HDR_PARAMS,ReflectionProbe.defaultTextureHDRDecodeValues);
+			this._shaderValues.setTexture(RenderableSprite3D.REFLECTIONTEXTURE,TextureCube.blackTexture);
+		}
+		else{
+			if(!this._probReflection.boxProjection){
+				this._shaderValues.removeDefine(MeshSprite3DShaderDeclaration.SHADERDEFINE_SPECCUBE_BOX_PROJECTION);
+				
+			}
+			else{
+				this._shaderValues.addDefine(MeshSprite3DShaderDeclaration.SHADERDEFINE_SPECCUBE_BOX_PROJECTION);
+				this._shaderValues.setVector3(RenderableSprite3D.REFLECTIONCUBE_PROBEPOSITION,this._probReflection.probePosition);
+				this._shaderValues.setVector3(RenderableSprite3D.REFLECTIONCUBE_PROBEBOXMAX,this._probReflection.boundsMax);
+				this._shaderValues.setVector3(RenderableSprite3D.REFLECTIONCUBE_PROBEBOXMIN,this._probReflection.boundsMin);
+			}
+			this._shaderValues.setTexture(RenderableSprite3D.REFLECTIONTEXTURE,this._probReflection.reflectionTexture);
+			this._shaderValues.setVector(RenderableSprite3D.REFLECTIONCUBE_HDR_PARAMS,this._probReflection.reflectionHDRParams);
+			
 		}
 	}
 

--- a/src/layaAir/laya/d3/core/MeshSprite3D.ts
+++ b/src/layaAir/laya/d3/core/MeshSprite3D.ts
@@ -25,6 +25,7 @@ export class MeshSprite3D extends RenderableSprite3D {
 		MeshSprite3DShaderDeclaration.SHADERDEFINE_COLOR = Shader3D.getDefineByName("COLOR");
 		MeshSprite3DShaderDeclaration.SHADERDEFINE_UV1 = Shader3D.getDefineByName("UV1");
 		MeshSprite3DShaderDeclaration.SHADERDEFINE_GPU_INSTANCE = Shader3D.getDefineByName("GPU_INSTANCE");
+		MeshSprite3DShaderDeclaration.SHADERDEFINE_SPECCUBE_BOX_PROJECTION = Shader3D.getDefineByName("SPECCUBE_BOX_PROJECTION");
 		StaticBatchManager._registerManager(MeshRenderStaticBatchManager.instance);
 		DynamicBatchManager._registerManager(MeshRenderDynamicBatchManager.instance);
 	}

--- a/src/layaAir/laya/d3/core/MeshSprite3DShaderDeclaration.ts
+++ b/src/layaAir/laya/d3/core/MeshSprite3DShaderDeclaration.ts
@@ -5,4 +5,5 @@ export class MeshSprite3DShaderDeclaration {
 	static SHADERDEFINE_COLOR: ShaderDefine;
 	static SHADERDEFINE_UV1: ShaderDefine;
 	static SHADERDEFINE_GPU_INSTANCE: ShaderDefine;
+	static SHADERDEFINE_SPECCUBE_BOX_PROJECTION:ShaderDefine;
 }

--- a/src/layaAir/laya/d3/core/RenderableSprite3D.ts
+++ b/src/layaAir/laya/d3/core/RenderableSprite3D.ts
@@ -27,7 +27,14 @@ export class RenderableSprite3D extends Sprite3D {
 	static LIGHTMAP_DIRECTION: number = Shader3D.propertyNameToID("u_LightMapDirection");
 	/**拾取颜色。*/
 	static PICKCOLOR: number = Shader3D.propertyNameToID("u_PickColor");
-
+	/** 反射贴图 */
+	static REFLECTIONTEXTURE:number = Shader3D.propertyNameToID("u_ReflectTexture");
+	/** 反射贴图参数 */
+	static REFLECTIONCUBE_HDR_PARAMS:number = Shader3D.propertyNameToID("u_ReflectCubeHDRParams");
+	/** 反射探针位置 最大最小值*/
+	static REFLECTIONCUBE_PROBEPOSITION:number = Shader3D.propertyNameToID("u_SpecCubeProbePosition");
+	static REFLECTIONCUBE_PROBEBOXMAX:number = Shader3D.propertyNameToID("u_SpecCubeBoxMax");
+	static REFLECTIONCUBE_PROBEBOXMIN:number = Shader3D.propertyNameToID("u_SpecCubeBoxMin");
 	pickColor: Vector4;
 
 

--- a/src/layaAir/laya/d3/core/SkinnedMeshRenderer.ts
+++ b/src/layaAir/laya/d3/core/SkinnedMeshRenderer.ts
@@ -19,6 +19,9 @@ import { RenderContext3D } from "./render/RenderContext3D";
 import { RenderElement } from "./render/RenderElement";
 import { SkinnedMeshSprite3DShaderDeclaration } from "./SkinnedMeshSprite3DShaderDeclaration";
 import { Render } from "../../renders/Render";
+import { ReflectionProbeMode, ReflectionProbe } from "./reflectionProbe/ReflectionProbe";
+import { MeshSprite3DShaderDeclaration } from "./MeshSprite3DShaderDeclaration";
+import { TextureCube } from "../resource/TextureCube";
 /**
  * <code>SkinMeshRenderer</code> 类用于蒙皮渲染器。
  */
@@ -245,6 +248,29 @@ export class SkinnedMeshRenderer extends MeshRenderer {
 			}
 		} else {
 			this._shaderValues.setMatrix4x4(Sprite3D.WORLDMATRIX, transform.worldMatrix);
+		}
+		//更新反射探针
+		if(!this._probReflection)
+		return;
+		if(this._reflectionMode==ReflectionProbeMode.off){
+			this._shaderValues.removeDefine(MeshSprite3DShaderDeclaration.SHADERDEFINE_SPECCUBE_BOX_PROJECTION);
+			this._shaderValues.setVector(RenderableSprite3D.REFLECTIONCUBE_HDR_PARAMS,ReflectionProbe.defaultTextureHDRDecodeValues);
+			this._shaderValues.setTexture(RenderableSprite3D.REFLECTIONTEXTURE,TextureCube.blackTexture);
+		}
+		else{
+			if(!this._probReflection.boxProjection){
+				this._shaderValues.removeDefine(MeshSprite3DShaderDeclaration.SHADERDEFINE_SPECCUBE_BOX_PROJECTION);
+				
+			}
+			else{
+				this._shaderValues.addDefine(MeshSprite3DShaderDeclaration.SHADERDEFINE_SPECCUBE_BOX_PROJECTION);
+				this._shaderValues.setVector3(RenderableSprite3D.REFLECTIONCUBE_PROBEPOSITION,this._probReflection.probePosition);
+				this._shaderValues.setVector3(RenderableSprite3D.REFLECTIONCUBE_PROBEBOXMAX,this._probReflection.boundsMax);
+				this._shaderValues.setVector3(RenderableSprite3D.REFLECTIONCUBE_PROBEBOXMIN,this._probReflection.boundsMin);
+			}
+			this._shaderValues.setTexture(RenderableSprite3D.REFLECTIONTEXTURE,this._probReflection.reflectionTexture);
+			this._shaderValues.setVector(RenderableSprite3D.REFLECTIONCUBE_HDR_PARAMS,this._probReflection.reflectionHDRParams);
+			
 		}
 	}
 

--- a/src/layaAir/laya/d3/core/material/PBRSpecularMaterial.ts
+++ b/src/layaAir/laya/d3/core/material/PBRSpecularMaterial.ts
@@ -67,6 +67,12 @@ export class PBRSpecularMaterial extends PBRMaterial {
 			'u_SimpleAnimatorParams':Shader3D.PERIOD_SPRITE,
 			'u_SimpleAnimatorTextureSize':Shader3D.PERIOD_SPRITE,
 
+			'u_ReflectCubeHDRParams': Shader3D.PERIOD_SPRITE,
+			'u_ReflectTexture': Shader3D.PERIOD_SPRITE,
+			'u_SpecCubeProbePosition':Shader3D.PERIOD_SPRITE,
+			'u_SpecCubeBoxMax':Shader3D.PERIOD_SPRITE,
+			'u_SpecCubeBoxMin':Shader3D.PERIOD_SPRITE,
+
 			'u_CameraPos': Shader3D.PERIOD_CAMERA,
 			'u_View': Shader3D.PERIOD_CAMERA,
 			'u_ProjectionParams': Shader3D.PERIOD_CAMERA,
@@ -90,8 +96,6 @@ export class PBRSpecularMaterial extends PBRMaterial {
 			'u_SpecGlossTexture': Shader3D.PERIOD_MATERIAL,
 			'u_SpecularColor': Shader3D.PERIOD_MATERIAL,
 
-			'u_ReflectTexture': Shader3D.PERIOD_SCENE,
-			'u_ReflectIntensity': Shader3D.PERIOD_SCENE,
 			'u_AmbientColor': Shader3D.PERIOD_SCENE,
 			'u_FogStart': Shader3D.PERIOD_SCENE,
 			'u_FogRange': Shader3D.PERIOD_SCENE,
@@ -121,8 +125,7 @@ export class PBRSpecularMaterial extends PBRMaterial {
 			'u_AmbientSHBg': Shader3D.PERIOD_SCENE,
 			'u_AmbientSHBb': Shader3D.PERIOD_SCENE,
 			'u_AmbientSHC': Shader3D.PERIOD_SCENE,
-			'u_ReflectionProbe': Shader3D.PERIOD_SCENE,
-			'u_ReflectCubeHDRParams': Shader3D.PERIOD_SCENE,
+
 
 			//legacy lighting
 			'u_DirectionLight.direction': Shader3D.PERIOD_SCENE,

--- a/src/layaAir/laya/d3/core/material/PBRStandardMaterial.ts
+++ b/src/layaAir/laya/d3/core/material/PBRStandardMaterial.ts
@@ -66,6 +66,13 @@ export class PBRStandardMaterial extends PBRMaterial {
 			'u_SimpleAnimatorTexture':Shader3D.PERIOD_SPRITE,
 			'u_SimpleAnimatorParams':Shader3D.PERIOD_SPRITE,
 			'u_SimpleAnimatorTextureSize':Shader3D.PERIOD_SPRITE,
+			
+			//反射
+			'u_ReflectCubeHDRParams': Shader3D.PERIOD_SPRITE,
+			'u_ReflectTexture': Shader3D.PERIOD_SPRITE,
+			'u_SpecCubeProbePosition':Shader3D.PERIOD_SPRITE,
+			'u_SpecCubeBoxMax':Shader3D.PERIOD_SPRITE,
+			'u_SpecCubeBoxMin':Shader3D.PERIOD_SPRITE,
 
 			'u_CameraPos': Shader3D.PERIOD_CAMERA,
 			'u_View': Shader3D.PERIOD_CAMERA,
@@ -90,8 +97,7 @@ export class PBRStandardMaterial extends PBRMaterial {
 			'u_MetallicGlossTexture': Shader3D.PERIOD_MATERIAL,
 			'u_Metallic': Shader3D.PERIOD_MATERIAL,
 
-			'u_ReflectTexture': Shader3D.PERIOD_SCENE,
-			'u_ReflectIntensity': Shader3D.PERIOD_SCENE,
+
 			'u_AmbientColor': Shader3D.PERIOD_SCENE,
 			'u_FogStart': Shader3D.PERIOD_SCENE,
 			'u_FogRange': Shader3D.PERIOD_SCENE,
@@ -121,8 +127,7 @@ export class PBRStandardMaterial extends PBRMaterial {
 			'u_AmbientSHBg': Shader3D.PERIOD_SCENE,
 			'u_AmbientSHBb': Shader3D.PERIOD_SCENE,
 			'u_AmbientSHC': Shader3D.PERIOD_SCENE,
-			'u_ReflectionProbe': Shader3D.PERIOD_SCENE,
-			'u_ReflectCubeHDRParams': Shader3D.PERIOD_SCENE,
+
 
 			//legacy lighting
 			'u_DirectionLight.direction': Shader3D.PERIOD_SCENE,

--- a/src/layaAir/laya/d3/core/reflectionProbe/ReflectionProbeManager.ts
+++ b/src/layaAir/laya/d3/core/reflectionProbe/ReflectionProbeManager.ts
@@ -3,6 +3,10 @@ import { ReflectionProbe } from "./ReflectionProbe";
 import { ReflectionProbeList } from "./ReflectionProbeList";
 import { SingletonList } from "../../component/SingletonList";  
 import { Bounds } from "../Bounds";
+import { SimpleSingletonList } from "../../component/SimpleSingletonList";
+import { TextureCube } from "../../resource/TextureCube";
+import { Vector4 } from "../../math/Vector4";
+import { Vector3 } from "../../math/Vector3";
 
 /**
  *<code>ReflectionProbeManager</code> 类用于反射探针管理
@@ -13,9 +17,26 @@ export class ReflectionProbeManager {
     /** @internal 反射探针队列 */
     private _reflectionProbes:ReflectionProbeList = new ReflectionProbeList();
     /** @internal 环境探针 */
-    private _sceneReflectionProbes:ReflectionProbe;
+    private _sceneReflectionProbe:ReflectionProbe;
     /** @internal 需要跟新反射探针的渲染队列 */
     private _motionObjects:SingletonList<BaseRender> =  new SingletonList<BaseRender>();
+    /** @internal */
+    _needUpdateAllRender:boolean = false;
+    
+    constructor(){
+        this._sceneReflectionProbe = new ReflectionProbe();
+        this._sceneReflectionProbe.bounds= new Bounds(new Vector3(0,0,0),new Vector3(0,0,0));
+        this._sceneReflectionProbe.boxProjection = false;
+        this._sceneReflectionProbe._isScene = true;
+    }
+
+    set sceneReflectionProbe(value:TextureCube){
+        this._sceneReflectionProbe.reflectionTexture = value;
+    }
+
+    set sceneReflectionCubeHDRParam(value:Vector4){
+        this._sceneReflectionProbe.reflectionHDRParams = value;
+    }
     
     /**
      * 更新baseRender的反射探针
@@ -40,10 +61,10 @@ export class ReflectionProbeManager {
             mainProbe = renflectProbe;
             maxOverlap = overlop;
         }
-        if(!mainProbe&&this._sceneReflectionProbes)//如果没有相交 传场景反射球
-            mainProbe = this._sceneReflectionProbes;
+        if(!mainProbe&&this._sceneReflectionProbe)//如果没有相交 传场景反射球
+            mainProbe = this._sceneReflectionProbe;
+        baseRender._probReflection = mainProbe;
      }
-    
     /**
      * 场景中添加反射探针
      * @internal
@@ -51,8 +72,8 @@ export class ReflectionProbeManager {
      */
     add(reflectionProbe:ReflectionProbe){
         this._reflectionProbes.add(reflectionProbe);
+        this._needUpdateAllRender = true;
     }
-
     /**
      * 场景中删除反射探针
      * @internal
@@ -60,9 +81,8 @@ export class ReflectionProbeManager {
      */
     remove(reflectionProbe:ReflectionProbe){
         this._reflectionProbes.remove(reflectionProbe);
+        this._needUpdateAllRender = true;
     }
-
-    
     /**
 	 * 添加运动物体。
 	 * @param 运动物体。
@@ -70,9 +90,9 @@ export class ReflectionProbeManager {
     addMotionObject(renderObject:BaseRender){
         this._motionObjects.add(renderObject);
     }
-
-   
-
+    /**
+     * 更新运动物体的反射探针信息
+     */
     update():void{
         if(this._reflectionProbes.length==0)
             return;
@@ -80,24 +100,27 @@ export class ReflectionProbeManager {
         for(var i:number = 0,n:number = this._motionObjects.length;i<n;i++){
             this._updateMotionObjects(elements[i]);
         }
+        this.clearMotionObjects();
     }
-
     /**
-     * Scene中的所有渲染物体更新反射探针
+     * 更新传入所有渲染器反射探针
+     * @param 渲染器列表
      */
-    updateAllRenderObjects(){
-        
+    updateAllRenderObjects(baseRenders:SimpleSingletonList){
+        var elements = baseRenders.elements;
+        for(var i:number = 0,n:number = baseRenders.length;i<n;i++){
+            this._updateMotionObjects(elements[i] as BaseRender);
+        }
+        this._needUpdateAllRender = false;
     }
-
-    
-
-    //清除所有Profab
+    /**
+     * 清楚变动队列
+     */
     clearMotionObjects(){
         this._motionObjects.length = 0;
     }
 
     destroy(){
-
     }
 }
 

--- a/src/layaAir/laya/d3/core/render/BaseRender.ts
+++ b/src/layaAir/laya/d3/core/render/BaseRender.ts
@@ -21,7 +21,7 @@ import { Texture2D } from "../../../resource/Texture2D"
 import { MeshRenderStaticBatchManager } from "../../graphics/MeshRenderStaticBatchManager";
 import { Stat } from "../../../utils/Stat";
 import { Lightmap } from "../scene/Lightmap";
-import { ReflectionProbe } from "../reflectionProbe/ReflectionProbe";
+import { ReflectionProbe, ReflectionProbeMode } from "../reflectionProbe/ReflectionProbe";
 
 /**
  * <code>Render</code> 类用于渲染器的父类，抽象类不允许实例。
@@ -87,7 +87,7 @@ export class BaseRender extends EventDispatcher implements ISingletonElement, IO
 	/** @internal 材质是否支持反射探针*/
 	_surportReflectionProbe:Boolean;
 	/** @internal 设置是反射探针模式 off  simple */
-	_reflectionMode:number = 0;
+	_reflectionMode:number = ReflectionProbeMode.simple;
 
 	/** @internal */
 	_updateMark: number = -1;
@@ -295,6 +295,14 @@ export class BaseRender extends EventDispatcher implements ISingletonElement, IO
 		return this._renderMark == -1 || this._renderMark == (Stat.loopCount - 1);
 	}
 
+	set reflectionMode(value:ReflectionProbeMode){
+		this._reflectionMode = value;
+	}
+
+	get reflectionMode():ReflectionProbeMode{
+		return this._reflectionMode;
+	}
+
 	/**
 	 * @internal
 	 * 创建一个新的 <code>BaseRender</code> 实例。
@@ -390,6 +398,17 @@ export class BaseRender extends EventDispatcher implements ISingletonElement, IO
 	}
 
 	/**
+	 * 渲染器添加到更新反射探针队列
+	 * @internal
+	 */
+	_addReflectionProbeUpdate(){
+		//TODO目前暂时不支持混合以及与天空盒模式，只支持simple和off
+		if(this._surportReflectionProbe&&this._reflectionMode==1){
+			this._scene._reflectionProbeManager.addMotionObject(this);
+		}
+	}
+
+	/**
 	 * @internal
 	 */
 	_applyLightMapParams(): void {
@@ -425,11 +444,10 @@ export class BaseRender extends EventDispatcher implements ISingletonElement, IO
 					this._octreeNode._octree.addMotionObject(this);
 			}
 		}
-		//TODO目前暂时不支持混合以及与天空盒模式，只支持simple和off
-		if(this._surportReflectionProbe&&this._reflectionMode==3){
-			this._scene._reflectionProbeManager.addMotionObject(this);
-		}
+		this._addReflectionProbeUpdate();
+		
 	}
+
 
 	
 

--- a/src/layaAir/laya/d3/core/render/SubMeshRenderElement.ts
+++ b/src/layaAir/laya/d3/core/render/SubMeshRenderElement.ts
@@ -177,7 +177,7 @@ export class SubMeshRenderElement extends RenderElement {
 				staBatchMarks.batched = false;//是否已有大于两个的元素可合并
 				queueElements.add(this);
 			}
-		} else if (this.renderSubShader._owner._enableInstancing && LayaGL.layaGPUInstance.supportInstance() && this.render.lightmapIndex < 0) {//需要支持Instance渲染才可用,暂不支持光照贴图
+		} else if (this.renderSubShader._owner._enableInstancing && LayaGL.layaGPUInstance.supportInstance() && this.render.lightmapIndex < 0 && this.render._probReflection._isScene ) {//需要支持Instance渲染才可用,暂不支持光照贴图//不是Scene反射探针的不能合并
 			var subMesh: SubMesh = (<SubMesh>this._geometry);
 			var insManager: MeshRenderDynamicBatchManager = ILaya3D.MeshRenderDynamicBatchManager.instance;
 			var insBatchMarks: BatchMark = insManager.getInstanceBatchOpaquaMark(this.render.receiveShadow, this.material.id, subMesh._id, this._transform._isFrontFaceInvert);
@@ -295,7 +295,7 @@ export class SubMeshRenderElement extends RenderElement {
 				queueElements.add(this);
 				queue.lastTransparentBatched = false;
 			}
-		} else if (this.renderSubShader._owner._enableInstancing && LayaGL.layaGPUInstance.supportInstance() && this.render.lightmapIndex < 0) {//需要支持Instance渲染才可用，暂不支持光照贴图
+		} else if (this.renderSubShader._owner._enableInstancing && LayaGL.layaGPUInstance.supportInstance() && this.render.lightmapIndex < 0 && this.render._probReflection._isScene) {//需要支持Instance渲染才可用，暂不支持光照贴图
 			var subMesh: SubMesh = (<SubMesh>this._geometry);
 			var insManager: MeshRenderDynamicBatchManager = ILaya3D.MeshRenderDynamicBatchManager.instance;
 			var insLastElement: RenderElement = queue.lastTransparentRenderElement;

--- a/src/layaAir/laya/d3/core/scene/Scene3D.ts
+++ b/src/layaAir/laya/d3/core/scene/Scene3D.ts
@@ -124,8 +124,6 @@ export class Scene3D extends Sprite implements ISubmit, ICreateResource {
 	static AMBIENTSHBG: number = Shader3D.propertyNameToID("u_AmbientSHBg");
 	static AMBIENTSHBB: number = Shader3D.propertyNameToID("u_AmbientSHBb");
 	static AMBIENTSHC: number = Shader3D.propertyNameToID("u_AmbientSHC");
-	static REFLECTIONPROBE: number = Shader3D.propertyNameToID("u_ReflectionProbe");
-	static REFLECTIONCUBE_HDR_PARAMS: number = Shader3D.propertyNameToID("u_ReflectCubeHDRParams");
 
 	//------------------legacy lighting-------------------------------
 	static LIGHTDIRECTION: number = Shader3D.propertyNameToID("u_DirectionLight.direction");
@@ -142,7 +140,7 @@ export class Scene3D extends Sprite implements ISubmit, ICreateResource {
 	//------------------legacy lighting-------------------------------
 
 	static AMBIENTCOLOR: number = Shader3D.propertyNameToID("u_AmbientColor");
-	static REFLECTIONTEXTURE: number = Shader3D.propertyNameToID("u_ReflectTexture");
+
 	static TIME: number = Shader3D.propertyNameToID("u_Time");
 
 	/** @internal */
@@ -445,8 +443,10 @@ export class Scene3D extends Sprite implements ISubmit, ICreateResource {
 	set reflection(value: TextureCube) {
 		if (this._reflection != value) {
 			value._addReference();
-			this._shaderValues.setTexture(Scene3D.REFLECTIONTEXTURE, value || TextureCube.blackTexture);
-			this._reflection = value;
+			this._reflectionProbeManager.sceneReflectionProbe = value;
+			this._reflection = value || TextureCube.blackTexture;
+			this._reflectionProbeManager._needUpdateAllRender = true;
+
 		}
 	}
 
@@ -463,6 +463,7 @@ export class Scene3D extends Sprite implements ISubmit, ICreateResource {
 			if (this._reflectionDecodeFormat == TextureDecodeFormat.RGBM)
 				this._reflectionCubeHDRParams.x *= 5.0;//5.0 is RGBM param
 			this._reflectionDecodeFormat = value;
+			this._reflectionProbeManager.sceneReflectionCubeHDRParam = this._reflectionCubeHDRParams;
 		}
 	}
 
@@ -479,6 +480,7 @@ export class Scene3D extends Sprite implements ISubmit, ICreateResource {
 		if (this._reflectionDecodeFormat == TextureDecodeFormat.RGBM)
 			this._reflectionCubeHDRParams.x *= 5.0;//5.0 is RGBM param
 		this._reflectionIntensity = value;
+		this._reflectionProbeManager.sceneReflectionCubeHDRParam = this._reflectionCubeHDRParams;
 	}
 
 	/**
@@ -571,7 +573,7 @@ export class Scene3D extends Sprite implements ISubmit, ICreateResource {
 		for (var i: number = 0; i < 7; i++)
 			this._shCoefficients[i] = new Vector4();
 
-		this._shaderValues.setVector(Scene3D.REFLECTIONCUBE_HDR_PARAMS, this._reflectionCubeHDRParams);
+		this._reflectionProbeManager.sceneReflectionCubeHDRParam = this._reflectionCubeHDRParams;
 
 		if (Render.supportWebGLPlusCulling) {//[NATIVE]
 			this._cullingBufferIndices = new Int32Array(1024);
@@ -665,6 +667,10 @@ export class Scene3D extends Sprite implements ISubmit, ICreateResource {
 		this._updateScript();
 		Animator._update(this);
 		VideoTexture._update();
+		if(this._reflectionProbeManager._needUpdateAllRender)
+			this._reflectionProbeManager.updateAllRenderObjects(this._renders);
+		else
+			this._reflectionProbeManager.update();
 		this._lateUpdateScript();
 	}
 
@@ -1254,6 +1260,7 @@ export class Scene3D extends Sprite implements ISubmit, ICreateResource {
 				this._cullingBufferIndices[indexInList] = render._cullingBufferIndex;
 			}
 		}
+		render._addReflectionProbeUpdate();
 	}
 
 	/**
@@ -1392,7 +1399,8 @@ export class Scene3D extends Sprite implements ISubmit, ICreateResource {
 
 	set customReflection(value: TextureCube) {
 		if (this._reflection != value) {
-			this._shaderValues.setTexture(Scene3D.REFLECTIONTEXTURE, value || TextureCube.blackTexture);
+			value._addReference();
+			this._reflectionProbeManager.sceneReflectionProbe = value;
 			this._reflection = value;
 		}
 	}

--- a/src/layaAir/laya/d3/shader/ShaderInit3D.ts
+++ b/src/layaAir/laya/d3/shader/ShaderInit3D.ts
@@ -130,7 +130,6 @@ export class ShaderInit3D {
 			'u_ViewProjection': Shader3D.PERIOD_CAMERA,
 
 			'u_ReflectTexture': Shader3D.PERIOD_SCENE,
-			'u_ReflectIntensity': Shader3D.PERIOD_SCENE,
 			'u_FogStart': Shader3D.PERIOD_SCENE,
 			'u_FogRange': Shader3D.PERIOD_SCENE,
 			'u_FogColor': Shader3D.PERIOD_SCENE,
@@ -179,7 +178,7 @@ export class ShaderInit3D {
 			's_DepthTest': Shader3D.RENDER_STATE_DEPTH_TEST,
 			's_DepthWrite': Shader3D.RENDER_STATE_DEPTH_WRITE
 		}
-		var shader: Shader3D = Shader3D.add("BLINNPHONG", null, null, true,true);
+		var shader: Shader3D = Shader3D.add("BLINNPHONG", null, null, true);
 		var subShader: SubShader = new SubShader(attributeMap, uniformMap);
 		shader.addSubShader(subShader);
 		subShader.addShaderPass(MeshBlinnPhongVS, MeshBlinnPhongPS, stateMap, "Forward");

--- a/src/layaAir/laya/d3/shader/files/PBRLibs/PBRCore.glsl
+++ b/src/layaAir/laya/d3/shader/files/PBRLibs/PBRCore.glsl
@@ -79,12 +79,13 @@ FragmentCommonData specularSetup(vec2 uv)
     return o;
 }
 
-LayaGI fragmentGI(float smoothness,vec3 eyeVec,mediump float occlusion,mediump vec2 lightmapUV,vec3 worldnormal)
+LayaGI fragmentGI(float smoothness,vec3 eyeVec,mediump float occlusion,mediump vec2 lightmapUV,vec3 worldnormal,vec3 worldPos)
 {
 	LayaGIInput giInput;
 	#ifdef LIGHTMAP
 		giInput.lightmapUV=lightmapUV;
 	#endif
+	giInput.worldPos = worldPos;
 
 	vec3 worldViewDir = -eyeVec;
 	mediump vec4 uvwRoughness;
@@ -149,7 +150,7 @@ void fragmentForward()
 	float perceptualRoughness = smoothnessToPerceptualRoughness(o.smoothness);
 	float roughness = perceptualRoughnessToRoughness(perceptualRoughness);
 	float nv = abs(dot(normalWorld, eyeVec));
-	LayaGI gi =fragmentGI(o.smoothness,eyeVec,occlusion,lightMapUV,normalWorld);
+	LayaGI gi =fragmentGI(o.smoothness,eyeVec,occlusion,lightMapUV,normalWorld,posworld);
 	vec4 color = LAYA_BRDF_GI(o.diffColor,o.specColor,o.oneMinusReflectivity,o.smoothness,perceptualRoughness,roughness,nv,normalWorld,eyeVec,gi);
 	
 	float shadowAttenuation = 1.0;
@@ -250,5 +251,6 @@ void fragmentForward()
 	
 	gl_FragColor=vec4(color.rgb,alpha);
 }
+
 
 

--- a/src/layaAir/laya/d3/utils/Scene3DUtils.ts
+++ b/src/layaAir/laya/d3/utils/Scene3DUtils.ts
@@ -15,6 +15,7 @@ import { TrailSprite3D } from "../core/trail/TrailSprite3D";
 import { StaticBatchManager } from "../graphics/StaticBatchManager";
 import { ClassUtils } from "../../utils/ClassUtils";
 import { SimpleSkinnedMeshSprite3D } from "../core/SimpleSkinnedMeshSprite3D";
+import { ReflectionProbe } from "../core/reflectionProbe/ReflectionProbe";
 
 
 
@@ -58,6 +59,9 @@ export class Scene3DUtils {
 				break;
 			case "TrailSprite3D":
 				node = new TrailSprite3D();
+				break;
+			case "ReflectionProbe":
+				node = new ReflectionProbe();
 				break;
 			default:
 				throw new Error("Utils3D:unidentified class type in (.lh) file.");


### PR DESCRIPTION
2、修复Bounds类中计算包围盒相交体积的方法
3、MeshRender中增加反射探针的更新
4、MeshSprite3D.ts中增加SPECCUBE_BOX_PROJECTION宏
5、RenderableSprite3D.ts中增加反射探针的uniform
6、SkinnedMeshRenderer.ts中增加反射探针更新
7、u_ReflectCubeHDRParams，u_ReflectTexture中调整为逐精灵传输增加反射探针的uniform
8、ReflectionProb中增加size offseet属性 增加反射探针解析
9、完善反射探针管理类
10、增加反射探针模式 off  simple
11、不是Scene的反射探针不可进行instance合并
12、Scene3D中增加反射探针更新
13、GlobalIllumination.glsl中增加反射探针uniform  增加反射采样方向的偏移函数