### PR TITLE
fix parse data with 'gravity' property doesn't work

### DIFF
--- a/src/layaAir/laya/d3/physics/Rigidbody3D.ts
+++ b/src/layaAir/laya/d3/physics/Rigidbody3D.ts
@@ -526,8 +526,9 @@ export class Rigidbody3D extends PhysicsTriggerComponent {
 		}
 
 		if (data.gravity) {
-			this.gravity.fromArray(data.gravity);
-			this.gravity = this.gravity;
+			var gravity = this.gravity;
+			gravity.fromArray(data.gravity);
+			this.gravity = gravity;
 		}
 		super._parse(data);
 		this._parseShape(data.shapes);


### PR DESCRIPTION
before
`if (data.gravity) {
			this.gravity.fromArray(data.gravity);
			this.gravity = this.gravity;
		}`

after
`if (data.gravity) {
			var gravity = this.gravity;
			gravity.fromArray(data.gravity);
			this.gravity = gravity;
		}`