### PR TITLE
Image组件新增功能：支持上下对称，左右对称，上下左右对称的方式填充纹理

### DIFF
--- a/src/layaAir/laya/display/Graphics.ts
+++ b/src/layaAir/laya/display/Graphics.ts
@@ -34,7 +34,7 @@ import { Texture } from "../resource/Texture"
 import { Utils } from "../utils/Utils"
 import { VectorGraphManager } from "../utils/VectorGraphManager"
 import { ILaya } from "../../ILaya";
-import { HTMLChar } from "../utils/HTMLChar";
+import { DrawSymmetricTexture } from "./cmd/DrawSymmetricTexture";
 
 /**
  * <code>Graphics</code> 类用于创建绘图显示对象。Graphics可以同时绘制多个位图或者矢量图，还可以结合save，restore，transform，scale，rotate，translate，alpha等指令对绘图效果进行变化。
@@ -739,5 +739,19 @@ export class Graphics {
      */
     draw9Grid(texture: Texture, x: number = 0, y: number = 0, width: number = 0, height: number = 0, sizeGrid: any[] = null): void {
         this._saveToCmd(null, Draw9GridTexture.create(texture, x, y, width, height, sizeGrid));
+    }
+
+    /**
+     * @private
+     * 绘制对称填充纹理的图片
+     * @param texture
+     * @param x
+     * @param y
+     * @param width
+     * @param height
+     * @param type
+     */
+    drawSymmetric(texture:Texture, x=0,y=0,width=0,height=0,type=0) {
+        this._saveToCmd(null, DrawSymmetricTexture.create(texture, x, y, width, height, type));
     }
 }

--- a/src/layaAir/laya/display/GraphicsBounds.ts
+++ b/src/layaAir/laya/display/GraphicsBounds.ts
@@ -30,6 +30,7 @@ import { DrawTrianglesCmd } from "./cmd/DrawTrianglesCmd";
 import { Draw9GridTexture } from "./cmd/Draw9GridTexture";
 import { ClassUtils } from "../utils/ClassUtils";
 import { SaveCmd } from "./cmd/SaveCmd"
+import {DrawSymmetricTexture} from "./cmd/DrawSymmetricTexture";
 
 /**
  * @private
@@ -150,7 +151,7 @@ export class GraphicsBounds {
 
                     this._switchMatrix(tMatrix, tempMatrix);
                     break;
-                case RotateCmd.ID://case context._rotate: 
+                case RotateCmd.ID://case context._rotate:
                     tempMatrix.identity();
                     tempMatrix.translate(-cmd.pivotX, -cmd.pivotY);
                     tempMatrix.rotate(cmd.angle);
@@ -172,11 +173,11 @@ export class GraphicsBounds {
 
                     this._switchMatrix(tMatrix, tempMatrix);
                     break;
-                case DrawImageCmd.ID://case context._drawTexture: 
+                case DrawImageCmd.ID://case context._drawTexture:
                 case FillTextureCmd.ID://case context._fillTexture
                     GraphicsBounds._addPointArrToRst(rst, Rectangle._getBoundPointS(cmd.x, cmd.y, cmd.width, cmd.height), tMatrix);
                     break;
-                case DrawTextureCmd.ID://case context._drawTextureTransform: 
+                case DrawTextureCmd.ID://case context._drawTextureTransform:
                     tMatrix.copyTo(tempMatrix);
                     if (cmd.matrix)
                         tempMatrix.concat(cmd.matrix);
@@ -267,7 +268,7 @@ export class GraphicsBounds {
 
                     GraphicsBounds._addPointArrToRst(rst, GraphicsBounds._tempPoints, tMatrix);
                     break;
-                case DrawCurvesCmd.ID://context._drawCurves:					
+                case DrawCurvesCmd.ID://context._drawCurves:
                     GraphicsBounds._addPointArrToRst(rst, Bezier.I.getBezierPoints(cmd.points), tMatrix, cmd.x, cmd.y);
                     break;
                 case DrawLinesCmd.ID://drawpoly
@@ -284,6 +285,10 @@ export class GraphicsBounds {
                     GraphicsBounds._addPointArrToRst(rst, this._getTriAngBBXPoints((cmd as DrawTrianglesCmd).vertices), tMatrix);
                     break;
                 case Draw9GridTexture.ID:
+                    GraphicsBounds._addPointArrToRst(rst, this._getDraw9GridBBXPoints(cmd as Draw9GridTexture), tMatrix);
+                    break;
+                case DrawSymmetricTexture.ID:
+                    //这两个的绘制原理差不多，因此获取包围盒的方式也用一样的
                     GraphicsBounds._addPointArrToRst(rst, this._getDraw9GridBBXPoints(cmd as Draw9GridTexture), tMatrix);
                     break;
             }
@@ -337,7 +342,7 @@ export class GraphicsBounds {
             rst.push(x - radius, y + radius);
             return rst;
         }
-        // 
+        //
         rst.push(x, y);	// 中心
 
         var delta: number = d1 % 360;
@@ -366,13 +371,13 @@ export class GraphicsBounds {
         return rst;
         /*
         var segnum:int = 32;
-        var step:Number = delta / segnum;		
+        var step:Number = delta / segnum;
         var i:Number;
         var angle:Number = startAngle;
         for (i = 0; i <= segnum; i++) {
             rst.push(x + radius * Math.cos(angle), y + radius * Math.sin(angle));
             angle += step;
-        }		
+        }
         */
     }
 

