### PR TITLE
fix：Spine

### DIFF
--- a/src/layaAir/laya/spine/optimize/SketonOptimise.ts
+++ b/src/layaAir/laya/spine/optimize/SketonOptimise.ts
@@ -18,6 +18,9 @@ import { ISpineOptimizeRender } from "./interface/ISpineOptimizeRender";
 
 export class SketonOptimise implements IPreRender {
     static normalRenderSwitch: boolean = false;
+    /** optimise render的最大骨骼数 */
+    static MAX_BONES = 100;
+    
     static cacheSwitch: boolean = false;
     canCache: boolean;
     sketon: spine.Skeleton;
@@ -46,6 +49,10 @@ export class SketonOptimise implements IPreRender {
     _initSpineRender(skeleton: spine.Skeleton, templet: SpineTemplet, renderNode: Spine2DRenderNode, state: spine.AnimationState): ISpineOptimizeRender {
         let sp: ISpineOptimizeRender;
         if (SketonOptimise.normalRenderSwitch) {
+            sp = new SpineNormalRender();
+        }
+        else if (this.maxBoneNumber > SketonOptimise.MAX_BONES) {
+            console.warn("The number of Bones :" , this.maxBoneNumber ," > " , SketonOptimise.MAX_BONES , ", use CPU caculation");
             sp = new SpineNormalRender();
         }
         else {


### PR DESCRIPTION
When the number of bones exceeds the preset maximum value, use CPU calculation.（当骨骼数大于预设最大值时）