### PR TITLE
fix: clear all timer listeners while Node.destroy()

### DIFF
--- a/src/layaAir/laya/display/Node.ts
+++ b/src/layaAir/laya/display/Node.ts
@@ -176,7 +176,7 @@ export class Node extends EventDispatcher {
 
     /**
      * <p>销毁此对象。destroy对象默认会把自己从父节点移除，并且清理自身引用关系，等待js自动垃圾回收机制回收。destroy后不能再使用。</p>
-     * <p>destroy时会移除自身的事情监听，自身的timer监听，移除子对象及从父节点移除自己。</p>
+     * <p>destroy时会移除自身的事件监听，自身的timer监听，移除子对象及从父节点移除自己。</p>
      * @param destroyChild	（可选）是否同时销毁子节点，若值为true,则销毁子节点，否则不销毁子节点。
      */
     destroy(destroyChild: boolean = true): void {
@@ -195,6 +195,8 @@ export class Node extends EventDispatcher {
 
         //移除所有事件监听
         this.offAll();
+        //移除所有timer监听
+        this.timer.clearAll(this);
     }
 
     /**


### PR DESCRIPTION
Node.destroy( ) 方法的文档注释中提到会移除自身的timer监听，但代码中并没有这个逻辑，给补上。