### PR TITLE
修复shader编译中的几个bug

### DIFF
--- a/src/layaAir/laya/d3/shader/DefineDatas.ts
+++ b/src/layaAir/laya/d3/shader/DefineDatas.ts
@@ -83,17 +83,23 @@ export class DefineDatas implements IClone {
 		var addMask: Array<number> = define._mask;
 		var size: number = define._length;
 		var mask: Array<number> = this._mask;
-		var maskStart: number = mask.length;
+		var maskStart: number = this._length;
 		if (maskStart < size) {
 			mask.length = size;
 			for (var i: number = 0; i < maskStart; i++)
 				mask[i] |= addMask[i];
-			for (; maskStart < size; maskStart++)
-				mask[maskStart] = addMask[maskStart];
+			for (; i < size; i++)
+				mask[i] = addMask[i];
 			this._length = size;
 		} else {
 			for (var i: number = 0; i < size; i++)
+			{
+				if(i<this._length)
 				mask[i] |= addMask[i];
+				else
+				mask[i] = addMask[i];
+			}
+				
 			this._length = Math.max(this._length, size);
 		}
 	}

--- a/src/layaAir/laya/d3/shader/files/BlitScreen.fs
+++ b/src/layaAir/laya/d3/shader/files/BlitScreen.fs
@@ -1,4 +1,4 @@
-#ifdef GL_FRAGMENT_PRECISION_HIGH
+#if defined(GL_FRAGMENT_PRECISION_HIGH)// 原来的写法会被我们自己的解析流程处理，而我们的解析是不认内置宏的，导致被删掉，所以改成 if defined 了
 	precision highp float;
 #else
 	precision mediump float;

--- a/src/layaAir/laya/d3/shader/files/BlitScreen.vs
+++ b/src/layaAir/laya/d3/shader/files/BlitScreen.vs
@@ -1,5 +1,9 @@
 #include "Lighting.glsl";
-
+#if defined(GL_FRAGMENT_PRECISION_HIGH)// 原来的写法会被我们自己的解析流程处理，而我们的解析是不认内置宏的，导致被删掉，所以改成 if defined 了
+	precision highp float;
+#else
+	precision mediump float;
+#endif
 attribute vec4 a_PositionTexcoord;
 uniform vec4 u_OffsetScale;
 varying vec2 v_Texcoord0;

--- a/src/layaAir/laya/d3/shader/files/Effect.fs
+++ b/src/layaAir/laya/d3/shader/files/Effect.fs
@@ -1,4 +1,4 @@
-#ifdef GL_FRAGMENT_PRECISION_HIGH
+#if defined(GL_FRAGMENT_PRECISION_HIGH)// 原来的写法会被我们自己的解析流程处理，而我们的解析是不认内置宏的，导致被删掉，所以改成 if defined 了
 	precision highp float;
 #else
 	precision mediump float;

--- a/src/layaAir/laya/d3/shader/files/Effect.vs
+++ b/src/layaAir/laya/d3/shader/files/Effect.vs
@@ -1,3 +1,8 @@
+#if defined(GL_FRAGMENT_PRECISION_HIGH)// 原来的写法会被我们自己的解析流程处理，而我们的解析是不认内置宏的，导致被删掉，所以改成 if defined 了
+	precision highp float;
+#else
+	precision mediump float;
+#endif
 #include "Lighting.glsl";
 
 attribute vec4 a_Position;

--- a/src/layaAir/laya/d3/shader/files/Mesh-BlinnPhong.fs
+++ b/src/layaAir/laya/d3/shader/files/Mesh-BlinnPhong.fs
@@ -1,4 +1,4 @@
-#ifdef GL_FRAGMENT_PRECISION_HIGH
+#if defined(GL_FRAGMENT_PRECISION_HIGH)// 原来的写法会被我们自己的解析流程处理，而我们的解析是不认内置宏的，导致被删掉，所以改成 if defined 了
 	precision highp float;
 	precision highp int;
 #else
@@ -87,7 +87,7 @@ varying vec3 v_Normal;
 	varying vec4 v_ShadowCoord;
 #endif
 
-#ifdef CALCULATE_SPOTSHADOWS
+#if defined(CALCULATE_SPOTSHADOWS)//shader中自定义的宏不可用ifdef 必须改成if defined
 	varying vec4 v_SpotShadowCoord;
 #endif
 
@@ -147,7 +147,7 @@ void main()
 	#ifdef LEGACYSINGLELIGHTING
 		#ifdef DIRECTIONLIGHT
 			LayaAirBlinnPhongDiectionLight(u_MaterialSpecular,u_Shininess,normal,gloss,viewDir,u_DirectionLight,dif,spe);
-			#ifdef CALCULATE_SHADOWS
+			#if defined(CALCULATE_SHADOWS)//shader中自定义的宏不可用ifdef 必须改成if defined
 				#ifdef SHADOW_CASCADE
 					vec4 shadowCoord = getShadowCoord(vec4(v_PositionWorld,1.0));
 				#else
