### PR TITLE
fix:Fix the bug where, if a 9-grid image contains transparent areas a…

### DIFF
--- a/src/layaAir/laya/resource/Context.ts
+++ b/src/layaAir/laya/resource/Context.ts
@@ -2544,10 +2544,46 @@ export class Context {
 
         var uv = tex.uv, w: number = tex.bitmap.width, h: number = tex.bitmap.height;
 
+        let ox = tex.offsetX;
+        let oy = tex.offsetY;
+
+        let sw = tex.sourceWidth;
+        let sh = tex.sourceHeight;
+
+        let ow = sw - tex.width - ox;
+        let oh = sh - tex.height - oy;
+
         var top: number = sizeGrid[0];
+        top -= oy;
+        if (0 > top) {
+            oy += top;
+            top = 0;
+        }
+        ty += oy;
+
         var left: number = sizeGrid[3];
+        left -= ox;
+        if (0 > left) {
+            ox += left;
+            left = 0;
+        }
+        tx += ox;
+
         var right: number = sizeGrid[1];
+        right -= ow;
+        if (0 > right) {
+            ow += right;
+            right = 0;
+        }
         var bottom: number = sizeGrid[2];
+        bottom -= oh;
+        if (0 > bottom) {
+            oh += bottom;
+            bottom = 0;
+        }
+        width -= ox + ow;
+        height -= oy + oh;
+
         var repeat: boolean = sizeGrid[4];
         var needClip: boolean = false;
 


### PR DESCRIPTION
…nd the option to trim the surrounding empty space is selected during the release of the texture after cropping, it results in incorrect size and position.(修复9宫格图片如果有透明区域，剪裁后发布纹理的时候勾选了剪裁图片周边空白，会出现大小位置不对的BUG)