--- a/src/layaAir/laya/display/cmd/DrawSymmetricTexture.ts
+++ b/src/layaAir/laya/display/cmd/DrawSymmetricTexture.ts
@@ -1,0 +1,72 @@
+/** created by WangCheng on 2021/9/12 17:56 */
+
+import {Texture} from "../../resource/Texture";
+import {Pool} from "../../utils/Pool";
+import {Context} from "../../resource/Context";
+
+/**
+ * 绘制对称填充纹理的图片
+ * @internal
+ */
+export class DrawSymmetricTexture {
+
+    static ID: string = "DrawSymmetricTexture";
+
+    /**
+     * 纹理。
+     */
+    texture: Texture;
+    /**
+     * （可选）X轴偏移量。
+     */
+    x: number;
+    /**
+     * （可选）Y轴偏移量。
+     */
+    y: number;
+    /**
+     * （可选）宽度。
+     */
+    width: number;
+    /**
+     * （可选）高度。
+     */
+    height: number;
+    /**纹理填充类型, 默认为 0 */
+    type: number;
+
+
+
+    /**@private */
+    static create(texture: Texture, x: number, y: number, width: number, height: number, type:number): DrawSymmetricTexture {
+        var cmd: DrawSymmetricTexture = Pool.getItemByClass("DrawSymmetricTexture", DrawSymmetricTexture);
+        cmd.texture = texture;
+        texture._addReference();
+        cmd.x = x;
+        cmd.y = y;
+        cmd.width = width;
+        cmd.height = height;
+        cmd.type = type;
+
+        return cmd;
+    }
+
+    /**
+     * 回收到对象池
+     */
+    recover(): void {
+        this.texture._removeReference();
+        Pool.recover("DrawSymmetricTexture", this);
+    }
+
+    /**@private */
+    run(context: Context, gx: number, gy: number): void {
+        context.drawSymmetricTexture(this.texture, this.x, this.y, this.width, this.height, this.type, gx, gy);
+    }
+
+    /**@private */
+    get cmdID(): string {
+        return DrawSymmetricTexture.ID;
+    }
+
+}

--- a/src/layaAir/laya/resource/Context.ts
+++ b/src/layaAir/laya/resource/Context.ts
@@ -289,7 +289,7 @@ export class Context {
 		this._fillAndStroke(fillColor, lineColor, lineWidth);
 	}
 
