### PR TITLE
修复正交相机下 物体排序距离计算错误bug

### DIFF
--- a/src/layaAir/laya/d3/core/scene/Scene3D.ts
+++ b/src/layaAir/laya/d3/core/scene/Scene3D.ts
@@ -1144,6 +1144,7 @@ export class Scene3D extends Sprite implements ISubmit, ICreateResource {
 		cameraCullInfo.cullingMask = camera.cullingMask;
 		cameraCullInfo.boundFrustum = camera.boundFrustum;
 		cameraCullInfo.useOcclusionCulling = camera.useOcclusionCulling;
+		cameraCullInfo.orthographic = camera.orthographic;
 		FrustumCulling.renderObjectCulling(cameraCullInfo, this, context, shader, replacementTag, false);
 	}
 

--- a/src/layaAir/laya/d3/graphics/FrustumCulling.ts
+++ b/src/layaAir/laya/d3/graphics/FrustumCulling.ts
@@ -33,6 +33,8 @@ export class CameraCullInfo {
 	boundFrustum: BoundFrustum;
 	/**遮挡标记 */
 	cullingMask: number;
+	/**是否正交 */
+	orthographic:boolean;
 }
 /**
  * 阴影裁剪数据
@@ -103,7 +105,14 @@ export class FrustumCulling {
 				Stat.frustumCulling++;
 				if (!cameraCullInfo.useOcclusionCulling || render._needRender(boundFrustum, context)) {
 					render._renderMark = loopCount;
-					render._distanceForSort = Vector3.distance(render.bounds.getCenter(), camPos);//TODO:合并计算浪费,或者合并后取平均值
+
+					//@fix 修复正交相机下 物体距离计算错误 导致排序出错
+					if (cameraCullInfo.orthographic) {
+						render._distanceForSort = Vector3.dot(boundFrustum.near.normal, render.bounds.getCenter());
+					} else {
+						render._distanceForSort = Vector3.distance(render.bounds.getCenter(), camPos);//TODO:合并计算浪费,或者合并后取平均值
+					}
+					
 					var elements: RenderElement[] = render._renderElements;
 					for (var j: number = 0, m: number = elements.length; j < m; j++)
 						elements[j]._update(scene, context, customShader, replacementTag);


### PR DESCRIPTION
复现环境：
1 类似瓦片地图上 摆放多个面片半透物体
2 摄像机为正交  物体为transparent队列
3 拖动相机  可以看到物体的排序前后关系是错乱的   
