### PR TITLE
add globalDataCMD

### DIFF
--- a/src/layaAir/laya/d3/core/render/command/BlitScreenQuadCMD.ts
+++ b/src/layaAir/laya/d3/core/render/command/BlitScreenQuadCMD.ts
@@ -76,22 +76,24 @@ export class BlitScreenQuadCMD extends Command {
 	 * @override
 	 */
 	run(): void {//TODO:相机的UV
-		//TODO  这里有点问题，不能这样控制
+		var source;
 		if(!this._source){
 			if(!this._commandBuffer._camera._internalRenderTexture)
 				throw "camera internalRenderTexture is null,please set camera enableBuiltInRenderTexture";
-			this._source = this._commandBuffer._camera._internalRenderTexture;
+			source = this._commandBuffer._camera._internalRenderTexture;
 		}
+		else
+			source = this._source;
+
 		var shader: Shader3D = this._shader || Command._screenShader;
 		var shaderData: ShaderData = this._shaderData || Command._screenShaderData;
 		var dest: RenderTexture = this._dest;
 
 		LayaGL.instance.viewport(0, 0, dest ? dest.width : RenderContext3D.clientWidth, dest ? dest.height : RenderContext3D.clientHeight);//TODO:是否在此
-
 		//TODO:优化
-		shaderData.setTexture(Command.SCREENTEXTURE_ID, this._source);
+		shaderData.setTexture(Command.SCREENTEXTURE_ID, source);
 		shaderData.setVector(Command.SCREENTEXTUREOFFSETSCALE_ID, this._offsetScale || BlitScreenQuadCMD._defaultOffsetScale);
-		this._sourceTexelSize.setValue(1.0 / this._source.width, 1.0 / this._source.height, this._source.width, this._source.height);
+		this._sourceTexelSize.setValue(1.0 / source.width, 1.0 / source.height, source.width, source.height);
 		shaderData.setVector(Command.MAINTEXTURE_TEXELSIZE_ID, this._sourceTexelSize);
 
 		(dest) && (dest._start());

--- a/src/layaAir/laya/d3/core/render/command/CommandBuffer.ts
+++ b/src/layaAir/laya/d3/core/render/command/CommandBuffer.ts
@@ -28,12 +28,18 @@ export class CommandBuffer {
 	_context:RenderContext3D;
 	/**@internal */
 	private _commands: Command[] = [];
-
+	/**@internal */
+	private _renderTexturePool:RenderTexture[] = [];
+	private _renderTexturelength:number = -1;
 	/**
 	 * 创建一个 <code>CommandBuffer</code> 实例。
 	 */
 	constructor() {
 
+	}
+
+	_getTempRenderTexture(resourceID:number):RenderTexture{
+		return this._renderTexturePool[resourceID];
 	}
 
 	/**
@@ -56,7 +62,7 @@ export class CommandBuffer {
 	}
 
 	/**
-	 * 设置全局Uniform图片数据
+	 * 设置全局纹理数据
 	 * @param nameID 
 	 * @param source 
 	 */
@@ -76,6 +82,16 @@ export class CommandBuffer {
 	}
 
 	/**
+	 * 设置全局Vector4数据
+	 * @param nameID 
+	 * @param source 
+	 */
+	setGlobalVector(nameID:number,source: Vector4){
+		var scene:Scene3D = this._camera.scene;
+		this._commands.push(SetShaderDataCMD.create(scene._shaderValues,nameID,source,ShaderDataType.Vector,this));
+	}
+
+	/**
 	 * 设置shader Vector3数据
 	 * @param shaderData 
 	 * @param nameID 
@@ -83,6 +99,16 @@ export class CommandBuffer {
 	 */
 	setShaderDataVector3(shaderData:ShaderData,nameID:number,value:Vector3):void{
 		this._commands.push(SetShaderDataCMD.create(shaderData,nameID,value,ShaderDataType.Vector3,this));
+	}
+
+	/**
+	 * 设置全局Vector3数据
+	 * @param nameID 
+	 * @param source 
+	 */
+	setGlobalVector3(nameID:number,source:Vector3){
+		var scene:Scene3D = this._camera.scene;
+		this._commands.push(SetShaderDataCMD.create(scene._shaderValues,nameID,source,ShaderDataType.Vector3,this));
 	}
 
 	/**
@@ -96,6 +122,16 @@ export class CommandBuffer {
 	}
 
 	/**
+	 * 设置全局Vector2数据
+	 * @param nameID Uniform标记
+	 * @param source 
+	 */
+	setGlobalVector2(nameID:number,source:Vector2){
+		var scene:Scene3D = this._camera.scene;
+		this._commands.push(SetShaderDataCMD.create(scene._shaderValues,nameID,source,ShaderDataType.Vector2,this));
+	}
+
+	/**
 	 * 设置shader Number属性
 	 * @param shaderData 
 	 * @param nameID 
@@ -103,6 +139,16 @@ export class CommandBuffer {
 	 */
 	setShaderDataNumber(shaderData:ShaderData,nameID:number,value:number):void{
 		this._commands.push(SetShaderDataCMD.create(shaderData,nameID,value,ShaderDataType.Number,this));
+	}
+
+	/**
+	 * 设置全局number属性
+	 * @param nameID 
+	 * @param source 
+	 */
+	setGlobalNumber(nameID:number,source:number){
+		var scene:Scene3D = this._camera.scene;
+		this._commands.push(SetShaderDataCMD.create(scene._shaderValues,nameID,source,ShaderDataType.Number,this));
 	}
 
 	/**
@@ -116,6 +162,16 @@ export class CommandBuffer {
 	}
 
 	/**
+	 * 设置全局int属性
+	 * @param nameID 
+	 * @param source 
+	 */
+	setGlobalInt(nameID:number,source:number){
+		var scene:Scene3D = this._camera.scene;
+		this._commands.push(SetShaderDataCMD.create(scene._shaderValues,nameID,source,ShaderDataType.Int,this));
+	}
+
+	/**
 	 * 设置shader Matrix属性
 	 * @param shaderData 
 	 * @param nameID 
@@ -123,6 +179,11 @@ export class CommandBuffer {
 	 */
 	setShaderDataMatrix(shaderData:ShaderData,nameID:number,value:Matrix4x4):void{
 		this._commands.push(SetShaderDataCMD.create(shaderData,nameID,value,ShaderDataType.Matrix4x4,this));
+	}
+
+	setGlobalMatrix(nameID:number,source:number){
+		var scene:Scene3D = this._camera.scene;
+		this._commands.push(SetShaderDataCMD.create(scene._shaderValues,nameID,source,ShaderDataType.Matrix4x4,this));
 	}
 
 	/**
@@ -136,6 +197,24 @@ export class CommandBuffer {
 	 */
 	blitScreenQuad(source: BaseTexture, dest: RenderTexture, offsetScale: Vector4 = null, shader: Shader3D = null, shaderData: ShaderData = null, subShader: number = 0): void {
 		this._commands.push(BlitScreenQuadCMD.create(source, dest, offsetScale, shader, shaderData, subShader, BlitScreenQuadCMD._SCREENTYPE_QUAD,this));
+	}
+
+	/**
+	 * 添加一条通过全屏四边形将源纹理渲染到目标渲染纹理指令。
+	 * @param source 
+	 * @param dest 
+	 * @param offsetScale 
+	 * @param material 
+	 * @param subShader 
+	 */
+	blitScreenQuadByMaterial(source:BaseTexture,dest:RenderTexture,offsetScale:Vector4 = null,material:Material = null,subShader: number = 0):void{
+		var shader:Shader3D;
+		var shaderData:ShaderData;
+		if(material){
+			shader = material._shader;
+			shaderData = material.shaderData
+		}
+		this._commands.push(BlitScreenQuadCMD.create(source,dest,offsetScale,shader,shaderData,subShader,BlitScreenQuadCMD._SCREENTYPE_QUAD,this));
 	}
 
 	/**
@@ -159,11 +238,15 @@ export class CommandBuffer {
 		this._commands.push(SetRenderTargetCMD.create(renderTexture));
 	}
 
+	TODO
+	getTempRenderTarget(){
+
+	}
+
 	//TODO
-	// getTempRenderTarget(){
+	// clearRenderTexture():void{
 
 	// }
-
 	
 	/**
 	 * @param mesh 

--- a/src/layaAir/laya/d3/core/render/command/CommandBuffer.ts
+++ b/src/layaAir/laya/d3/core/render/command/CommandBuffer.ts
@@ -28,18 +28,12 @@ export class CommandBuffer {
 	_context:RenderContext3D;
 	/**@internal */
 	private _commands: Command[] = [];
-	/**@internal */
-	private _renderTexturePool:RenderTexture[] = [];
-	private _renderTexturelength:number = -1;
+
 	/**
 	 * 创建一个 <code>CommandBuffer</code> 实例。
 	 */
 	constructor() {
 
-	}
-
-	_getTempRenderTexture(resourceID:number):RenderTexture{
-		return this._renderTexturePool[resourceID];
 	}
 
 	/**
@@ -236,11 +230,6 @@ export class CommandBuffer {
 	 */
 	setRenderTarget(renderTexture: RenderTexture): void {
 		this._commands.push(SetRenderTargetCMD.create(renderTexture));
-	}
-
-	TODO
-	getTempRenderTarget(){
-
 	}
 
 	//TODO


### PR DESCRIPTION

1、CommandBuffer_BlurryGlass示例 修复场景窗口变化后，效果不对的bug
2、CommandBuffer.ts增加setGlobalData的各个函数
3、增加Blit命令的Material接口blitScreenQuadByMaterial
4、删除多余代码

1、CommandBuffer_ The blurryglass example fixes the bug that the effect is not correct after the scene window changes

2、 CommandBuffer.ts Add setglobaldata functions

3. Add the material interface of BLIT command blitscreenqudbymaterial

4. Delete redundant code
