### PR TITLE
默认放开webGL对纹理数据的跨域限制

### DIFF
--- a/src/layaAir/laya/device/media/HtmlVideo.ts
+++ b/src/layaAir/laya/device/media/HtmlVideo.ts
@@ -35,6 +35,9 @@ export class HtmlVideo extends Bitmap {
         style.top = '0px';
         style.left = '0px';
 
+        // 默认放开webGL对纹理数据的跨域限制
+        this.video.setAttribute('crossorigin', 'anonymous');
+
         this.video.addEventListener("loadedmetadata", ()=> {
             this._w = this.video.videoWidth;
             this._h = this.video.videoHeight;


### PR DESCRIPTION
是否可以默认加上webGL对纹理数据的跨域限制?