### PR TITLE
整理构建命令

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,12 +104,6 @@ The following command execution directories are the root directory of the LayaAi
 
 ### Environment Preparation
 
-##### Install Gulp globally
-
-```
-npm install -g gulp
-```
-
 ##### Install dependencies
 
 ```
@@ -117,8 +111,6 @@ npm install
 ```
 
 ### Build the project
-
-#### windows:
 
 - ##### Publishing Engine
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "layaAir.config.js",
   "scripts": {
-    "build": "cd src/publishTool&&cmd /k publish.bat",
+    "build": "node src/publishTool/publish.js",
     "compile": "gulp LayaAirBuild",
     "buildDoc": "cd src/generateDoc&&cmd /k run.bat"
   },

--- a/src/publishTool/publish.bat
+++ b/src/publishTool/publish.bat
@@ -1,14 +1,6 @@
 @echo off
-if exist ..\..\build (
-   rmdir /s/q ..\..\build
-) 
 
-if exist ..\..\bin\tsc\layaAir (
-   rmdir /s/q ..\..\bin\tsc\layaAir
-) 
-node index.js
-
-cd ..\
-gulp build
+cd ..\..
+npm run build
 
 @pause

--- a/src/publishTool/publish.js
+++ b/src/publishTool/publish.js
@@ -1,0 +1,14 @@
+const fs = require('fs');
+const path = require('path');
+const cp = require('child_process');
+
+const ROOT_DIR = process.cwd();
+
+if (fs.existsSync('build')) fs.rmdirSync('build', { recursive: true });
+if (fs.existsSync('bin/tsc/layaAir')) fs.rmdirSync('bin/tsc/layaAir', { recursive: true });
+
+process.chdir('src/publishTool');
+cp.execSync('node index.js', { stdio: 'inherit' });
+
+process.chdir(ROOT_DIR);
+cp.execSync(`${path.join('node_modules', '.bin', 'gulp')} --cwd=src build`, { stdio: 'inherit' });


### PR DESCRIPTION
- 使用项目的 gulp 执行构建，不需要全局安装 gulp
- build 命令通过 publish.js 执行构建，支持 macOS 和 linux 平台执行构建，兼容旧的 publish.bat 双击构建方式

Fix #632