### PR TITLE
fix: Update the maskLayer index, or remove it after Dialog destroyed.

### DIFF
--- a/src/layaAir/laya/ui/Dialog.ts
+++ b/src/layaAir/laya/ui/Dialog.ts
@@ -295,6 +295,7 @@ export class Dialog extends View {
         this.closeEffect = null;
         this._dragArea = null;
         super.destroy(destroyChild);
+        Dialog.manager._checkMask();
     }
 
     /**

--- a/src/layaAir/laya/ui/DialogManager.ts
+++ b/src/layaAir/laya/ui/DialogManager.ts
@@ -32,13 +32,13 @@ export class DialogManager extends Sprite {
     lockLayer: Sprite;
 
     /**@private 全局默认弹出对话框效果，可以设置一个效果代替默认的弹出效果，如果不想有任何效果，可以赋值为null*/
-    popupEffect = (dialog: Dialog)=>{
+    popupEffect = (dialog: Dialog) => {
         dialog.scale(1, 1);
         dialog._effectTween = Tween.from(dialog, { x: ILaya.stage.width / 2, y: ILaya.stage.height / 2, scaleX: 0, scaleY: 0 }, 300, Ease.backOut, Handler.create(this, this.doOpen, [dialog]), 0, false, false);
     }
 
     /**@private 全局默认关闭对话框效果，可以设置一个效果代替默认的关闭效果，如果不想有任何效果，可以赋值为null*/
-    closeEffect = (dialog: Dialog)=>{
+    closeEffect = (dialog: Dialog) => {
         dialog._effectTween = Tween.to(dialog, { x: ILaya.stage.width / 2, y: ILaya.stage.height / 2, scaleX: 0, scaleY: 0 }, 300, Ease.strongOut, Handler.create(this, this.doClose, [dialog]), 0, false, false);
     }
 
@@ -219,6 +219,7 @@ export class DialogManager extends Sprite {
 
     /**@internal 发生层次改变后，重新检查遮罩层是否正确*/
     _checkMask(): void {
+        if (this._destroyed) return;
         this.maskLayer.removeSelf();
         for (var i: number = this.numChildren - 1; i > -1; i--) {
             var dialog: Dialog = (<Dialog>this.getChildAt(i));


### PR DESCRIPTION
实际项目中遇到的问题。

**一句话描述：**
dialog.destroy() 之后，会遗留遮罩层。

**稍微复杂的逻辑：**
调用 dialog.close() 之后，在 dialog.closeEffect 中的 **tween 执行完毕前如果 dialog 被 destroy 了**，那么就不会执行到 DialogManager 中的 doClose（即 Tween 的 complete 不会被执行）。此时 doClose 中用于更新 maskLayer 的 _checkMask 方法也就没有机会执行，结果就是弹窗关闭了，但是遮罩层还在。

**dialog.close() 的 tween 执行完毕前调用 dialog.destroy() 这个场景是普遍存在的**
比如当前场景 (Scene.autoDestroyAtClosed = true) 中打开的 Dialog 弹窗上点击退出游戏副本，
此时的逻辑通常是关闭 Dialog 弹窗，并跳转到新的场景 ( Scene.open("......", true) ) 并自动关闭当前场景，
在 scene.onDestroy() 中清理内存时会调用 dialog.destroy()，此时就会触发上述逻辑。
