### PR TITLE
重构Rendertexture

### DIFF
--- a/src/layaAir/laya/d3/depthMap/DepthPass.ts
+++ b/src/layaAir/laya/d3/depthMap/DepthPass.ts
@@ -7,12 +7,13 @@ import { Viewport } from "../math/Viewport";
 import { RenderTexture } from "../resource/RenderTexture";
 import { Shader3D } from "../shader/Shader3D";
 import { ShaderData } from "../shader/ShaderData";
+import { ShaderDefine } from "../shader/ShaderDefine";
 
 
 /**
  * 深度贴图模式
  */
-export enum DepthTextureMode{
+export enum DepthTextureMode {
 	/**不生成深度贴图 */
 	None = 0,
 	/**生成深度贴图 */
@@ -26,36 +27,38 @@ export enum DepthTextureMode{
  * <code>ShadowCasterPass</code> 类用于实现阴影渲染管线
  */
 export class DepthPass {
-	private static SHADOW_BIAS:Vector4 = new Vector4();
+	private static SHADOW_BIAS: Vector4 = new Vector4();
+	/** @internal */
+	static DEPTHPASS: ShaderDefine = Shader3D.getDefineByName("DEPTHPASS");
 	/** @internal */
 	static DEFINE_SHADOW_BIAS: number = Shader3D.propertyNameToID("u_ShadowBias");
 	/**@internal */
-	static DEPTHTEXTURE:number = Shader3D.propertyNameToID("u_CameraDepthTexture");
+	static DEPTHTEXTURE: number = Shader3D.propertyNameToID("u_CameraDepthTexture");
 	/**@internal */
-	static DEPTHNORMALSTEXTURE:number = Shader3D.propertyNameToID("u_CameraDepthNormalsTexture");
+	static DEPTHNORMALSTEXTURE: number = Shader3D.propertyNameToID("u_CameraDepthNormalsTexture");
 	/**@internal */
-	static DEPTHZBUFFERPARAMS:number = Shader3D.propertyNameToID("u_ZBufferParams");
+	static DEPTHZBUFFERPARAMS: number = Shader3D.propertyNameToID("u_ZBufferParams");
 	/**@internal */
-	private _depthTexture:RenderTexture;
+	private _depthTexture: RenderTexture;
 	/**@internal */
-	private _depthNormalsTexture:RenderTexture;
+	private _depthNormalsTexture: RenderTexture;
 	/**@internal */
-	private _viewPort:Viewport;
+	private _viewPort: Viewport;
 	/**@internal */
-	private _camera:Camera;
-	
+	private _camera: Camera;
+
 	// Values used to linearize the Z buffer (http://www.humus.name/temp/Linearize%20depth.txt)
-    // x = 1-far/near
-    // y = far/near
-    // z = x/far
-    // w = y/far
-    // or in case of a reversed depth buffer (UNITY_REVERSED_Z is 1)
-    // x = -1+far/near
-    // y = 1
-    // z = x/far
+	// x = 1-far/near
+	// y = far/near
+	// z = x/far
+	// w = y/far
+	// or in case of a reversed depth buffer (UNITY_REVERSED_Z is 1)
+	// x = -1+far/near
+	// y = 1
+	// z = x/far
 	// w = 1/far
 	/**@internal */
-	private _zBufferParams:Vector4 = new Vector4();
+	private _zBufferParams: Vector4 = new Vector4();
 
 	constructor() {
 	}
@@ -65,21 +68,21 @@ export class DepthPass {
 	 * @param camera 
 	 * @param depthType 
 	 */
-	update(camera: Camera,depthType:DepthTextureMode): void {
+	update(camera: Camera, depthType: DepthTextureMode,depthTextureFormat:RenderTextureDepthFormat): void {
 		this._viewPort = camera.viewport;
 		this._camera = camera;
-		switch(depthType){
+		switch (depthType) {
 			case DepthTextureMode.Depth:
-				camera.depthTexture = this._depthTexture = RenderTexture.createFromPool(this._viewPort.width, this._viewPort.height,RenderTextureFormat.Depth,RenderTextureDepthFormat.DEPTH_16);
+				camera.depthTexture = this._depthTexture = RenderTexture.createFromPool(this._viewPort.width, this._viewPort.height, RenderTextureFormat.Depth, depthTextureFormat);
 				break;
 			case DepthTextureMode.DepthNormals:
-				camera.depthNormalTexture = this._depthNormalsTexture = RenderTexture.createFromPool(this._viewPort.width,this._viewPort.height,RenderTextureFormat.R8G8B8A8,RenderTextureDepthFormat.DEPTH_16);
+				camera.depthNormalTexture = this._depthNormalsTexture = RenderTexture.createFromPool(this._viewPort.width, this._viewPort.height, RenderTextureFormat.R8G8B8A8, depthTextureFormat);
 				break;
 			case DepthTextureMode.MotionVectors:
 				//TODO：
 				break;
 			default:
-				throw("there is UnDefined type of DepthTextureMode")
+				throw ("there is UnDefined type of DepthTextureMode")
 		}
 	}
 
@@ -88,30 +91,33 @@ export class DepthPass {
 	 * @param context 
 	 * @param depthType 
 	 */
-	render(context: RenderContext3D,depthType:DepthTextureMode): void {
+	render(context: RenderContext3D, depthType: DepthTextureMode): void {
 		var scene = context.scene;
-		switch(depthType){
+		switch (depthType) {
 			case DepthTextureMode.Depth:
-				var shaderValues:ShaderData = scene._shaderValues;
+
+				var shaderValues: ShaderData = scene._shaderValues;
 				context.pipelineMode = "ShadowCaster";
+				shaderValues.addDefine(DepthPass.DEPTHPASS);
 				ShaderData.setRuntimeValueMode(false);
 				this._depthTexture._start();
-				shaderValues.setVector(DepthPass.DEFINE_SHADOW_BIAS,DepthPass.SHADOW_BIAS);
+				shaderValues.setVector(DepthPass.DEFINE_SHADOW_BIAS, DepthPass.SHADOW_BIAS);
 				var gl = LayaGL.instance;
 				var offsetX: number = this._viewPort.x;
 				var offsetY: number = this._viewPort.y;
 				gl.enable(gl.SCISSOR_TEST);
-				gl.viewport(offsetX, offsetY, this._viewPort.width,this._viewPort.height);
-				gl.scissor(offsetX, offsetY, this._viewPort.width,this._viewPort.height);
+				gl.viewport(offsetX, offsetY, this._viewPort.width, this._viewPort.height);
+				gl.scissor(offsetX, offsetY, this._viewPort.width, this._viewPort.height);
 				gl.clear(gl.DEPTH_BUFFER_BIT);
 				scene._opaqueQueue._render(context);
 				this._depthTexture._end();
 				ShaderData.setRuntimeValueMode(true);
-				this._setupDepthModeShaderValue(depthType,this._camera);
+				this._setupDepthModeShaderValue(depthType, this._camera);
 				context.pipelineMode = context.configPipeLineMode;
+				shaderValues.removeDefine(DepthPass.DEPTHPASS);
 				break;
 			case DepthTextureMode.DepthNormals:
-				var shaderValues:ShaderData = scene._shaderValues;
+				var shaderValues: ShaderData = scene._shaderValues;
 				context.pipelineMode = "DepthNormal";
 				ShaderData.setRuntimeValueMode(false);
 				this._depthNormalsTexture._start();
@@ -120,20 +126,20 @@ export class DepthPass {
 				var offsetX: number = this._viewPort.x;
 				var offsetY: number = this._viewPort.y;
 				gl.enable(gl.SCISSOR_TEST);
-				gl.viewport(offsetX, offsetY, this._viewPort.width,this._viewPort.height);
-				gl.scissor(offsetX, offsetY, this._viewPort.width,this._viewPort.height);
+				gl.viewport(offsetX, offsetY, this._viewPort.width, this._viewPort.height);
+				gl.scissor(offsetX, offsetY, this._viewPort.width, this._viewPort.height);
 				gl.clearColor(0.5, 0.5, 1.0, 0.0);
-				gl.clear(gl.DEPTH_BUFFER_BIT|gl.COLOR_BUFFER_BIT);
+				gl.clear(gl.DEPTH_BUFFER_BIT | gl.COLOR_BUFFER_BIT);
 				scene._opaqueQueue._render(context);
 				this._depthNormalsTexture._end();
 				ShaderData.setRuntimeValueMode(true);
-				this._setupDepthModeShaderValue(depthType,this._camera);
+				this._setupDepthModeShaderValue(depthType, this._camera);
 				context.pipelineMode = context.configPipeLineMode;
 				break;
 			case DepthTextureMode.MotionVectors:
 				break;
 			default:
-				throw("there is UnDefined type of DepthTextureMode")
+				throw ("there is UnDefined type of DepthTextureMode")
 		}
 	}
 
@@ -141,24 +147,24 @@ export class DepthPass {
 	 * 渲染完后传入使用的参数
 	 * @internal
 	 */
-	private _setupDepthModeShaderValue(depthType:DepthTextureMode,camera:Camera){
-		switch(depthType){
+	_setupDepthModeShaderValue(depthType: DepthTextureMode, camera: Camera) {
+		switch (depthType) {
 			case DepthTextureMode.Depth:
 				var far = camera.farPlane;
 				var near = camera.nearPlane;
-				this._zBufferParams.setValue(1.0-far/near,far/near,(near-far)/(near*far),1/near);
-				camera._shaderValues.setVector(DepthPass.DEFINE_SHADOW_BIAS,DepthPass.SHADOW_BIAS);
-				camera._shaderValues.setTexture(DepthPass.DEPTHTEXTURE,this._depthTexture);
-				camera._shaderValues.setVector(DepthPass.DEPTHZBUFFERPARAMS,this._zBufferParams);
+				this._zBufferParams.setValue(1.0 - far / near, far / near, (near - far) / (near * far), 1 / near);
+				camera._shaderValues.setVector(DepthPass.DEFINE_SHADOW_BIAS, DepthPass.SHADOW_BIAS);
+				camera._shaderValues.setTexture(DepthPass.DEPTHTEXTURE, this._depthTexture);
+				camera._shaderValues.setVector(DepthPass.DEPTHZBUFFERPARAMS, this._zBufferParams);
 				break;
 			case DepthTextureMode.DepthNormals:
-				camera._shaderValues.setTexture(DepthPass.DEPTHNORMALSTEXTURE,this._depthNormalsTexture);
+				camera._shaderValues.setTexture(DepthPass.DEPTHNORMALSTEXTURE, this._depthNormalsTexture);
 				break;
 			case DepthTextureMode.MotionVectors:
 				break;
 			default:
-				throw("there is UnDefined type of DepthTextureMode")
-			}
+				throw ("there is UnDefined type of DepthTextureMode")
+		}
 	}
 
 	/**
@@ -169,7 +175,7 @@ export class DepthPass {
 		this._depthTexture && RenderTexture.recoverToPool(this._depthTexture);
 		this._depthNormalsTexture && RenderTexture.recoverToPool(this._depthNormalsTexture);
 		this._depthTexture = null;
-		this._depthNormalsTexture = null;	
+		this._depthNormalsTexture = null;
 	}
 }
 

--- a/src/layaAir/laya/d3/resource/MulSampleRenderTexture.ts
+++ b/src/layaAir/laya/d3/resource/MulSampleRenderTexture.ts
@@ -1,0 +1,188 @@
+import { LayaGL } from "../../layagl/LayaGL";
+import { BaseTexture } from "../../resource/BaseTexture";
+import { FilterMode } from "../../resource/FilterMode";
+import { RenderTextureDepthFormat, RenderTextureFormat, RTDEPTHATTACHMODE } from "../../resource/RenderTextureFormat";
+import { WarpMode } from "../../resource/WrapMode";
+import { LayaGPU } from "../../webgl/LayaGPU";
+import { WebGLContext } from "../../webgl/WebGLContext";
+import { RenderContext3D } from "../core/render/RenderContext3D";
+import { RenderTexture } from "./RenderTexture";
+/**
+ * <code>MulSampleRenderTexture</code>类用于创建多重采样渲染目标
+ * webGL2.0多重采样才会生效
+ */
+export class MulSampleRenderTexture extends RenderTexture{
+    /**多重采样次数 */
+    protected _mulSampler: number = 1;
+    /**是否为多重采样贴图 */
+    protected _mulSamplerRT = true;
+    /** @internal RenderBuffer*/
+	protected _mulRenderBuffer: any;
+	/** @internal 用来拷贝的frameBuffer*/
+	protected _mulFrameBuffer: any;
+
+    constructor(width: number, height: number, format: RenderTextureFormat = RenderTextureFormat.R8G8B8, depthStencilFormat: RenderTextureDepthFormat = RenderTextureDepthFormat.DEPTH_16,mulSampler:number = 1){
+        super(width, height, format, depthStencilFormat);
+        this._mulSampler = mulSampler;
+    }
+
+    protected _create(width:number,height:number):void{
+        var gl: WebGLRenderingContext = LayaGL.instance;
+		var gl2: WebGL2RenderingContext = <WebGL2RenderingContext>gl;
+		var glTextureType: number = this._glTextureType;
+		var layaGPU: LayaGPU = LayaGL.layaGPUInstance;
+		var isWebGL2: Boolean = layaGPU._isWebGL2;
+		var format: number = this._format;
+        
+        this._frameBuffer = gl.createFramebuffer();
+		gl.bindFramebuffer(gl.FRAMEBUFFER, this._frameBuffer);
+        
+        //createRenderBuffer
+        this._mulRenderBuffer = gl2.createRenderbuffer();
+        gl2.bindRenderbuffer(gl2.RENDERBUFFER,this._mulRenderBuffer);
+        switch(format){
+            case RenderTextureFormat.R8G8B8:
+                gl2.renderbufferStorageMultisample(gl2.RENDERBUFFER,this._mulSampler,gl2.RGB8,width,height);
+                break;
+            case RenderTextureFormat.R8G8B8A8:
+                gl2.renderbufferStorageMultisample(gl2.RENDERBUFFER,this._mulSampler,gl2.RGBA8,width,height);
+                break;
+            case RenderTextureFormat.Alpha8:
+                gl2.renderbufferStorageMultisample(gl2.RENDERBUFFER,this._mulSampler,gl2.ALPHA,width,height);
+                break;
+            case RenderTextureFormat.R16G16B16A16:
+                gl2.renderbufferStorageMultisample(gl2.RENDERBUFFER,this._mulSampler,gl2.RGBA16F,width,height);
+                break;
+        }
+		gl2.framebufferRenderbuffer(gl.FRAMEBUFFER,gl.COLOR_ATTACHMENT0,gl.RENDERBUFFER,this._mulRenderBuffer);
+
+        //set gl_Texture
+        this._creatGlTexture(width,height);
+        if (format !== RenderTextureFormat.Depth && format !== RenderTextureFormat.ShadowMap) {
+			this._mulFrameBuffer = gl2.createFramebuffer();
+			gl.bindFramebuffer(gl.FRAMEBUFFER,this._mulFrameBuffer);
+			gl.framebufferTexture2D(gl2.FRAMEBUFFER,gl2.COLOR_ATTACHMENT0,gl2.TEXTURE_2D,this._glTexture,0);
+		}
+        
+        //set Depth_Gl
+        this._createGLDepthRenderbuffer(width,height);
+
+    }
+
+    protected _createGLDepthRenderbuffer(width:number,height:number){
+        var gl: WebGLRenderingContext = LayaGL.instance;
+        var gl2: WebGL2RenderingContext = <WebGL2RenderingContext>gl;
+        gl.bindFramebuffer(gl.FRAMEBUFFER, this._frameBuffer);
+        if (this._depthStencilFormat !== RenderTextureDepthFormat.DEPTHSTENCIL_NONE) {
+            this._depthStencilBuffer = gl.createRenderbuffer();
+			gl.bindRenderbuffer(gl.RENDERBUFFER, this._depthStencilBuffer);
+			
+            switch (this._depthStencilFormat) {
+                case RenderTextureDepthFormat.DEPTH_16:
+                    gl2.renderbufferStorageMultisample(gl.RENDERBUFFER,this._mulSampler,gl2.DEPTH_COMPONENT16,width,height);
+                    gl2.framebufferRenderbuffer(gl.FRAMEBUFFER,gl2.DEPTH_ATTACHMENT,gl.RENDERBUFFER,this._depthStencilBuffer);
+                    break;
+                case RenderTextureDepthFormat.STENCIL_8:
+                    gl2.renderbufferStorageMultisample(gl.RENDERBUFFER,this._mulSampler,gl2.STENCIL_INDEX8,width,height);
+                    gl2.framebufferRenderbuffer(gl.FRAMEBUFFER,gl2.STENCIL_ATTACHMENT,gl.RENDERBUFFER,this._depthStencilBuffer);
+                    break;
+                case RenderTextureDepthFormat.DEPTHSTENCIL_24_8:
+                    gl2.renderbufferStorageMultisample(gl.RENDERBUFFER,this._mulSampler,gl2.DEPTH_STENCIL,width,height);
+                    gl2.framebufferRenderbuffer(gl.FRAMEBUFFER,gl2.DEPTH_STENCIL_ATTACHMENT,gl.RENDERBUFFER,this._depthStencilBuffer);
+                    break;
+                default:
+                    throw "RenderTexture: unkonw depth format.";
+            }
+        }
+    }
+
+    protected _createGLDepthTexture(width:number,height:number){
+        var glTextureType: number = this._glTextureType;
+		var layaGPU: LayaGPU = LayaGL.layaGPUInstance;
+		var isWebGL2: Boolean = layaGPU._isWebGL2;
+		var gl: WebGLRenderingContext = LayaGL.instance;
+		var gl2: WebGL2RenderingContext = <WebGL2RenderingContext>gl;
+        if (this._depthStencilFormat !== RenderTextureDepthFormat.DEPTHSTENCIL_NONE) {
+            this._depthStencilTexture = new BaseTexture(RenderTextureFormat.Depth,false);
+			this._depthStencilTexture.lock = true;
+			this._depthStencilTexture.width = width;
+			this._depthStencilTexture.height = height;
+			this._depthStencilTexture.mipmapCount = 1;
+			this._depthStencilTexture._glTextureType = LayaGL.instance.TEXTURE_2D;
+			this._depthStencilTexture._readyed = true;
+            //绑定mulBuffer
+            gl.bindFramebuffer(gl.FRAMEBUFFER,this._mulFrameBuffer);
+            this._depthStencilTexture.filterMode = FilterMode.Point;
+			this._depthStencilTexture.wrapModeU = WarpMode.Clamp;
+			this._depthStencilTexture.wrapModeV = WarpMode.Clamp;
+            WebGLContext.bindTexture(gl, this._depthStencilTexture._glTextureType, this._depthStencilTexture._getSource());
+            switch (this._depthStencilFormat) {
+				case RenderTextureDepthFormat.DEPTH_16:
+					if (isWebGL2) {
+						gl2.texStorage2D(glTextureType, this._mipmapCount, gl2.DEPTH_COMPONENT16, width, height);
+					}
+					else {
+						gl.texImage2D(glTextureType, 0, gl.DEPTH_COMPONENT, width, height, 0, gl.DEPTH_COMPONENT, gl.UNSIGNED_SHORT, null);
+					}
+					gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.TEXTURE_2D, this._depthStencilTexture._getSource(), 0);
+					break;
+				case RenderTextureDepthFormat.DEPTHSTENCIL_24_8:
+					if (isWebGL2) {
+						gl2.texStorage2D(glTextureType, this._mipmapCount, gl2.DEPTH24_STENCIL8, width, height);
+					}
+					else {
+						gl.texImage2D(glTextureType, 0, gl.DEPTH_STENCIL, width, height, 0, gl.DEPTH_STENCIL, layaGPU._webgl_depth_texture.UNSIGNED_INT_24_8_WEBGL, null);
+					}
+					gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.TEXTURE_2D, this._depthStencilTexture._getSource(), 0);
+					break;
+				case RenderTextureDepthFormat.DEPTH_32:
+					if (isWebGL2) {
+						gl2.texStorage2D(glTextureType, this._mipmapCount, gl2.DEPTH_COMPONENT32F, width, height);
+					}
+					else {
+						gl.texImage2D(glTextureType, 0, gl.DEPTH_COMPONENT, width, height, 0, gl.DEPTH_COMPONENT, gl.UNSIGNED_INT, null);
+					}
+					gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.TEXTURE_2D, this._depthStencilTexture._getSource(), 0);
+					break;
+				default:
+					break;
+			}
+        }
+        
+    }
+
+
+    _end(){
+        var gl: WebGLRenderingContext = LayaGL.instance;
+		var gl2: WebGL2RenderingContext = <WebGL2RenderingContext>gl;
+		//blitMtlColor TO texture
+        gl2.bindFramebuffer(gl2.READ_FRAMEBUFFER,this._frameBuffer);
+        gl2.bindFramebuffer(gl2.DRAW_FRAMEBUFFER,this._mulFrameBuffer);
+        gl2.clearBufferfv(gl2.COLOR,0,[0.0,0.0,0.0,0.0]);
+        gl2.blitFramebuffer(0,0,this.width,this.height,0,0,this._width,this._height,gl2.COLOR_BUFFER_BIT,gl.NEAREST);
+		if(this._depthAttachMode==RTDEPTHATTACHMODE.TEXTURE){
+            gl2.bindFramebuffer(gl2.READ_FRAMEBUFFER,this._frameBuffer);
+            gl2.bindFramebuffer(gl2.DRAW_FRAMEBUFFER,this._mulFrameBuffer);
+            gl2.clearBufferfi(gl.DEPTH_STENCIL, 0, 1.0, 0);
+            gl2.blitFramebuffer(0,0,this.width,this.height,0,0,this._width,this._height,gl2.DEPTH_BUFFER_BIT,gl.NEAREST)
+        }
+        gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+	
+		RenderTexture._currentActive = null;
+		(this._isCameraTarget) && (RenderContext3D._instance.invertY = false);
+		this._readyed = true;
+    }
+
+    	/**
+	 * @inheritDoc
+	 * @override
+	 */
+	protected _disposeResource(): void {
+        super._disposeResource();
+        var gl: WebGLRenderingContext = LayaGL.instance;
+        this._mulRenderBuffer && gl.deleteRenderbuffer(this._mulRenderBuffer);
+	    this._mulFrameBuffer && gl.deleteFramebuffer(this._mulFrameBuffer);
+        this._mulRenderBuffer = null;
+        this._mulFrameBuffer = null;
+	}
+}

--- a/src/layaAir/laya/d3/shader/files/Lighting.glsl
+++ b/src/layaAir/laya/d3/shader/files/Lighting.glsl
@@ -38,10 +38,6 @@ const int c_ClusterBufferHeight = CLUSTER_Z_COUNT*(1+int(ceil(float(MAX_LIGHT_CO
 const int c_ClusterBufferFloatWidth = c_ClusterBufferWidth*4;
 
 #ifndef GRAPHICS_API_GLES3
-	mat2 inverseMat(mat2 m) {
-		return mat2(m[1][1],-m[0][1],
-				-m[1][0], m[0][0]) / (m[0][0]*m[1][1] - m[0][1]*m[1][0]);
-	}
 	mat3 inverseMat(mat3 m) {
 		float a00 = m[0][0], a01 = m[0][1], a02 = m[0][2];
 		float a10 = m[1][0], a11 = m[1][1], a12 = m[1][2];
@@ -56,46 +52,6 @@ const int c_ClusterBufferFloatWidth = c_ClusterBufferWidth*4;
 		return mat3(b01, (-a22 * a01 + a02 * a21), (a12 * a01 - a02 * a11),
 					b11, (a22 * a00 - a02 * a20), (-a12 * a00 + a02 * a10),
 					b21, (-a21 * a00 + a01 * a20), (a11 * a00 - a01 * a10)) / det;
-	}
-	mat4 inverseMat(mat4 m) {
-		float
-			a00 = m[0][0], a01 = m[0][1], a02 = m[0][2], a03 = m[0][3],
-			a10 = m[1][0], a11 = m[1][1], a12 = m[1][2], a13 = m[1][3],
-			a20 = m[2][0], a21 = m[2][1], a22 = m[2][2], a23 = m[2][3],
-			a30 = m[3][0], a31 = m[3][1], a32 = m[3][2], a33 = m[3][3],
-
-			b00 = a00 * a11 - a01 * a10,
-			b01 = a00 * a12 - a02 * a10,
-			b02 = a00 * a13 - a03 * a10,
-			b03 = a01 * a12 - a02 * a11,
-			b04 = a01 * a13 - a03 * a11,
-			b05 = a02 * a13 - a03 * a12,
-			b06 = a20 * a31 - a21 * a30,
-			b07 = a20 * a32 - a22 * a30,
-			b08 = a20 * a33 - a23 * a30,
-			b09 = a21 * a32 - a22 * a31,
-			b10 = a21 * a33 - a23 * a31,
-			b11 = a22 * a33 - a23 * a32,
-
-			det = b00 * b11 - b01 * b10 + b02 * b09 + b03 * b08 - b04 * b07 + b05 * b06;
-
-		return mat4(
-			a11 * b11 - a12 * b10 + a13 * b09,
-			a02 * b10 - a01 * b11 - a03 * b09,
-			a31 * b05 - a32 * b04 + a33 * b03,
-			a22 * b04 - a21 * b05 - a23 * b03,
-			a12 * b08 - a10 * b11 - a13 * b07,
-			a00 * b11 - a02 * b08 + a03 * b07,
-			a32 * b02 - a30 * b05 - a33 * b01,
-			a20 * b05 - a22 * b02 + a23 * b01,
-			a10 * b10 - a11 * b08 + a13 * b06,
-			a01 * b08 - a00 * b10 - a03 * b06,
-			a30 * b04 - a31 * b02 + a33 * b00,
-			a21 * b02 - a20 * b04 - a23 * b00,
-			a11 * b07 - a10 * b09 - a12 * b06,
-			a00 * b09 - a01 * b07 + a02 * b06,
-			a31 * b01 - a30 * b03 - a32 * b00,
-			a20 * b03 - a21 * b01 + a22 * b00) / det;
 	}
 #endif
 

--- a/src/layaAir/laya/d3/shader/files/ShadowCasterVS.glsl
+++ b/src/layaAir/laya/d3/shader/files/ShadowCasterVS.glsl
@@ -74,16 +74,21 @@ vec4 shadowCasterVertex()
 	
 
 	#ifdef SHADOW
-		positionWS.xyz = applyShadowBias(positionWS.xyz,normalWS,u_ShadowLightDirection);
+		#ifndef DEPTHPASS
+			positionWS.xyz = applyShadowBias(positionWS.xyz,normalWS,u_ShadowLightDirection);
+		#endif
 		positionCS = u_ViewProjection * positionWS;
-		positionCS.z = max(positionCS.z, 0.0);//min ndc z is 0.0
+		#ifndef DEPTHPASS
+			positionCS.z = max(positionCS.z, 0.0);//min ndc z is 0.0
+		#endif
 	#endif
 
 	
 	#ifdef SHADOW_SPOT
-	
-		positionCS.z = positionCS.z-u_ShadowBias.x/positionCS.w;
-		positionCS.z = max(positionCS.z, 0.0);//min ndc z is 0.0
+		#ifndef DEPTHPASS
+			positionCS.z = positionCS.z-u_ShadowBias.x/positionCS.w;
+			positionCS.z = max(positionCS.z, 0.0);//min ndc z is 0.0
+		#endif
 	#endif
 	
 	


### PR DESCRIPTION
DepthPass
修改深度Pass，兼容深度图和阴影图获取深度的方式差异
Camera
重构Camera渲染标记
增加渲染优化参数canBlitDepth，主流程的渲染深度图可以直接作用于后期处理
增加设置Camera的深度贴图格式，增加深度图32位以及模板图
解决iOS中使用CopyTexSubImage2D特别慢的bug