### PR TITLE
fix:Bug caused by not checking for a null value in playStateInfo.anim…

### DIFF
--- a/src/layaAir/laya/d3/component/Animator/Animator.ts
+++ b/src/layaAir/laya/d3/component/Animator/Animator.ts
@@ -351,16 +351,12 @@ export class Animator extends Component {
 
         let clip = stateInfo._clip;
         let events = clip!._animationEvents;
-        if (!events || 0 == events.length) return;
+        if (!events || 0 == events.length || null == playStateInfo.animatorState) return;
         let clipDuration = clip!._duration;
         let time = playStateInfo._normalizedPlayTime * clipDuration;
         let parentPlayTime = playStateInfo._parentPlayTime;
         if (null == parentPlayTime) {
-            if (null == playStateInfo.animatorState) {
-                parentPlayTime = 0;
-            } else {
-                parentPlayTime = clipDuration * playStateInfo.animatorState.clipStart;
-            }
+            parentPlayTime = clipDuration * playStateInfo.animatorState.clipStart;
         }
         if (time < parentPlayTime) {
             this._eventScript(events, parentPlayTime, clipDuration * playStateInfo.animatorState.clipEnd);


### PR DESCRIPTION
…atorState when fixing the 3D animation execution script event, leading to a NullPointerException.(修正3D动画执行脚本事件的时候playStateInfo.animatorState为空未判断造成空指针异常的bug)