### PR TITLE
fix : Spine And ShurikenParticle.clone BUG

### DIFF
--- a/src/layaAir/laya/d3/core/particleShuriKen/module/FrameOverTime.ts
+++ b/src/layaAir/laya/d3/core/particleShuriKen/module/FrameOverTime.ts
@@ -163,8 +163,16 @@ export class FrameOverTime implements IClone {
 		(this._overTime) && (this._overTime.cloneTo(destFrameOverTime._overTime));
 		destFrameOverTime._constantMin = this._constantMin;
 		destFrameOverTime._constantMax = this._constantMax;
-		(this._overTimeMin) && (this._overTimeMin.cloneTo(destFrameOverTime._overTimeMin));
-		(this._overTimeMax) && (this._overTimeMax.cloneTo(destFrameOverTime._overTimeMax));
+		
+		if(this._overTimeMin){
+			if(!destFrameOverTime._overTimeMin) destFrameOverTime._overTimeMin = this._overTime.clone();
+			else this._overTimeMin.cloneTo(destFrameOverTime._overTimeMin);
+		}
+		
+		if (this._overTimeMax) {
+			if(!destFrameOverTime._overTimeMax) destFrameOverTime._overTimeMax = this._overTimeMax.clone();
+			this._overTimeMax.cloneTo(destFrameOverTime._overTimeMax)
+		}
 	}
 
 	/**

--- a/src/layaAir/laya/spine/Spine2DRenderNode.ts
+++ b/src/layaAir/laya/spine/Spine2DRenderNode.ts
@@ -410,6 +410,10 @@ export class Spine2DRenderNode extends BaseRenderNode2D implements ISpineSkeleto
         } else
             this.spineItem = this._templet.sketonOptimise._initSpineRender(this._skeleton, this._templet, this, this._state);
 
+        let sprite = this.owner as Sprite;
+        sprite.width = templet.width;
+        sprite.height = templet.height;
+
         let skinIndex = this._templet.getSkinIndexByName(this._skinName);
         if (skinIndex != -1)
             this.showSkinByIndex(skinIndex);
@@ -873,7 +877,7 @@ export class Spine2DRenderNode extends BaseRenderNode2D implements ISpineSkeleto
         for (var i = 0, n = elements.length; i < n; i++) {
             let element = Spine2DRenderNode.createRenderElement2D();
             element.geometry.bufferState = geo.bufferState;
-            element.geometry.indexFormat = IndexFormat.UInt16;
+            element.geometry.indexFormat = geo.indexFormat;
             element.geometry.clearRenderParams();
             element.geometry.setDrawElemenParams(elements[i][1], elements[i][2]);
             let material = elements[i][0];
@@ -907,15 +911,23 @@ export class Spine2DRenderNode extends BaseRenderNode2D implements ISpineSkeleto
      * @en Draw a single geometry
      * @param geo Render geometry element
      * @param material Material to use for rendering
+     * @param count indexCount
+     * @param offset startIndex
      * @zh 绘制单个几何体
      * @param geo 渲染几何元素
      * @param material 用于渲染的材质
+     * @param count 索引数量
+     * @param offset 起始索引
      */