-	//矢量方法	
+	//矢量方法
 	/**@internal */
 	_drawPie(x: number, y: number, radius: number, startAngle: number, endAngle: number, fillColor: any, lineColor: any, lineWidth: number, vid: number): void {
 		//移动中心点
@@ -635,7 +635,7 @@ export class Context {
 	 * 当前canvas请求保存渲染结果。
 	 * 实现：
 	 * 如果value==true，就要给_target赋值
-	 * @param value {Boolean} 
+	 * @param value {Boolean}
 	 */
 	set asBitmap(value: boolean) {
 		if (value) {
@@ -830,7 +830,7 @@ export class Context {
 		var submit: Submit = this._curSubmit;
 		var sameKey: boolean = submit && (submit._key.submitType === SubmitBase.KEY_DRAWTEXTURE && submit._key.blendShader === this._nBlendType);
 		if (this._mesh.vertNum + 4 > Context._MAXVERTNUM) {
-			this._mesh = MeshQuadTexture.getAMesh(this.isMain);//创建新的mesh  TODO 如果_mesh不是常见格式，这里就不能这么做了。以后把_mesh单独表示成常用模式 
+			this._mesh = MeshQuadTexture.getAMesh(this.isMain);//创建新的mesh  TODO 如果_mesh不是常见格式，这里就不能这么做了。以后把_mesh单独表示成常用模式
 			this.meshlist.push(this._mesh);
 			sameKey = false;
 		}
@@ -1006,12 +1006,12 @@ export class Context {
 			return;
 		}
 		_clipRect = pre;
-		
+
 		Stat.drawCall++;//= pos.length / 2;
-		
+
 		if (pos.length < 4)
 			return;
-		
+
 		var finalVB:VertexBuffer2D = _curSubmit._vb || _vb;
 		var sx:Number = _curMat.a, sy:Number = _curMat.d;
 		var vpos:int = finalVB._byteLength >> 2;// + Context._RECTVBSIZE;
@@ -1103,8 +1103,8 @@ export class Context {
 		/*
 		var cd:Array = submit.shaderValue.clipDir;
 		var cp:Array = submit.shaderValue.clipRect;
-		
-		if (clipInfo[0] != cp[0] || clipInfo[1] != cp[1] || clipInfo[2] != cd[0] || clipInfo[3] != cd[1] || clipInfo[4] != cd[2] || clipInfo[5] != cd[3] ) 
+
+		if (clipInfo[0] != cp[0] || clipInfo[1] != cp[1] || clipInfo[2] != cd[0] || clipInfo[3] != cd[1] || clipInfo[4] != cd[2] || clipInfo[5] != cd[3] )
 			return false;
 		return true;
 		*/
@@ -1120,7 +1120,7 @@ export class Context {
 		//var sameKey:Boolean = tex.bitmap.id >= 0 && preKey.submitType === SubmitBase.KEY_DRAWTEXTURE && preKey.other === tex.bitmap.id ;
 
 		if (this._mesh.vertNum + minVertNum > Context._MAXVERTNUM) {
-			this._mesh = MeshQuadTexture.getAMesh(this.isMain);//创建新的mesh  TODO 如果_mesh不是常见格式，这里就不能这么做了。以后把_mesh单独表示成常用模式 
+			this._mesh = MeshQuadTexture.getAMesh(this.isMain);//创建新的mesh  TODO 如果_mesh不是常见格式，这里就不能这么做了。以后把_mesh单独表示成常用模式
 			this.meshlist.push(this._mesh);
 			//sameKey = false;
 		}
@@ -1231,7 +1231,7 @@ export class Context {
 		this._lastTex = tex;
 
 		if (mesh.vertNum + 4 > Context._MAXVERTNUM) {
-			mesh = this._mesh = MeshQuadTexture.getAMesh(this.isMain);//创建新的mesh  TODO 如果_mesh不是常见格式，这里就不能这么做了。以后把_mesh单独表示成常用模式 
+			mesh = this._mesh = MeshQuadTexture.getAMesh(this.isMain);//创建新的mesh  TODO 如果_mesh不是常见格式，这里就不能这么做了。以后把_mesh单独表示成常用模式
 			this.meshlist.push(mesh);
 			sameKey = false;	//新的mesh不能算samekey了
 		}
@@ -1310,7 +1310,7 @@ export class Context {
 	}
 
 	/**
-	 * 应用当前矩阵。把转换后的位置放到输出数组中。 
+	 * 应用当前矩阵。把转换后的位置放到输出数组中。
 	 * @param	x
 	 * @param	y
 	 * @param	w
@@ -1409,9 +1409,9 @@ export class Context {
 	}
 
 	/**
-	 * 
+	 *
 	 * @param	tex
-	 * @param	x			
+	 * @param	x
 	 * @param	y
 	 * @param	width
 	 * @param	height
@@ -1574,7 +1574,7 @@ export class Context {
 		this._drawCount++;
 		var rgba: number = 0xffffffff;
 		if (this._mesh.vertNum + 4 > Context._MAXVERTNUM) {
-			this._mesh = MeshQuadTexture.getAMesh(this.isMain);//创建新的mesh  TODO 如果_mesh不是常见格式，这里就不能这么做了。以后把_mesh单独表示成常用模式 
+			this._mesh = MeshQuadTexture.getAMesh(this.isMain);//创建新的mesh  TODO 如果_mesh不是常见格式，这里就不能这么做了。以后把_mesh单独表示成常用模式
 			this.meshlist.push(this._mesh);
 		}
 
@@ -1599,11 +1599,11 @@ export class Context {
 		return false;
 	}
 
-	drawTriangles(tex: Texture, 
-			x: number, y: number, 
-			vertices: Float32Array, 
-			uvs : Float32Array, 
-			indices : Uint16Array, 
+	drawTriangles(tex: Texture,
+			x: number, y: number,
+			vertices: Float32Array,
+			uvs : Float32Array,
+			indices : Uint16Array,
 			matrix : Matrix, alpha: number, color: ColorFilter, blendMode: string, colorNum: number = 0xffffffff): void {
 
 		if (!tex._getSource()) { //source内调用tex.active();
@@ -1639,7 +1639,7 @@ export class Context {
 		//var rgba:int = mixRGBandAlpha(0xffffffff);
 		//rgba = _mixRGBandAlpha(rgba, alpha);	这个函数有问题，不能连续调用，输出作为输入
 		if (triMesh.vertNum + vertices.length / 2 > Context._MAXVERTNUM) {
-			triMesh = this._triangleMesh = MeshTexture.getAMesh(this.isMain);//创建新的mesh  TODO 如果_mesh不是常见格式，这里就不能这么做了。以后把_mesh单独表示成常用模式 
+			triMesh = this._triangleMesh = MeshTexture.getAMesh(this.isMain);//创建新的mesh  TODO 如果_mesh不是常见格式，这里就不能这么做了。以后把_mesh单独表示成常用模式
 			this.meshlist.push(triMesh);
 			sameKey = false;	//新的mesh不能算samekey了
 		}
@@ -1809,7 +1809,7 @@ export class Context {
 	}
 
 	/**
-	 * 
+	 *
 	 * @param	start
 	 * @param	end
 	 */
@@ -2071,7 +2071,7 @@ export class Context {
 	}
 
 	/**
-	 * 
+	 *
 	 * @param	x
 	 * @param	y
 	 * @param	b 是否应用矩阵
@@ -2341,7 +2341,7 @@ export class Context {
 		 * |     p6--------------------p7   |
 		 * |  x,y+h                  x+w,y+h|
 		 * p5-------------------------------p8
-		 * 
+		 *
 		 * 不用了
 		 * 这个其实用4个fillrect拼起来更好，能与fillrect合并。虽然多了几个点。
 		 */
@@ -2376,16 +2376,16 @@ export class Context {
 	get canvas(): HTMLCanvas {
 		return this._canvas;
 	}
-	//=============新增==================	
+	//=============新增==================
 	/* 下面的方式是有bug的。canvas是直接save，restore，现在是为了优化，但是有bug，所以先不重载了
 	public function saveTransform(matrix:Matrix):void {
 		this._curMat.copyTo(matrix);
 	}
-	
+
 	public function restoreTransform(matrix:Matrix):void {
 		matrix.copyTo(this._curMat);
 	}
-	
+
 	public function transformByMatrix(matrix:Matrix,tx:Number,ty:Number):void {
 		var mat:Matrix = _curMat;
 		matrix.setTranslate(tx, ty);
@@ -2397,15 +2397,15 @@ export class Context {
 
 	/* 下面的是错误的。位置没有被缩放
 	public function transformByMatrix(matrix:Matrix, tx:Number, ty:Number):void {
-		SaveTransform.save(this);			
-		Matrix.mul(matrix, _curMat, _curMat);	
+		SaveTransform.save(this);
+		Matrix.mul(matrix, _curMat, _curMat);
 		_curMat.tx += tx;
 		_curMat.ty += ty;
 		_curMat._checkTransform();
 	}
-			
+
 	public function transformByMatrixNoSave(matrix:Matrix, tx:Number, ty:Number):void {
-		Matrix.mul(matrix, _curMat, _curMat);	
+		Matrix.mul(matrix, _curMat, _curMat);
 		_curMat.tx += tx;
 		_curMat.ty += ty;
 		_curMat._checkTransform();
@@ -2425,7 +2425,7 @@ export class Context {
 	 * @param	w
 	 */
 	private _fillTexture_h(tex: Texture, imgid: number, uv: ArrayLike<number>, oriw: number, orih: number, x: number, y: number, w: number): void {
-		if(oriw<=0) 
+		if(oriw<=0)
 			console.error('_fillTexture_h error: oriw must>0');
 
 		var stx: number = x;
@@ -2458,7 +2458,7 @@ export class Context {
 	 * @param	h
 	 */
 	private _fillTexture_v(tex: Texture, imgid: number, uv: ArrayLike<number>, oriw: number, orih: number, x: number, y: number, h: number): void {
-		if(orih<=0) 
+		if(orih<=0)
 			console.error('_fillTexture_v error: orih must>0');
 		var sty: number = y;
 		var num: number = Math.floor(h / orih);
@@ -2625,6 +2625,68 @@ export class Context {
 		}
 
 		if (needClip) this.restore();
+	}
+
+	drawSymmetricTexture(tex:Texture, tx:number, ty:number, width:number, height:number, type:number, gx:number, gy:number):void {
+		if (!tex._getSource())
+			return;
+		tx += gx;
+		ty += gy;
+		let uv = tex.uv;
+		let imgid = (tex.bitmap as Texture2D).id;
+		let mat = this._curMat;
+		let tuv = this._tempUV;
+
+		// 整图的uv
+		// 一定是方的，所以uv只要左上右下就行
+		let uvl = uv[0];
+		let uvt = uv[1];
+		let uvr = uv[4];
+		let uvb = uv[5];
+
+		//1：左右对称；2上下对称；3：上下左右中心对称
+		//1, 2, 3 左上UV同
+		//1, 3 左下UV同
+		//2, 3 右上UV同
+		//3 右下UV
+
+		let offsetX = 0, offsetY = 0;
+		let drawW = width, drawH = height;
+		if(type & 1) {
+			drawW = width * 0.5;
+			offsetX = drawW;
+		}
+		if(type & 2) {
+			drawH = height * 0.5;
+			offsetY = drawH;
+		}
+
+		if(type & 1) {
+			//绘制右上角矩形
+			tuv[0] = uvr; tuv[1] = uvt; tuv[2] = uvl; tuv[3] = uvt;
+			tuv[6] = uvr; tuv[7] = uvb; tuv[4] = uvl; tuv[5] = uvb;
+			this._inner_drawTexture(tex, imgid, tx+offsetX, ty, drawW, drawH, mat, tuv, 1, false);
+		}
+
+		if(type & 2) {
+			//绘制左下角矩形
+			tuv[0] = uvl; tuv[1] = uvb; tuv[2] = uvr; tuv[3] = uvb;
+			tuv[6] = uvl; tuv[7] = uvt; tuv[4] = uvr; tuv[5] = uvt;
+			this._inner_drawTexture(tex, imgid, tx, ty+offsetY, drawW, drawH, mat, tuv, 1, false);
+		}
+
+		//绘制左上角矩形, 这块矩形总是会绘制的
+		tuv[0] = uvl; tuv[1] = uvt; tuv[2] = uvr; tuv[3] = uvt;
+		tuv[6] = uvl; tuv[7] = uvb; tuv[4] = uvr; tuv[5] = uvb;
+		this._inner_drawTexture(tex, imgid, tx, ty, drawW, drawH, mat, tuv, 1, false);
+
+		if(type === 3) {
+			//绘制右下角矩形
+			tuv[0] = uvr; tuv[1] = uvb;  tuv[2] = uvl; tuv[3] = uvb;
+			tuv[6] = uvr; tuv[7] = uvt;  tuv[4] = uvl; tuv[5] = uvt;
+			this._inner_drawTexture(tex, imgid, tx+offsetX, ty+offsetY, drawW, drawH, mat, tuv, 1, false);
+		}
+
 	}
 }
 

--- a/src/layaAir/laya/ui/AutoBitmap.ts
+++ b/src/layaAir/laya/ui/AutoBitmap.ts
@@ -7,6 +7,7 @@ import { Draw9GridTexture } from "../display/cmd/Draw9GridTexture";
 import { DrawTextureCmd } from "../display/cmd/DrawTextureCmd";
 import { SpriteConst } from "../display/SpriteConst";
 import { Matrix } from "../maths/Matrix";
+import { DrawSymmetricTexture } from "../display/cmd/DrawSymmetricTexture";
 
 /**
  * <code>AutoBitmap</code> 类是用于表示位图图像或绘制图形的显示对象。
@@ -23,6 +24,8 @@ export class AutoBitmap extends Graphics {
     private _source: Texture;
     /**@private 网格数据*/
     private _sizeGrid: number[];
+    /**@private 对称图像类型*/
+    private _symmetricType: number = 0;
     /**@private */
     protected _isChanged: boolean;
     /**@internal */
@@ -32,7 +35,7 @@ export class AutoBitmap extends Graphics {
     //private var _key:String;
     private  _drawGridCmd:Draw9GridTexture|null;
 
-    /**@inheritDoc 
+    /**@inheritDoc
      * @override
     */
     destroy(): void {
@@ -75,6 +78,23 @@ export class AutoBitmap extends Graphics {
 
     set sizeGrid(value: number[]) {
         this._sizeGrid = value.map((v) => { return +v; });
+        this._setChanged();
+    }
+    /**
+     * 当前精灵图的纹理(对称)填充类型，默认值为0
+     * <p> <code>symmetricType</code> 的值如下所示：
+     * <ol>
+     * <li>0: 直接铺满填充</li>
+     * <li>1: 左右对称填充</li>
+     * <li>2: 上下对称填充</li>
+     * <li>3: 上下左右对称填充</li>
+     * </p>
+     */
+    get symmetricType() {
+        return this._symmetricType;
+    }
+    set symmetricType(value) {
+        this._symmetricType = value;
         this._setChanged();
     }
 
@@ -191,8 +211,15 @@ export class AutoBitmap extends Graphics {
 
         //如果没有设置9宫格，或大小未改变，则直接用原图绘制
         if (!sizeGrid || (sw === width && sh === height)) {
-            let cmd = this._createDrawTexture(source, this._offset ? this._offset[0] : 0, this._offset ? this._offset[1] : 0, width, height, null, 1, null, null, this.uv);
+            let cmd:any;
+            if(this._symmetricType) {
+                cmd = DrawSymmetricTexture.create(source, 0, 0, width, height, this._symmetricType);
+            }
+            else {
+                cmd = this._createDrawTexture(source, this._offset ? this._offset[0] : 0, this._offset ? this._offset[1] : 0, width, height, null, 1, null, null, this.uv);
+            }
             cmd && this._setDrawGridCmd(cmd);
+
         } else {
             let cmd = Draw9GridTexture.create(source, 0, 0, width, height, sizeGrid);
             this._setDrawGridCmd(cmd);
@@ -227,7 +254,7 @@ export class AutoBitmap extends Graphics {
         var source = this._source;
         if (!source || !source.bitmap){
             return;
-        } 
+        }
 
         //let newcmd = Draw9GridTexture.create(source, 0, 0, width, height, sizeGrid);
         let cmds = this.cmds;

--- a/src/layaAir/laya/ui/Image.ts
+++ b/src/layaAir/laya/ui/Image.ts
@@ -18,7 +18,7 @@ import { ClassUtils } from "../utils/ClassUtils";
 /**
  * <code>Image</code> 类是用于表示位图图像或绘制图形的显示对象。
  * Image和Clip组件是唯一支持异步加载的两个组件，比如img.skin = "abc/xxx.png"，其他UI组件均不支持异步加载。
- * 
+ *
  * @example <caption>以下示例代码，创建了一个新的 <code>Image</code> 实例，设置了它的皮肤、位置信息，并添加到舞台上。</caption>
  *	package
  *	 {
@@ -88,6 +88,9 @@ import { ClassUtils } from "../utils/ClassUtils";
  * @see laya.ui.AutoBitmap
  */
 export class Image extends UIComponent {
+    public static readonly SYMMETRIC_FILL_NONE = 0;
+    public static readonly SYMMETRIC_FILL_HORI = 1;
+    public static readonly SYMMETRIC_FILL_VERT = 2;
     /**@internal */
     _bitmap: AutoBitmap;
     /**@private */
@@ -105,7 +108,7 @@ export class Image extends UIComponent {
     }
 
     /**
-     * @inheritDoc 
+     * @inheritDoc
      * @override
      */
 	destroy(destroyChild: boolean = true): void {
@@ -123,7 +126,7 @@ export class Image extends UIComponent {
     }
 
     /**
-     * @inheritDoc 
+     * @inheritDoc
      * @override
      */
 	protected createChildren(): void {
@@ -192,7 +195,7 @@ export class Image extends UIComponent {
     }
 
     /**
-     * @inheritDoc 
+     * @inheritDoc
      * @override
      */
 	protected measureWidth(): number {
@@ -200,7 +203,7 @@ export class Image extends UIComponent {
     }
 
     /**
-     * @inheritDoc 
+     * @inheritDoc
      * @override
      */
 	protected measureHeight(): number {
@@ -208,7 +211,7 @@ export class Image extends UIComponent {
     }
 
     /**
-     * @inheritDoc 
+     * @inheritDoc
      * @override
      */
 	set width(value: number) {
@@ -217,15 +220,15 @@ export class Image extends UIComponent {
     }
 
     /**
-     * @inheritDoc 
-     * @override 
+     * @inheritDoc
+     * @override
      */
     get width() {
         return super.width;
     }
 
     /**
-     * @inheritDoc 
+     * @inheritDoc
      * @override
      */
 	set height(value: number) {
@@ -233,7 +236,7 @@ export class Image extends UIComponent {
         this._bitmap.height = value == 0 ? 0.0000001 : value;
     }
     /**
-     * @inheritDoc 
+     * @inheritDoc
      * @override
      */
     get height() {
@@ -256,7 +259,24 @@ export class Image extends UIComponent {
     }
 
     /**
-     * @inheritDoc 
+     * 当前精灵图的纹理(对称)填充类型，默认值为0
+     * <p> <code>symmetricType</code> 的值如下所示：
+     * <ol>
+     * <li>0: 直接铺满填充</li>
+     * <li>1: 左右对称填充</li>
+     * <li>2: 上下对称填充</li>
+     * <li>3: 上下左右对称填充</li>
+     * </p>
+     */
+    get symmetricType() {
+        return this._bitmap.symmetricType;
+    }
+    set symmetricType(value) {
+        this._bitmap.symmetricType = value;
+    }
+
+    /**
+     * @inheritDoc
      * @override
      */
     set dataSource(value: any) {
@@ -265,7 +285,7 @@ export class Image extends UIComponent {
         else super.dataSource = value;
     }
     /**
-     * @inheritDoc 
+     * @inheritDoc
      * @override
      */
     get dataSource() {


### PR DESCRIPTION
这提交使Image组件可以支持以3种方式进行纹理填充。
实现原理和九宫格类似，渲染时额外的创建顶点和uv进行渲染提交。
三种填充模式的渲染效果如下图：
![image](https://user-images.githubusercontent.com/29858187/132987044-5dd6a979-9874-42fe-8fce-d15990a3e9f1.png)
