### PR TITLE
本地调试时音频地址赋值后会被动追加file:///头，导致替换背景音乐后cache删除失败。两个Sound会共用到一个audio，导致Au…

### DIFF
--- a/src/layaAir/laya/media/h5audio/AudioSound.ts
+++ b/src/layaAir/laya/media/h5audio/AudioSound.ts
@@ -79,8 +79,9 @@ export class AudioSound extends EventDispatcher {
         if (url == ILaya.SoundManager._bgMusic) {
             AudioSound._initMusicAudio();
             ad = AudioSound._musicAudio;
-            if (ad.src != url) {
-                AudioSound._audioCache[ad.src] = null;
+            let preUrl=ad.src && ad.src.replace("file:///","");
+            if (preUrl != url) {
+                AudioSound._audioCache[preUrl] = null;
                 ad = null;
             }
         } else {


### PR DESCRIPTION
…dioSound卸载掉当前播放中的音乐。