@@ -169,7 +169,7 @@ void main()
 
 		#ifdef SPOTLIGHT
 			LayaAirBlinnPhongSpotLight(v_PositionWorld,u_MaterialSpecular,u_Shininess,normal,gloss,viewDir,u_SpotLight,dif,spe);
-			#ifdef CALCULATE_SPOTSHADOWS
+			#if defined(CALCULATE_SPOTSHADOWS)//shader中自定义的宏不可用ifdef 必须改成if defined
 				vec4 spotShadowcoord = v_SpotShadowCoord;
 				float spotShadowAttenuation = sampleSpotShadowmap(spotShadowcoord);
 				dif *= spotShadowAttenuation;
@@ -185,7 +185,7 @@ void main()
 				if(i >= u_DirationLightCount)
 					break;
 				DirectionLight directionLight = getDirectionLight(u_LightBuffer,i);
-				#ifdef CALCULATE_SHADOWS
+				#if defined(CALCULATE_SHADOWS)//shader中自定义的宏不可用ifdef 必须改成if defined
 					if(i == 0)
 					{
 						#ifdef SHADOW_CASCADE
@@ -220,7 +220,7 @@ void main()
 					if(i >= clusterInfo.y)//SpotLightCount
 						break;
 					SpotLight spotLight = getSpotLight(u_LightBuffer,u_LightClusterBuffer,clusterInfo,i);
-					#ifdef CALCULATE_SPOTSHADOWS
+					#if defined(CALCULATE_SPOTSHADOWS)//shader中自定义的宏不可用ifdef 必须改成if defined
 						if(i == 0)
 						{
 							vec4 spotShadowcoord = v_SpotShadowCoord;

--- a/src/layaAir/laya/d3/shader/files/Mesh-BlinnPhong.vs
+++ b/src/layaAir/laya/d3/shader/files/Mesh-BlinnPhong.vs
@@ -1,3 +1,10 @@
+#if defined(GL_FRAGMENT_PRECISION_HIGH)// 原来的写法会被我们自己的解析流程处理，而我们的解析是不认内置宏的，导致被删掉，所以改成 if defined 了
+	precision highp float;
+	precision highp int;
+#else
+	precision mediump float;
+	precision mediump int;
+#endif
 #include "Lighting.glsl";
 #include "Shadow.glsl";
 
@@ -63,7 +70,7 @@ varying vec3 v_Normal;
 	varying vec4 v_ShadowCoord;
 #endif
 
-#ifdef CALCULATE_SPOTSHADOWS
+#if defined(CALCULATE_SPOTSHADOWS)//shader中自定义的宏不可用ifdef 必须改成if defined
 	varying vec4 v_SpotShadowCoord;
 #endif
 
@@ -195,7 +202,7 @@ void main()
 		v_ShadowCoord =getShadowCoord(vec4(positionWS,1.0));
 	#endif
 
-	#ifdef CALCULATE_SPOTSHADOWS
+	#if defined(CALCULATE_SPOTSHADOWS)//shader中自定义的宏不可用ifdef 必须改成if defined
 		v_SpotShadowCoord = u_SpotViewProjectMatrix*vec4(positionWS,1.0);
 	#endif
 

--- a/src/layaAir/laya/d3/shader/files/Mesh-BlinnPhongShadowCaster.fs
+++ b/src/layaAir/laya/d3/shader/files/Mesh-BlinnPhongShadowCaster.fs
@@ -1,4 +1,4 @@
-#ifdef GL_FRAGMENT_PRECISION_HIGH
+#if defined(GL_FRAGMENT_PRECISION_HIGH)// 原来的写法会被我们自己的解析流程处理，而我们的解析是不认内置宏的，导致被删掉，所以改成 if defined 了
 	precision highp float;
 	precision highp int;
 #else

--- a/src/layaAir/laya/d3/shader/files/PBR.fs
+++ b/src/layaAir/laya/d3/shader/files/PBR.fs
@@ -1,4 +1,4 @@
-#ifdef GL_FRAGMENT_PRECISION_HIGH
+#if defined(GL_FRAGMENT_PRECISION_HIGH)// 原来的写法会被我们自己的解析流程处理，而我们的解析是不认内置宏的，导致被删掉，所以改成 if defined 了
 	precision highp float;
 	precision highp int;
 #else

--- a/src/layaAir/laya/d3/shader/files/PBR.vs
+++ b/src/layaAir/laya/d3/shader/files/PBR.vs
@@ -1,3 +1,10 @@
+#if defined(GL_FRAGMENT_PRECISION_HIGH)// 原来的写法会被我们自己的解析流程处理，而我们的解析是不认内置宏的，导致被删掉，所以改成 if defined 了
+	precision highp float;
+	precision highp int;
+#else
+	precision mediump float;
+	precision mediump int;
+#endif
 #include "Lighting.glsl";
 #include "Shadow.glsl"
 #include "PBRVSInput.glsl";

--- a/src/layaAir/laya/d3/shader/files/PBRLibs/PBRCore.glsl
+++ b/src/layaAir/laya/d3/shader/files/PBRLibs/PBRCore.glsl
@@ -8,7 +8,7 @@ struct FragmentCommonData{
 	//vec3 reflUVW;
 };
 
-#ifndef SETUP_BRDF_INPUT
+#if !defined(SETUP_BRDF_INPUT)//shader内部的宏需要将改成#ifdef改成#if类型 不然会被Laya的shader分析器优化掉
     #define SETUP_BRDF_INPUT metallicSetup//default is metallicSetup,also can be other. 
 #endif
 
@@ -156,7 +156,7 @@ void fragmentForward()
 	float shadowAttenuation = 1.0;
 	#ifdef LEGACYSINGLELIGHTING
 		#ifdef DIRECTIONLIGHT
-			#ifdef CALCULATE_SHADOWS
+			#if defined(CALCULATE_SHADOWS)//shader中自定义的宏不可用ifdef 必须改成if defined
 				#ifdef SHADOW_CASCADE
 					vec4 shadowCoord = getShadowCoord(vec4(v_PositionWorld,1.0));
 				#else
@@ -176,7 +176,7 @@ void fragmentForward()
 		
 		#ifdef SPOTLIGHT
 			shadowAttenuation = 1.0;
-			#ifdef CALCULATE_SPOTSHADOWS
+			#if defined(CALCULATE_SPOTSHADOWS)//shader中自定义的宏不可用ifdef 必须改成if defined
 				vec4 spotShadowcoord = v_SpotShadowCoord;
 				shadowAttenuation = sampleSpotShadowmap(spotShadowcoord);
 			#endif
@@ -190,7 +190,7 @@ void fragmentForward()
 				shadowAttenuation = 1.0;
 				if(i >= u_DirationLightCount)
 					break;
-				#ifdef CALCULATE_SHADOWS
+				#if defined(CALCULATE_SHADOWS)//shader中自定义的宏不可用ifdef 必须改成if defined
 					if(i == 0)
 					{
 						#ifdef SHADOW_CASCADE
@@ -225,7 +225,7 @@ void fragmentForward()
 					shadowAttenuation = 1.0;
 					if(i >= clusterInfo.y)//SpotLightCount
 						break;
-					#ifdef CALCULATE_SPOTSHADOWS
+					#if defined(CALCULATE_SPOTSHADOWS)//shader中自定义的宏不可用ifdef 必须改成if defined
 						if(i == 0)
 						{
 							vec4 spotShadowcoord = v_SpotShadowCoord;

--- a/src/layaAir/laya/d3/shader/files/PBRLibs/PBRFSInput.glsl
+++ b/src/layaAir/laya/d3/shader/files/PBRLibs/PBRFSInput.glsl
@@ -100,7 +100,7 @@ varying vec3 v_PositionWorld;
 	varying vec4 v_ShadowCoord;
 #endif
 
-#ifdef CALCULATE_SPOTSHADOWS
+#if defined(CALCULATE_SPOTSHADOWS)//shader中自定义的宏不可用ifdef 必须改成if defined
 	varying vec4 v_SpotShadowCoord;
 #endif
 

--- a/src/layaAir/laya/d3/shader/files/PBRLibs/PBRVSInput.glsl
+++ b/src/layaAir/laya/d3/shader/files/PBRLibs/PBRVSInput.glsl
@@ -50,7 +50,7 @@ varying float v_posViewZ;
 	varying vec4 v_ShadowCoord;
 #endif
 
-#ifdef CALCULATE_SPOTSHADOWS
+#if defined(CALCULATE_SPOTSHADOWS)//shader中自定义的宏不可用ifdef 必须改成if defined
 	varying vec4 v_SpotShadowCoord;
 #endif
 

--- a/src/layaAir/laya/d3/shader/files/PBRLibs/PBRVertex.glsl
+++ b/src/layaAir/laya/d3/shader/files/PBRLibs/PBRVertex.glsl
@@ -92,7 +92,7 @@ void vertexForward()
 		v_ShadowCoord = getShadowCoord(vec4(v_PositionWorld,1.0));
 	#endif
 
-	#ifdef CALCULATE_SPOTSHADOWS
+	#if defined(CALCULATE_SPOTSHADOWS)//shader中自定义的宏不可用ifdef 必须改成if defined
 		v_SpotShadowCoord = u_SpotViewProjectMatrix*vec4(v_PositionWorld,1.0);
 	#endif
 }

--- a/src/layaAir/laya/d3/shader/files/PBRShadowCaster.fs
+++ b/src/layaAir/laya/d3/shader/files/PBRShadowCaster.fs
@@ -1,4 +1,4 @@
-#ifdef GL_FRAGMENT_PRECISION_HIGH
+#if defined(GL_FRAGMENT_PRECISION_HIGH)// 原来的写法会被我们自己的解析流程处理，而我们的解析是不认内置宏的，导致被删掉，所以改成 if defined 了
 	precision highp float;
 	precision highp int;
 #else

--- a/src/layaAir/laya/d3/shader/files/PBRSpecular.fs
+++ b/src/layaAir/laya/d3/shader/files/PBRSpecular.fs
@@ -1,4 +1,4 @@
-#ifdef GL_FRAGMENT_PRECISION_HIGH
+#if defined(GL_FRAGMENT_PRECISION_HIGH)// 原来的写法会被我们自己的解析流程处理，而我们的解析是不认内置宏的，导致被删掉，所以改成 if defined 了
 	precision highp float;
 	precision highp int;
 #else

--- a/src/layaAir/laya/d3/shader/files/PBRSpecularShadowCaster.fs
+++ b/src/layaAir/laya/d3/shader/files/PBRSpecularShadowCaster.fs
@@ -1,4 +1,4 @@
-#ifdef GL_FRAGMENT_PRECISION_HIGH
+#if defined(GL_FRAGMENT_PRECISION_HIGH)// 原来的写法会被我们自己的解析流程处理，而我们的解析是不认内置宏的，导致被删掉，所以改成 if defined 了
 	precision highp float;
 	precision highp int;
 #else

--- a/src/layaAir/laya/d3/shader/files/ParticleShuriKen.fs
+++ b/src/layaAir/laya/d3/shader/files/ParticleShuriKen.fs
@@ -1,4 +1,4 @@
-#ifdef GL_FRAGMENT_PRECISION_HIGH
+#if defined(GL_FRAGMENT_PRECISION_HIGH)// 原来的写法会被我们自己的解析流程处理，而我们的解析是不认内置宏的，导致被删掉，所以改成 if defined 了
   precision highp float;
 #else
   precision mediump float;

--- a/src/layaAir/laya/d3/shader/files/ParticleShuriKen.vs
+++ b/src/layaAir/laya/d3/shader/files/ParticleShuriKen.vs
@@ -1,6 +1,18 @@
-#include "Lighting.glsl";
+// #include "Lighting.glsl";
 
-#ifdef GL_FRAGMENT_PRECISION_HIGH
+//修改这里剔除没有用到的光照函数，增加粒子的编译速度
+vec2 TransformUV(vec2 texcoord,vec4 tilingOffset) {
+	vec2 transTexcoord=vec2(texcoord.x,texcoord.y-1.0)*tilingOffset.xy+vec2(tilingOffset.z,-tilingOffset.w);
+	transTexcoord.y+=1.0;
+	return transTexcoord;
+}
+
+vec4 remapGLPositionZ(vec4 position) {
+	position.z=position.z * 2.0 - position.w;
+	return position;
+}
+
+#if defined(GL_FRAGMENT_PRECISION_HIGH)
   precision highp float;
 #else
   precision mediump float;

--- a/src/layaAir/laya/d3/shader/files/Shadow.glsl
+++ b/src/layaAir/laya/d3/shader/files/Shadow.glsl
@@ -68,7 +68,7 @@ uniform vec4 u_ShadowBias; // x: depth bias, y: normal bias
 
 
 
-#ifdef CALCULATE_SHADOWS
+#if defined(CALCULATE_SHADOWS)//shader中自定义的宏不可用ifdef 必须改成if defined
 
 	TEXTURE2D_SHADOW(u_ShadowMap);
 
@@ -138,7 +138,7 @@ uniform vec4 u_ShadowBias; // x: depth bias, y: normal bias
 	}
 #endif
 
-#ifdef CALCULATE_SPOTSHADOWS
+#if defined(CALCULATE_SPOTSHADOWS)//shader中自定义的宏不可用ifdef 必须改成if defined
 	TEXTURE2D_SHADOW(u_SpotShadowMap);
 	uniform mat4 u_SpotViewProjectMatrix;
 	float sampleSpotShadowmap(vec4 shadowCoord)

--- a/src/layaAir/laya/d3/shader/files/SkyBox.fs
+++ b/src/layaAir/laya/d3/shader/files/SkyBox.fs
@@ -1,4 +1,4 @@
-#ifdef GL_FRAGMENT_PRECISION_HIGH
+#if defined(GL_FRAGMENT_PRECISION_HIGH)// 原来的写法会被我们自己的解析流程处理，而我们的解析是不认内置宏的，导致被删掉，所以改成 if defined 了
 precision highp float;
 #else
 precision mediump float;

--- a/src/layaAir/laya/d3/shader/files/SkyBox.vs
+++ b/src/layaAir/laya/d3/shader/files/SkyBox.vs
@@ -1,3 +1,8 @@
+#if defined(GL_FRAGMENT_PRECISION_HIGH)// 原来的写法会被我们自己的解析流程处理，而我们的解析是不认内置宏的，导致被删掉，所以改成 if defined 了
+precision highp float;
+#else
+precision mediump float;
+#endif
 #include "Lighting.glsl";
 
 attribute vec4 a_Position;

--- a/src/layaAir/laya/d3/shader/files/SkyBoxProcedural.fs
+++ b/src/layaAir/laya/d3/shader/files/SkyBoxProcedural.fs
@@ -1,4 +1,4 @@
-#ifdef GL_FRAGMENT_PRECISION_HIGH
+#if defined(GL_FRAGMENT_PRECISION_HIGH)// 原来的写法会被我们自己的解析流程处理，而我们的解析是不认内置宏的，导致被删掉，所以改成 if defined 了
 	precision highp float;
 #else
 	precision mediump float;

--- a/src/layaAir/laya/d3/shader/files/SkyBoxProcedural.vs
+++ b/src/layaAir/laya/d3/shader/files/SkyBoxProcedural.vs
@@ -1,4 +1,4 @@
-#ifdef GL_FRAGMENT_PRECISION_HIGH
+#if defined(GL_FRAGMENT_PRECISION_HIGH)// 原来的写法会被我们自己的解析流程处理，而我们的解析是不认内置宏的，导致被删掉，所以改成 if defined 了
 	precision highp float;
 #else
 	precision mediump float;

--- a/src/layaAir/laya/d3/shader/files/SkyPanoramic.fs
+++ b/src/layaAir/laya/d3/shader/files/SkyPanoramic.fs
@@ -1,4 +1,4 @@
-#ifdef GL_FRAGMENT_PRECISION_HIGH
+#if defined(GL_FRAGMENT_PRECISION_HIGH)// 原来的写法会被我们自己的解析流程处理，而我们的解析是不认内置宏的，导致被删掉，所以改成 if defined 了
 	precision highp float;
 #else
 	precision mediump float;

--- a/src/layaAir/laya/d3/shader/files/Trail.fs
+++ b/src/layaAir/laya/d3/shader/files/Trail.fs
@@ -1,4 +1,4 @@
-#ifdef GL_FRAGMENT_PRECISION_HIGH
+#if defined(GL_FRAGMENT_PRECISION_HIGH)// 原来的写法会被我们自己的解析流程处理，而我们的解析是不认内置宏的，导致被删掉，所以改成 if defined 了
 	precision highp float;
 #else
 	precision mediump float;

--- a/src/layaAir/laya/d3/shader/files/Trail.vs
+++ b/src/layaAir/laya/d3/shader/files/Trail.vs
@@ -1,3 +1,8 @@
+#if defined(GL_FRAGMENT_PRECISION_HIGH)// 原来的写法会被我们自己的解析流程处理，而我们的解析是不认内置宏的，导致被删掉，所以改成 if defined 了
+	precision highp float;
+#else
+	precision mediump float;
+#endif
 #include "Lighting.glsl";
 
 attribute vec3 a_Position;

--- a/src/layaAir/laya/d3/shader/files/Unlit.fs
+++ b/src/layaAir/laya/d3/shader/files/Unlit.fs
@@ -1,4 +1,4 @@
-#ifdef GL_FRAGMENT_PRECISION_HIGH
+#if defined(GL_FRAGMENT_PRECISION_HIGH)// 原来的写法会被我们自己的解析流程处理，而我们的解析是不认内置宏的，导致被删掉，所以改成 if defined 了
 	precision highp float;
 #else
 	precision mediump float;

--- a/src/layaAir/laya/d3/shader/files/Unlit.vs
+++ b/src/layaAir/laya/d3/shader/files/Unlit.vs
@@ -1,3 +1,8 @@
+#if defined(GL_FRAGMENT_PRECISION_HIGH)// 原来的写法会被我们自己的解析流程处理，而我们的解析是不认内置宏的，导致被删掉，所以改成 if defined 了
+	precision highp float;
+#else
+	precision mediump float;
+#endif
 #include "Lighting.glsl";
 
 attribute vec4 a_Position;

--- a/src/layaAir/laya/d3/shader/files/WaterPrimary.fs
+++ b/src/layaAir/laya/d3/shader/files/WaterPrimary.fs
@@ -1,4 +1,4 @@
-#ifdef GL_FRAGMENT_PRECISION_HIGH
+#if defined(GL_FRAGMENT_PRECISION_HIGH)// 原来的写法会被我们自己的解析流程处理，而我们的解析是不认内置宏的，导致被删掉，所以改成 if defined 了
 	precision highp float;
 #else
 	precision mediump float;

--- a/src/layaAir/laya/d3/shader/files/extendTerrain.fs
+++ b/src/layaAir/laya/d3/shader/files/extendTerrain.fs
@@ -1,4 +1,4 @@
-#ifdef GL_FRAGMENT_PRECISION_HIGH
+#if defined(GL_FRAGMENT_PRECISION_HIGH)// 原来的写法会被我们自己的解析流程处理，而我们的解析是不认内置宏的，导致被删掉，所以改成 if defined 了
 	precision highp float;
 #else
 	precision mediump float;
@@ -40,7 +40,7 @@
 #endif
 
 #include "Shadow.glsl"
-#ifdef CALCULATE_SHADOWS
+#if defined(CALCULATE_SHADOWS)//shader中自定义的宏不可用ifdef 必须改成if defined
 	varying vec4 v_ShadowCoord;
 #endif
 varying float v_posViewZ;
@@ -188,7 +188,7 @@ vec3 globalDiffuse = u_AmbientColor;
 	globalDiffuse += decodeHDR(texture2D(u_LightMap, v_LightMapUV),5.0);
 #endif
 
-#ifdef CALCULATE_SHADOWS
+#if defined(CALCULATE_SHADOWS)//shader中自定义的宏不可用ifdef 必须改成if defined
 	float shadowValue = shadowValue = sampleShadowmap(v_ShadowCoord);
 	gl_FragColor = vec4(gl_FragColor.rgb * (globalDiffuse + diffuse) * shadowValue, gl_FragColor.a);
 #else
@@ -196,7 +196,7 @@ vec3 globalDiffuse = u_AmbientColor;
 #endif
 
 #if defined(DIRECTIONLIGHT)||defined(POINTLIGHT)||defined(SPOTLIGHT)
-	#ifdef CALCULATE_SHADOWS
+	#if defined(CALCULATE_SHADOWS)//shader中自定义的宏不可用ifdef 必须改成if defined
 		gl_FragColor.rgb += specular * shadowValue;
 	#else
 		gl_FragColor.rgb += specular;

--- a/src/layaAir/laya/d3/shader/files/extendTerrain.vs
+++ b/src/layaAir/laya/d3/shader/files/extendTerrain.vs
@@ -22,7 +22,7 @@ varying vec2 v_Texcoord0;
 	uniform vec4 u_LightmapScaleOffset;
 #endif
 
-#ifdef CALCULATE_SHADOWS
+#if defined(CALCULATE_SHADOWS)//shader中自定义的宏不可用ifdef 必须改成if defined
 	varying vec4 v_ShadowCoord;
 #endif
 
@@ -45,7 +45,7 @@ void main()
 		v_PositionWorld=(u_WorldMat*a_Position).xyz;
 	#endif
 
-	#ifdef CALCULATE_SHADOWS
+	#if defined(CALCULATE_SHADOWS)//shader中自定义的宏不可用ifdef 必须改成if defined
 		v_ShadowCoord = getShadowCoord(vec4(v_PositionWorld));
 	#endif
 	gl_Position=remapGLPositionZ(gl_Position);

--- a/src/layaAir/laya/d3/shader/files/line.fs
+++ b/src/layaAir/laya/d3/shader/files/line.fs
@@ -1,4 +1,4 @@
-#ifdef GL_FRAGMENT_PRECISION_HIGH
+#if defined(GL_FRAGMENT_PRECISION_HIGH)// 原来的写法会被我们自己的解析流程处理，而我们的解析是不认内置宏的，导致被删掉，所以改成 if defined 了
 precision highp float;
 #else
 precision mediump float;

--- a/src/layaAir/laya/d3/shader/files/line.vs
+++ b/src/layaAir/laya/d3/shader/files/line.vs
@@ -1,3 +1,9 @@
+#if defined(GL_FRAGMENT_PRECISION_HIGH)// 原来的写法会被我们自己的解析流程处理，而我们的解析是不认内置宏的，导致被删掉，所以改成 if defined 了
+precision highp float;
+#else
+precision mediump float;
+#endif
+
 #include "Lighting.glsl";
 
 attribute vec4 a_Position;

--- a/src/layaAir/laya/d3/shader/files/postProcess/Bloom.fs
+++ b/src/layaAir/laya/d3/shader/files/postProcess/Bloom.fs
@@ -1,4 +1,4 @@
-#ifdef GL_FRAGMENT_PRECISION_HIGH
+#if defined(GL_FRAGMENT_PRECISION_HIGH)// 原来的写法会被我们自己的解析流程处理，而我们的解析是不认内置宏的，导致被删掉，所以改成 if defined 了
 	precision highp float;
 #else
 	precision mediump float;

--- a/src/layaAir/laya/d3/shader/files/postProcess/Bloom.vs
+++ b/src/layaAir/laya/d3/shader/files/postProcess/Bloom.vs
@@ -1,5 +1,9 @@
 #include "Lighting.glsl";
-
+#if defined(GL_FRAGMENT_PRECISION_HIGH)// 原来的写法会被我们自己的解析流程处理，而我们的解析是不认内置宏的，导致被删掉，所以改成 if defined 了
+	precision highp float;
+#else
+	precision mediump float;
+#endif
 attribute vec4 a_PositionTexcoord;
 varying vec2 v_Texcoord0;
 

--- a/src/layaAir/laya/d3/shader/files/postProcess/BloomDownsample13.fs
+++ b/src/layaAir/laya/d3/shader/files/postProcess/BloomDownsample13.fs
@@ -1,4 +1,4 @@
-#ifdef GL_FRAGMENT_PRECISION_HIGH
+#if defined(GL_FRAGMENT_PRECISION_HIGH)// 原来的写法会被我们自己的解析流程处理，而我们的解析是不认内置宏的，导致被删掉，所以改成 if defined 了
 	precision highp float;
 #else
 	precision mediump float;

--- a/src/layaAir/laya/d3/shader/files/postProcess/BloomDownsample4.fs
+++ b/src/layaAir/laya/d3/shader/files/postProcess/BloomDownsample4.fs
@@ -1,4 +1,4 @@
-#ifdef GL_FRAGMENT_PRECISION_HIGH
+#if defined(GL_FRAGMENT_PRECISION_HIGH)// 原来的写法会被我们自己的解析流程处理，而我们的解析是不认内置宏的，导致被删掉，所以改成 if defined 了
 	precision highp float;
 #else
 	precision mediump float;

--- a/src/layaAir/laya/d3/shader/files/postProcess/BloomPrefilter13.fs
+++ b/src/layaAir/laya/d3/shader/files/postProcess/BloomPrefilter13.fs
@@ -1,4 +1,4 @@
-#ifdef GL_FRAGMENT_PRECISION_HIGH
+#if defined(GL_FRAGMENT_PRECISION_HIGH)// 原来的写法会被我们自己的解析流程处理，而我们的解析是不认内置宏的，导致被删掉，所以改成 if defined 了
 	precision highp float;
 #else
 	precision mediump float;

--- a/src/layaAir/laya/d3/shader/files/postProcess/BloomPrefilter4.fs
+++ b/src/layaAir/laya/d3/shader/files/postProcess/BloomPrefilter4.fs
@@ -1,4 +1,4 @@
-#ifdef GL_FRAGMENT_PRECISION_HIGH
+#if defined(GL_FRAGMENT_PRECISION_HIGH)// 原来的写法会被我们自己的解析流程处理，而我们的解析是不认内置宏的，导致被删掉，所以改成 if defined 了
 	precision highp float;
 #else
 	precision mediump float;

--- a/src/layaAir/laya/d3/shader/files/postProcess/BloomUpsampleBox.fs
+++ b/src/layaAir/laya/d3/shader/files/postProcess/BloomUpsampleBox.fs
@@ -1,4 +1,4 @@
-#ifdef GL_FRAGMENT_PRECISION_HIGH
+#if defined(GL_FRAGMENT_PRECISION_HIGH)// 原来的写法会被我们自己的解析流程处理，而我们的解析是不认内置宏的，导致被删掉，所以改成 if defined 了
 	precision highp float;
 #else
 	precision mediump float;

--- a/src/layaAir/laya/d3/shader/files/postProcess/BloomUpsampleTent.fs
+++ b/src/layaAir/laya/d3/shader/files/postProcess/BloomUpsampleTent.fs
@@ -1,4 +1,4 @@
-#ifdef GL_FRAGMENT_PRECISION_HIGH
+#if defined(GL_FRAGMENT_PRECISION_HIGH)// 原来的写法会被我们自己的解析流程处理，而我们的解析是不认内置宏的，导致被删掉，所以改成 if defined 了
 	precision highp float;
 #else
 	precision mediump float;

--- a/src/layaAir/laya/d3/shader/files/postProcess/Composite.fs
+++ b/src/layaAir/laya/d3/shader/files/postProcess/Composite.fs
@@ -1,4 +1,4 @@
-#ifdef GL_FRAGMENT_PRECISION_HIGH
+#if defined(GL_FRAGMENT_PRECISION_HIGH)// 原来的写法会被我们自己的解析流程处理，而我们的解析是不认内置宏的，导致被删掉，所以改成 if defined 了
 	precision highp float;
 #else
 	precision mediump float;

--- a/src/layaAir/laya/particle/shader/Particle.ps.glsl
+++ b/src/layaAir/laya/particle/shader/Particle.ps.glsl
@@ -1,4 +1,4 @@
-#ifdef GL_FRAGMENT_PRECISION_HIGH
+#if defined(GL_FRAGMENT_PRECISION_HIGH)// 原来的写法会被我们自己的解析流程处理，而我们的解析是不认内置宏的，导致被删掉，所以改成 if defined 了
 precision highp float;
 #else
 precision mediump float;

--- a/src/layaAir/laya/renders/Render.ts
+++ b/src/layaAir/laya/renders/Render.ts
@@ -23,7 +23,7 @@ export class Render {
     /** @internal 主画布。canvas和webgl渲染都用这个画布*/
     static _mainCanvas: HTMLCanvas;
 
-    static supportWebGLPlusCulling: boolean = false;
+    // static supportWebGLPlusCulling: boolean = false;
     static supportWebGLPlusAnimation: boolean = false;
     static supportWebGLPlusRendering: boolean = false;
     /**是否是加速器 只读*/
@@ -132,13 +132,13 @@ export class Render {
 {
     Render.isConchApp = ((window as any).conch != null);
     if (Render.isConchApp) {
-        Render.supportWebGLPlusCulling = false;
-        Render.supportWebGLPlusAnimation = false;
+        //Render.supportWebGLPlusCulling = false;
+        //Render.supportWebGLPlusAnimation = false;
         Render.supportWebGLPlusRendering = false;
     }
     else if ((window as any).qq != null && (window as any).qq.webglPlus != null) {
-        Render.supportWebGLPlusCulling = false;
-        Render.supportWebGLPlusAnimation = false;
+        //Render.supportWebGLPlusCulling = false;
+        //Render.supportWebGLPlusAnimation = false;
         Render.supportWebGLPlusRendering = false;
     }
 }

--- a/src/layaAir/laya/webgl/shader/d2/files/texture.ps.glsl
+++ b/src/layaAir/laya/webgl/shader/d2/files/texture.ps.glsl
@@ -1,7 +1,7 @@
 /*
 	texture和fillrect使用的。
 */
-#ifdef GL_FRAGMENT_PRECISION_HIGH
+#if defined(GL_FRAGMENT_PRECISION_HIGH)// 原来的写法会被我们自己的解析流程处理，而我们的解析是不认内置宏的，导致被删掉，所以改成 if defined 了
 precision highp float;
 #else
 precision mediump float;

--- a/src/layaAir/laya/webgl/utils/ShaderNode.ts
+++ b/src/layaAir/laya/webgl/utils/ShaderNode.ts
@@ -50,7 +50,7 @@ export class ShaderNode {
             this.conditionType === ILaya.ShaderCompile.IFDEF_ELSE && (ifdef = !ifdef);
             if (!ifdef) return out;
         }
-
+        if(this.noCompile)
         this.text && out.push(this.text);
         this.childs.length > 0 && this.childs.forEach(function (o: ShaderNode, index: number, arr: ShaderNode[]): void {
             o._toscript(def, out, id);

--- a/src/samples/3d/LayaAir3D_Shader/customShader/outline.fs
+++ b/src/samples/3d/LayaAir3D_Shader/customShader/outline.fs
@@ -1,4 +1,4 @@
-#ifdef GL_FRAGMENT_PRECISION_HIGH
+#if defined(GL_FRAGMENT_PRECISION_HIGH)// 原来的写法会被我们自己的解析流程处理，而我们的解析是不认内置宏的，导致被删掉，所以改成 if defined 了
 precision highp float; 
 #else 
     precision mediump float; 

--- a/src/samples/3d/LayaAir3D_Shader/customShader/outline02.fs
+++ b/src/samples/3d/LayaAir3D_Shader/customShader/outline02.fs
@@ -1,4 +1,4 @@
-#ifdef GL_FRAGMENT_PRECISION_HIGH 
+#if defined(GL_FRAGMENT_PRECISION_HIGH)// 原来的写法会被我们自己的解析流程处理，而我们的解析是不认内置宏的，导致被删掉，所以改成 if defined 了
 precision highp float;
 #else
 precision mediump float;

--- a/src/samples/3d/LayaAir3D_Shader/customShader/simpleShader.fs
+++ b/src/samples/3d/LayaAir3D_Shader/customShader/simpleShader.fs
@@ -1,4 +1,4 @@
-#ifdef GL_FRAGMENT_PRECISION_HIGH
+#if defined(GL_FRAGMENT_PRECISION_HIGH)// 原来的写法会被我们自己的解析流程处理，而我们的解析是不认内置宏的，导致被删掉，所以改成 if defined 了
 precision highp float;
 #else
 precision mediump float;

--- a/src/samples/3d/LayaAir3D_Shader/customShader/terrainShader.fs
+++ b/src/samples/3d/LayaAir3D_Shader/customShader/terrainShader.fs
@@ -1,4 +1,4 @@
-#ifdef GL_FRAGMENT_PRECISION_HIGH
+#if defined(GL_FRAGMENT_PRECISION_HIGH)// 原来的写法会被我们自己的解析流程处理，而我们的解析是不认内置宏的，导致被删掉，所以改成 if defined 了
 precision highp float;
 #else
 precision mediump float;

--- a/src/samples/3d/LayaAir3D_Shader/customShader/terrainShader.vs
+++ b/src/samples/3d/LayaAir3D_Shader/customShader/terrainShader.vs
@@ -1,3 +1,8 @@
+#if defined(GL_FRAGMENT_PRECISION_HIGH)// 原来的写法会被我们自己的解析流程处理，而我们的解析是不认内置宏的，导致被删掉，所以改成 if defined 了
+precision highp float;
+#else
+precision mediump float;
+#endif
 #include "Lighting.glsl";
 attribute vec4 a_Position;
 attribute vec2 a_Texcoord0;


### PR DESCRIPTION
DefineDatas.ts 修复了宏定义的mask宏定义标签造成的shader编译bug
ShaderPass.ts 修复了shader字符串不根据宏定义做裁剪的bug
匹配编译剔除：shader中自定义的宏不可用ifdef 必须改成if defined
粒子删除没有用到的灯光函数，增加粒子shader编译速度
将所有的shader中都添加shader精度设置 避免数据精度不匹配问题