### PR TITLE
updatePhysicsByWorldRoot 手动更新物理世界(worldRoot)

### DIFF
--- a/src/layaAir/laya/physics/Physics.ts
+++ b/src/layaAir/laya/physics/Physics.ts
@@ -241,7 +241,8 @@ export class Physics extends EventDispatcher {
     }
 
     /**物理世界根容器，将根据此容器作为物理世界坐标世界，进行坐标变换，默认值为stage
-     * 设置特定容器后，就可整体位移物理对象，保持物理世界不变*/
+     * 设置特定容器后，就可整体位移物理对象，保持物理世界不变。
+     * 注意，仅会在 set worldRoot 时平移一次，其他情况请配合 updatePhysicsByWorldRoot 函数使用*/
     get worldRoot(): Sprite {
         return this._worldRoot || Laya.stage;
     }
@@ -251,7 +252,17 @@ export class Physics extends EventDispatcher {
         if (value) {
             //TODO：
             var p: Point = value.localToGlobal(Point.TEMP.setTo(0, 0));
-            this.world.ShiftOrigin({ x: p.x / Physics.PIXEL_RATIO, y: p.y / Physics.PIXEL_RATIO });
+            this.world.ShiftOrigin({ x: -p.x / Physics.PIXEL_RATIO, y: -p.y / Physics.PIXEL_RATIO });
+        }
+    }
+
+    /**
+     * 设定 worldRoot 后，手动触发物理世界更新
+     */
+    updatePhysicsByWorldRoot() {
+        if (!!this.worldRoot) {
+            var p: Point = this.worldRoot.localToGlobal(Point.TEMP.setTo(0, 0));
+            this.world.ShiftOrigin({ x: -p.x / Physics.PIXEL_RATIO, y: -p.y / Physics.PIXEL_RATIO });
         }
     }
 }

--- a/src/layaAir/laya/physics/RigidBody.ts
+++ b/src/layaAir/laya/physics/RigidBody.ts
@@ -200,6 +200,7 @@ export class RigidBody extends Component {
 
             if (ang == 0) {
                 var point: Point = sp.parent.globalToLocal(Point.TEMP.setTo(pos.x * IPhysics.Physics.PIXEL_RATIO + sp.pivotX, pos.y * IPhysics.Physics.PIXEL_RATIO + sp.pivotY), false, IPhysics.Physics.I.worldRoot);
+                sp.parent.fromParentPoint(point);
                 this.accessGetSetFunc(sp, "x", "set")(point.x);
                 this.accessGetSetFunc(sp, "y", "set")(point.y);
             } else {


### PR DESCRIPTION
updatePhysicsByWorldRoot 手动更新物理世界(worldRoot); 更新物理世界后，当 RigidBody.allowSleep=false时，还需调整point位置