### PR TITLE
更正从缓存池中获取 HTMLParse 实例错误

### DIFF
--- a/src/layaAir/laya/html/utils/HTMLParse.ts
+++ b/src/layaAir/laya/html/utils/HTMLParse.ts
@@ -34,7 +34,9 @@ export class HTMLParse {
      * @param type
      */
     static getInstance(type: string): any {
-        var rst: any = Pool.getItem(HTMLParse._htmlClassMapShort[type]);
+	var cls = HTMLParse._htmlClassMapShort[type];
+	var clsName = HTMLElement.getClassName(cls);
+        var rst: any = Pool.getItemByClass(clsName, cls);
         if (!rst) {
             rst = ClassUtils.getInstance(type);
         }


### PR DESCRIPTION
HTMLParse._htmlClassMapShort[type]  获取到的是一个 Class , 这里需要改成获取类名。