### PR TITLE
fix 修复滚动系数太高导致滑动时画面明显卡顿

### DIFF
--- a/src/layaAir/laya/ui/ScrollBar.ts
+++ b/src/layaAir/laya/ui/ScrollBar.ts
@@ -41,7 +41,7 @@ import { AssetDb } from "../resource/AssetDb";
  */
 export class ScrollBar extends UIComponent {
     /**滚动衰减系数*/
-    rollRatio: number = 0.97;
+    rollRatio: number = 0.9;
     /**滚动变化时回调，回传value参数。*/
     changeHandler: Handler;
     /**是否缩放滑动条，默认值为true。 */


### PR DESCRIPTION
0.97滚动系数太高，卡顿非常明显，只能降低系数，或者希望官方想个较好办法。