-    drawGeo(geo: IRenderGeometryElement, material: Material) {
+    drawGeo(geo: IRenderGeometryElement, material: Material , count:number , offset:number ) {
         let element = Spine2DRenderNode.createRenderElement2D();
-        element.geometry = geo;
-        // geo.clearRenderParams();
-        // geo.setDrawElemenParams(geo.bufferState._bindedIndexBuffer.indexCount, 0);
+        let eleGeo = element.geometry;
+        eleGeo.bufferState = geo.bufferState;
+        eleGeo.indexFormat = geo.indexFormat;
+        eleGeo.instanceCount = geo.instanceCount;
+        eleGeo.clearRenderParams();
+        eleGeo.setDrawElemenParams(count , offset);
+
         this._renderElements.push(element);
         if (this._materials[0] != null) {
             let rendernodeMaterial = this._materials[0];
@@ -1022,6 +1034,8 @@ class TimeKeeper {
      * @zh 更新时间管理器
      */
     update() {
+        // this.delta =1 / 30;
+
         this.delta = this.timer.delta / 1000;
         if (this.delta > this.maxDelta)
             this.delta = this.maxDelta;

--- a/src/layaAir/laya/spine/SpineTemplet.ts
+++ b/src/layaAir/laya/spine/SpineTemplet.ts
@@ -32,6 +32,10 @@ export class SpineTemplet extends Resource {
     private _textures: Record<string, Texture2D>;
     private _basePath: string;
 
+    width:number;
+
+    height:number;
+
     /**
      * @en Indicates if slot is needed
      * @zh 是否需要插槽
@@ -43,7 +47,6 @@ export class SpineTemplet extends Resource {
      * @zh 骨骼优化对象
      */
     sketonOptimise: SketonOptimise;
-
 
     /** @ignore */
     constructor() {
@@ -149,6 +152,8 @@ export class SpineTemplet extends Resource {
         this._textures = textures;
         this.mainBlendMode = this.skeletonData.slots[0]?.blendMode || 0;
         this.mainTexture = this._mainTexture;
+        this.width = this.skeletonData.width;
+        this.height = this.skeletonData.height;
         this.sketonOptimise.checkMainAttach(this.skeletonData);
     }
 

--- a/src/layaAir/laya/spine/optimize/SpineOptimizeRender.ts
+++ b/src/layaAir/laya/spine/optimize/SpineOptimizeRender.ts
@@ -400,7 +400,7 @@ export class SpineOptimizeRender implements ISpineOptimizeRender {
                     this.renderProxytype = ERenderProxyType.RenderOptimize;
                 }
                 else {
-                    currentRender.material && this._nodeOwner.drawGeo(currentRender.geo, currentRender.material);
+                    // currentRender.material && this._nodeOwner.drawGeo(currentRender.geo, currentRender.material , 0 ,0);
                     this.renderProxytype = ERenderProxyType.RenderOptimize;
                 }
                 this._isRender = true;
@@ -876,12 +876,10 @@ class SkinRender implements IVBIBUpdate {
      */
     updateIB(indexArray: Uint16Array, ibLength: number, mutiRenderData: MultiRenderData, isMuti: boolean) {
         let ib = this.ib;
-        let iblen = ibLength * 2;
-        ib._setIndexDataLength(iblen)
-        ib._setIndexData(new Uint16Array(indexArray.buffer, 0, iblen / 2), 0);
-        this.geo.clearRenderParams();
-        this.geo.setDrawElemenParams(iblen / 2, 0);
-        this.ib.indexCount = iblen / 2;
+        ib._setIndexDataLength(ibLength * 2)
+        ib._setIndexData(new Uint16Array(indexArray.buffer, 0, ibLength), 0);
+        ib.indexCount = ibLength;
+        
         if (isMuti) {
             let elementsCreator = this.elementsMap.get(mutiRenderData.id);
             if (!elementsCreator) {
@@ -901,7 +899,7 @@ class SkinRender implements IVBIBUpdate {
             }
             if (material != this.material) {
                 this.owner._nodeOwner.clear();
-                this.owner._nodeOwner.drawGeo(this.geo, material);
+                this.owner._nodeOwner.drawGeo(this.geo, material , ibLength ,  0);
             }
         }
     }
@@ -920,9 +918,9 @@ class SkinRender implements IVBIBUpdate {
         if (this.hasNormalRender) {
             this._renerer = SpineAdapter.createNormalRender(templet, false);
         }
-        if (templet.mainTexture) {
-            this.material = templet.getMaterial(templet.mainTexture, templet.mainBlendMode);
-        }
+        // if (templet.mainTexture) {
+        //     this.material = templet.getMaterial(templet.mainTexture, templet.mainBlendMode);
+        // }
     }
 
     /**


### PR DESCRIPTION
1.Data residue resulting from switching from the RandomTwoConstant type to other types causes errors during cloning.(RandomTwoConstant类型换到别的类型产生的数据残留，导致clone时报错)
2.Reusing RenderElement and setting its geometry causes rendering state errors in subsequent uses.(重复使用的 RenderElement 设置 geo 导致下一次使用渲染状态错误)
3.Planning to add spine width and height functionality.(准备增加spine宽高功能)