### PR TITLE
修复物理形状包围盒的检测第二次输出信息错误的bug

### DIFF
--- a/src/layaAir/laya/d3/component/Animator.ts
+++ b/src/layaAir/laya/d3/component/Animator.ts
@@ -322,14 +322,16 @@ export class Animator extends Component {
 					playStateInfo._playEventIndex--;
 				playStateInfo._lastIsFront = frontPlay;
 			}
-
+			var preEventIndex:number = playStateInfo._playEventIndex;
 			if (frontPlay) {
-				playStateInfo._playEventIndex = this._eventScript(scripts, events, playStateInfo._playEventIndex, loopCount > 0 ? clipDuration : time, true);
+				var newEventIndex = this._eventScript(scripts, events, playStateInfo._playEventIndex, loopCount > 0 ? clipDuration : time, true);
+				(preEventIndex === playStateInfo._playEventIndex) &&(playStateInfo._playEventIndex = newEventIndex);//这里打个补丁，在event中调用Play 需要重置eventindex，不能直接赋值
 				for (var i: number = 0, n: number = loopCount - 1; i < n; i++)
 					this._eventScript(scripts, events, 0, clipDuration, true);
 				(loopCount > 0 && time > 0) && (playStateInfo._playEventIndex = this._eventScript(scripts, events, 0, time, true));//if need cross loop,'time' must large than 0
 			} else {
-				playStateInfo._playEventIndex = this._eventScript(scripts, events, playStateInfo._playEventIndex, loopCount > 0 ? 0 : time, false);
+				var newEventIndex  = this._eventScript(scripts, events, playStateInfo._playEventIndex, loopCount > 0 ? 0 : time, false);
+				(preEventIndex === playStateInfo._playEventIndex) &&(playStateInfo._playEventIndex = newEventIndex);//这里打个补丁，在event中调用Play 需要重置eventindex，不能直接赋值
 				var eventIndex: number = events.length - 1;
 				for (i = 0, n = loopCount - 1; i < n; i++)
 					this._eventScript(scripts, events, eventIndex, 0, false);
@@ -959,7 +961,6 @@ export class Animator extends Component {
 
 		if (needRender) {
 			if (this._avatar) {
-				Render.supportWebGLPlusAnimation && this._updateAnimationNodeWorldMatix(this._animationNodeLocalPositions, this._animationNodeLocalRotations, this._animationNodeLocalScales, this._animationNodeWorldMatrixs, this._animationNodeParentIndices);//[NATIVE]
 				this._updateAvatarNodesToSprite();
 			}
 		}

--- a/src/layaAir/laya/d3/core/particleShuriKen/ShurikenParticleRenderer.ts
+++ b/src/layaAir/laya/d3/core/particleShuriKen/ShurikenParticleRenderer.ts
@@ -15,6 +15,7 @@ import { Transform3D } from "../Transform3D";
 import { ShuriKenParticle3D } from "./ShuriKenParticle3D";
 import { ShurikenParticleSystem } from "./ShurikenParticleSystem";
 import { ShuriKenParticle3DShaderDeclaration } from "./ShuriKenParticle3DShaderDeclaration";
+import { Vector2 } from "../../math/Vector2";
 
 
 /**
@@ -153,6 +154,16 @@ export class ShurikenParticleRenderer extends BaseRender {
 			particleSystem._generateBounds();
 			bounds = particleSystem._bounds;
 			bounds._tranform(this._owner.transform.worldMatrix, this._bounds);
+			// 在世界坐标下考虑重力影响
+			if (particleSystem.gravityModifier != 0) {
+				var max: Vector3 = this._bounds.getMax();
+				var min: Vector3 = this._bounds.getMin();
+				var gravityOffset: Vector2 = particleSystem._gravityOffset;
+				max.y -= gravityOffset.x;
+				min.y -= gravityOffset.y;
+				this._bounds.setMax(max);
+				this._bounds.setMin(min);
+			}                               
 		}
 		else {
 			var min: Vector3 = this._bounds.getMin();
@@ -161,18 +172,6 @@ export class ShurikenParticleRenderer extends BaseRender {
 			var max: Vector3 = this._bounds.getMax();
 			max.setValue(Number.MAX_VALUE, Number.MAX_VALUE, Number.MAX_VALUE);
 			this._bounds.setMax(max);
-		}
-
-		if (Render.supportWebGLPlusCulling) {//[NATIVE]
-			var min: Vector3 = this._bounds.getMin();
-			var max: Vector3 = this._bounds.getMax();
-			var buffer: Float32Array = FrustumCulling._cullingBuffer;
-			buffer[this._cullingBufferIndex + 1] = min.x;
-			buffer[this._cullingBufferIndex + 2] = min.y;
-			buffer[this._cullingBufferIndex + 3] = min.z;
-			buffer[this._cullingBufferIndex + 4] = max.x;
-			buffer[this._cullingBufferIndex + 5] = max.y;
-			buffer[this._cullingBufferIndex + 6] = max.z;
 		}
 	}
 

--- a/src/layaAir/laya/d3/graphics/IndexBuffer3D.ts
+++ b/src/layaAir/laya/d3/graphics/IndexBuffer3D.ts
@@ -205,6 +205,8 @@ export class IndexBuffer3D extends Buffer {
 	destroy(): void {
 		super.destroy();
 		this._buffer = null;
+		this._byteLength = 0;
+		this._indexCount = 0;
 	}
 
 }

--- a/src/layaAir/laya/d3/graphics/VertexBuffer3D.ts
+++ b/src/layaAir/laya/d3/graphics/VertexBuffer3D.ts
@@ -148,6 +148,7 @@ export class VertexBuffer3D extends Buffer {
 		this._buffer = null;
 		this._float32Reader = null;
 		this._vertexDeclaration = null;
+		this._byteLength = 0;
 	}
 }
 

--- a/src/layaAir/laya/d3/physics/PhysicsSimulation.ts
+++ b/src/layaAir/laya/d3/physics/PhysicsSimulation.ts
@@ -586,14 +586,20 @@ export class PhysicsSimulation {
 		}
 
 		var collisionObjects: number = bt.AllConvexResultCallback_get_m_collisionObjects(convexResultCall);
+		var btPoints: number = bt.AllConvexResultCallback_get_m_hitPointWorld(convexResultCall);
+		var btNormals: number = bt.AllConvexResultCallback_get_m_hitNormalWorld(convexResultCall);
+		var btFractions: number = bt.AllConvexResultCallback_get_m_hitFractions(convexResultCall);
+
+		bt.tVector3Array_clear(btPoints);
+		bt.tVector3Array_clear(btNormals);
+		bt.tScalarArray_clear(btFractions);
 		bt.tBtCollisionObjectArray_clear(collisionObjects);//清空检测队列
 		bt.btCollisionWorld_convexSweepTest(this._btCollisionWorld, sweepShape, convexTransform, convexTransTo, convexResultCall, allowedCcdPenetration);
 		var count: number = bt.tBtCollisionObjectArray_size(collisionObjects);
+		
 		if (count > 0) {
 			this._collisionsUtils.recoverAllHitResultsPool();
-			var btPoints: number = bt.AllConvexResultCallback_get_m_hitPointWorld(convexResultCall);
-			var btNormals: number = bt.AllConvexResultCallback_get_m_hitNormalWorld(convexResultCall);
-			var btFractions: number = bt.AllConvexResultCallback_get_m_hitFractions(convexResultCall);
+		
 			for (var i: number = 0; i < count; i++) {
 				var hitResult: HitResult = this._collisionsUtils.getHitResult();
 				out.push(hitResult);

--- a/src/layaAir/laya/html/dom/HTMLDivElement.ts
+++ b/src/layaAir/laya/html/dom/HTMLDivElement.ts
@@ -147,6 +147,22 @@ export class HTMLDivElement extends Sprite {
         this._setGraphicDirty();
     }
 
+    set width(value: number) {
+        this._element.width = value;
+    }
+
+    get width():number {
+        return this._element.width;
+    }
+
+    set height(value: number) {
+        this._element.height = value;
+    }
+
+    get height():number {
+        return this._element.height;
+    }
+
     /**
      * 获取內容宽度
      */

--- a/src/layaAir/laya/net/Loader.ts
+++ b/src/layaAir/laya/net/Loader.ts
@@ -462,16 +462,40 @@ export class Loader extends EventDispatcher {
 					data.pics = [];
 				}
 				this.event(Event.PROGRESS, 0.3 + 1 / toloadPics.length * 0.6);
-				return this._loadResourceFilter(Loader.IMAGE, toloadPics.pop() as string);
+				return this._loadResourceFilter(Loader.IMAGE, URL.formatURL(toloadPics.pop() as string));
 			} else {
 				if(!(data instanceof Texture2D))
 				{
-					let tex: Texture2D = new Texture2D(data.width, data.height, 1, false, false);
-					tex.wrapModeU = BaseTexture.WARPMODE_CLAMP;
-					tex.wrapModeV = BaseTexture.WARPMODE_CLAMP;
-					tex.loadImageSource(data, true);
-					tex._setCreateURL(data.src);
-					data = tex;
+					if (data instanceof ArrayBuffer) {
+						let url = this._http.url;
+						var ext: string = Utils.getFileExtension(url);
+						let format: TextureFormat;
+						switch (ext) {
+							case "ktx":
+								format = TextureFormat.ETC1RGB;
+								break;
+							case "pvr":
+								format = TextureFormat.PVRTCRGBA_4BPPV;
+								break;
+							default: {
+								console.error('unknown format', ext);
+								return;
+							}
+						}
+						let tex = new Texture2D(0, 0, format, false, false);
+						tex.wrapModeU = WarpMode.Clamp;
+						tex.wrapModeV = WarpMode.Clamp;
+						tex.setCompressData(data);
+						tex._setCreateURL(url);
+						data = tex;
+					} else {
+						let tex: Texture2D = new Texture2D(data.width, data.height, 1, false, false);
+						tex.wrapModeU = BaseTexture.WARPMODE_CLAMP;
+						tex.wrapModeV = BaseTexture.WARPMODE_CLAMP;
+						tex.loadImageSource(data, true);
+						tex._setCreateURL(data.src);
+						data = tex;
+					}
 				}
 				this._data.pics.push(data);
 				if (this._data.toLoads.length > 0) {

--- a/src/layaAir/laya/net/TTFLoader.ts
+++ b/src/layaAir/laya/net/TTFLoader.ts
@@ -22,7 +22,7 @@ export class TTFLoader {
     //TODO:coverage
     load(fontPath: string): void {
         this._url = fontPath;
-        var tArr: any[] = fontPath.split(".ttf")[0].split("/");
+        var tArr: any[] = fontPath.toLowerCase().split(".ttf")[0].split("/");
         this.fontName = tArr[tArr.length - 1];
         if (ILaya.Render.isConchApp) {
             this._loadConch();

--- a/src/layaAir/laya/webgl/text/TextRender.ts
+++ b/src/layaAir/laya/webgl/text/TextRender.ts
@@ -86,7 +86,7 @@ export class TextRender {
 			bugIOS = miniadp.systemInfo.system.toLowerCase() === 'ios 10.1.1';
 			//12.3
         }
-        if ((ILaya.Browser.onMiniGame||ILaya.Browser.onTTMiniGame||ILaya.Browser.onBLMiniGame||ILaya.Browser.onAlipayMiniGame) /*&& !Browser.onAndroid*/ && !bugIOS) TextRender.isWan1Wan = true; //android 微信下 字边缘发黑，所以不用getImageData了
+        if ((ILaya.Browser.onMiniGame||ILaya.Browser.onTTMiniGame||ILaya.Browser.onBLMiniGame||ILaya.Browser.onAlipayMiniGame || ILaya.Browser.onTBMiniGame) /*&& !Browser.onAndroid*/ && !bugIOS) TextRender.isWan1Wan = true; //android 微信下 字边缘发黑，所以不用getImageData了
         //TextRender.isWan1Wan = true;
         this.charRender = ILaya.Render.isConchApp ? (new CharRender_Native()) : (new CharRender_Canvas(2048, 2048, TextRender.scaleFontWithCtx, !TextRender.isWan1Wan, false));
         TextRender.textRenderInst = this;
@@ -132,7 +132,8 @@ export class TextRender {
      */
     getNextChar(str: string): string |null{
         var len: number = str.length;
-        var start: number = this._curStrPos;
+		var start: number = this._curStrPos;
+		if(!str.substring) return null;	// 保护一下，避免下面 substring 报错
         if (start >= len)
             return null;
 
@@ -189,7 +190,7 @@ export class TextRender {
     }
 
     _fast_filltext(ctx: Context, data: string | WordText|null, htmlchars: HTMLChar[]|null, x: number, y: number, font: FontInfo, color: string, strokeColor: string, lineWidth: number, textAlign: number, underLine: number = 0): void {
-        if (data && data.length < 1) return;
+        if (data && !(data.length >= 1)) return;	// length有可能是 undefined
         if (htmlchars && htmlchars.length < 1) return;
         if (lineWidth < 0) lineWidth = 0;
         this.setFont(font);
@@ -214,7 +215,7 @@ export class TextRender {
         //拷贝到texture上,得到一个gltexture和uv
         var wt = (<WordText>data);
         var isWT = !htmlchars && (data instanceof WordText);
-        var str = (<string>data);
+        var str = data.toString();//(<string>data);guo 某种情况下，str还是WordText（没找到为啥），这里保护一下
         var isHtmlChar= !!htmlchars;
         /**
          * sameTexData 
@@ -376,9 +377,8 @@ export class TextRender {
      * @return
      */
     hasFreedText(txts: any[]): boolean {
-        var sz: number = txts.length;
-        for (var i: number = 0; i < sz; i++) {
-            var pri: any = txts[i];
+        for(let i in txts){
+            var pri = txts[i];
             if (!pri) continue;
             var tex: TextTexture = ((<TextTexture>pri.tex));
             if (tex.__destroyed || tex.genID != pri.texgen) {


### PR DESCRIPTION
1、修复物理形状包围盒的检测第二次输出信息错误的bug

2、修复粒子包围盒重力影响的bug

3、修复粒子CPUGPU统计不准确的bug

4、修复动画事件调用播放动画函数导致事件错乱的bug

5、HTMLDivElement 宽高设置不正确

6、2D图集加载pvr出错的bug（loader）

7、TTFLoader  兼容ttf后缀（TTFLoader）