### PR TITLE
Update:Spine

### DIFF
--- a/src/layaAir/laya/spine/Spine2DRenderNode.ts
+++ b/src/layaAir/laya/spine/Spine2DRenderNode.ts
@@ -29,6 +29,7 @@ import { SpineEmptyRender } from "./optimize/SpineEmptyRender";
 import { Texture2D } from "../resource/Texture2D";
 import { Sprite } from "../display/Sprite";
 import { Color } from "../maths/Color";
+import { Rectangle } from "../maths/Rectangle";
 
 /**
  * @en The spine animation consists of three parts: `SpineTemplet`, `SpineSkeletonRender`, and `SpineSkeleton`.
@@ -179,7 +180,7 @@ export class Spine2DRenderNode extends BaseRenderNode2D implements ISpineSkeleto
         this._spriteShaderData.setBuffer(SpineShaderInit.NMatrix, buffer);
         Vector2.TempVector2.setValue(context.width, context.height);
         this._spriteShaderData.setVector2(SpineShaderInit.Size, Vector2.TempVector2);
-        context.globalAlpha
+        // context.globalAlpha
         if (this._oldAlpha !==  context.globalAlpha) {
             let scolor = this.spineItem.getSpineColor();
             let a = scolor.a *  context.globalAlpha;
@@ -411,9 +412,14 @@ export class Spine2DRenderNode extends BaseRenderNode2D implements ISpineSkeleto
             this.spineItem = this._templet.sketonOptimise._initSpineRender(this._skeleton, this._templet, this, this._state);
 
         let sprite = this.owner as Sprite;
-        sprite.width = templet.width;
-        sprite.height = templet.height;
-
+        let boundsStyle = sprite._getBoundsStyle();
+        let userBounds = boundsStyle.userBounds;
+        if (!userBounds) {
+            userBounds = boundsStyle.userBounds = new Rectangle;
+        }
+        userBounds.setTo(sprite.x + templet.offsetX  , sprite.y - templet.offsetY - templet.height , templet.width , templet.height );
+        sprite.autoSize = true;
+        
         let skinIndex = this._templet.getSkinIndexByName(this._skinName);
         if (skinIndex != -1)
             this.showSkinByIndex(skinIndex);

--- a/src/layaAir/laya/spine/SpineTemplet.ts
+++ b/src/layaAir/laya/spine/SpineTemplet.ts
@@ -31,11 +31,26 @@ export class SpineTemplet extends Resource {
 
     private _textures: Record<string, Texture2D>;
     private _basePath: string;
-
+    /**
+     * @en Base width of spine animation
+     * @zh spine 动画基础宽度
+     */
     width:number;
-
+    /**
+     * @en Base height of spine animation
+     * @zh spine 动画基础高度
+     */
     height:number;
-
+    /**
+     * @en X-axis offset of spine animation
+     * @zh spine 动画X轴偏移
+     */
+    offsetX:number;
+    /**
+     * @en Y-axis offset of spine animation
+     * @zh spine 动画Y轴偏移
+     */
+    offsetY:number;
     /**
      * @en Indicates if slot is needed
      * @zh 是否需要插槽
@@ -154,6 +169,8 @@ export class SpineTemplet extends Resource {
         this.mainTexture = this._mainTexture;
         this.width = this.skeletonData.width;
         this.height = this.skeletonData.height;
+        this.offsetX = this.skeletonData.x;
+        this.offsetY = this.skeletonData.y;
         this.sketonOptimise.checkMainAttach(this.skeletonData);
     }
 

--- a/src/layaAir/laya/spine/SpineTempletLoader.ts
+++ b/src/layaAir/laya/spine/SpineTempletLoader.ts
@@ -1,6 +1,7 @@
 import { Laya } from "../../Laya";
 import { IResourceLoader, ILoadTask, Loader, ILoadURL } from "../net/Loader";
 import { URL } from "../net/URL";
+import { TextureFormat } from "../RenderEngine/RenderEnum/TextureFormat";
 import { Texture2D } from "../resource/Texture2D";
 import { Utils } from "../utils/Utils";
 import { SpineTemplet } from "./SpineTemplet";
@@ -52,7 +53,8 @@ class SpineTempletLoader implements IResourceLoader {
                 url, type: Loader.TEXTURE2D,
                 propertyParams: {
                     premultiplyAlpha: true
-                }
+                },
+                constructParams:[0,0,TextureFormat.R8G8B8A8,false,false,true,true]
             });
             return new SpineTexture(null);
         });
@@ -106,7 +108,8 @@ class SpineTempletLoader implements IResourceLoader {
                 type: Loader.TEXTURE2D,
                 propertyParams: {
                     premultiplyAlpha: true
-                }
+                },
+                constructParams:[0,0,TextureFormat.R8G8B8A8,false,false,true,true]
             }
         }),
             null, task.progress?.createCallback()).then((res: Array<Texture2D>) => {

--- a/src/layaAir/laya/spine/material/SpineShaderInit.ts
+++ b/src/layaAir/laya/spine/material/SpineShaderInit.ts
@@ -175,10 +175,16 @@ export class SpineShaderInit {
         'a_pos': [2, ShaderDataType.Vector2],
         "a_weight": [3, ShaderDataType.Float],
         "a_BoneId": [4, ShaderDataType.Float],
-
         'a_PosWeightBoneID_2': [5, ShaderDataType.Vector4],
         'a_PosWeightBoneID_3': [6, ShaderDataType.Vector4],
         'a_PosWeightBoneID_4': [7, ShaderDataType.Vector4],
+
+        // 'a_PosWeightBoneID_1': [2, ShaderDataType.Vector4],//pos.xy weight boneID
+        // 'a_PosWeightBoneID_2': [3, ShaderDataType.Vector4],
+        // 'a_PosWeightBoneID_3': [4, ShaderDataType.Vector4],
+        // 'a_PosWeightBoneID_4': [5, ShaderDataType.Vector4],
+        // 'a_PosWeightBoneID_5': [6, ShaderDataType.Vector4],
+        // 'a_PosWeightBoneID_6': [7, ShaderDataType.Vector4],
 
         'a_NMatrix_0': [8, ShaderDataType.Vector3],
         'a_NMatrix_1': [9, ShaderDataType.Vector3],
@@ -237,20 +243,29 @@ export class SpineShaderInit {
             new VertexElement(36, VertexElementFormat.Single, 4),
             new VertexElement(40, VertexElementFormat.Vector4, 5),
             new VertexElement(56, VertexElementFormat.Vector4, 6),
-            new VertexElement(72, VertexElementFormat.Vector4, 7)
+            new VertexElement(72, VertexElementFormat.Vector4, 7),
+            // new VertexElement(24, VertexElementFormat.Vector4, 2),
+            // new VertexElement(40, VertexElementFormat.Vector4, 3),
+            // new VertexElement(56, VertexElementFormat.Vector4, 4),
+            // new VertexElement(72, VertexElementFormat.Vector4, 5),
+            // new VertexElement(88, VertexElementFormat.Vector4, 6),
+            // new VertexElement(104, VertexElementFormat.Vector4, 6),
         ]);
 
         SpineShaderInit.SpineNormalVertexDeclaration = new VertexDeclaration(32, [
             new VertexElement(0, VertexElementFormat.Vector2, 0),
             new VertexElement(8, VertexElementFormat.Vector4, 1),
             new VertexElement(24, VertexElementFormat.Vector2, 2)
+            // new VertexElement(24, VertexElementFormat.Vector4, 2)
         ])
 
         SpineShaderInit.SpineRBVertexDeclaration = new VertexDeclaration(36, [
             new VertexElement(0, VertexElementFormat.Vector2, 0),
             new VertexElement(8, VertexElementFormat.Vector4, 1),
             new VertexElement(24, VertexElementFormat.Vector2, 2),
-            new VertexElement(32, VertexElementFormat.Single, 4)
+            new VertexElement(32, VertexElementFormat.Single, 4),
+            // new VertexElement(36, VertexElementFormat.Single, 4),
+            // new VertexElement(24, VertexElementFormat.Vector4, 2),
         ])
 
         SpineShaderInit.instanceNMatrixDeclaration = new VertexDeclaration(24 , [

--- a/src/layaAir/laya/spine/mesh/SpineVirtualMesh.ts
+++ b/src/layaAir/laya/spine/mesh/SpineVirtualMesh.ts
@@ -14,6 +14,11 @@ export class SpineVirtualMesh extends SpineMeshBase {
      */
     static vertexSize: number = 8;
     /**
+     * @en Size of each vertex in the vertex array with Two Color.
+     * @zh 双顶点色模式顶点数组中每个顶点的大小。
+     */
+    static vertexSize_TwoColor: number = 12;
+    /**
      * @en Shared vertex array for all instances.
      * @zh 所有实例共享的顶点数组。
      */
@@ -48,14 +53,15 @@ export class SpineVirtualMesh extends SpineMeshBase {
      */
     appendVerticesClip(vertices: ArrayLike<number>, indices: ArrayLike<number>) {
         let indicesLength = indices.length;
-        let verticesLength = vertices.length;
+        let vertexCount = vertices.length / 8;
         let vertexSize = SpineVirtualMesh.vertexSize;
+        let verticesLength = vertexCount * vertexSize;
         let indexStart = this.verticesLength / vertexSize;
         let vertexBuffer = this.vertexArray;
 
         let before = this.verticesLength;
         let vlen = before;
-        for (let j = 0; j < verticesLength; vlen += 8, j += 8) {
+        for (let j = 0; j < verticesLength; vlen += vertexSize, j += 8) {
             vertexBuffer[vlen] = vertices[j + 6];
             vertexBuffer[vlen + 1] = vertices[j + 7];
             vertexBuffer[vlen + 2] = vertices[j + 2];

--- a/src/layaAir/laya/spine/normal/SpineSkeletonRenderer.ts
+++ b/src/layaAir/laya/spine/normal/SpineSkeletonRenderer.ts
@@ -347,7 +347,7 @@ export class SpineSkeletonRenderer extends SpineNormalRenderBase implements ISpi
         let drawOrder = skeleton.drawOrder;
         let attachmentColor: spine.Color;
         let skeletonColor = skeleton.color;
-        let vertexSize = twoColorTint ? 12 : 8;
+        let vertexSize = twoColorTint ? SpineVirtualMesh.vertexSize_TwoColor : SpineVirtualMesh.vertexSize;
         let inRange = false;
         if (slotRangeStart == -1) inRange = true;
         let mesh: SpineVirtualMesh;
@@ -482,6 +482,7 @@ export class SpineSkeletonRenderer extends SpineNormalRenderBase implements ISpi
             clipper.clipEndWithSlot(slot);
         }
         clipper.clipEnd();
+        
         mesh && mesh.draw();
     }
 }

--- a/src/layaAir/laya/spine/optimize/AttachmentParse.ts
+++ b/src/layaAir/laya/spine/optimize/AttachmentParse.ts
@@ -78,6 +78,11 @@ export class AttachmentParse {
      * @zh 附件中的顶点数量。
      */
     vertexCount: number;
+    /**
+     * @en Indicates if normal rendering is required.
+     * @zh 指示是否需要正常渲染。
+     */
+    isNormalRender: boolean = false;
 
     /**
      * @en Initializes the attachment parser with the given parameters.
@@ -147,34 +152,27 @@ export class AttachmentParse {
                 let bones = mesh.bones;
                 let v = 0;
                 let needPoint = (vside - 6) / 4;
+                
                 for (let w = 0, b = 0; w < vertexSize; w++) {
                     let n = bones[v++];
                     n += v;
+                    let result = [];
                     let offset = w * this.stride;
                     let nid = 0;
 
-                    let result = [];
                     for (; v < n; v++, b += 3, nid++) {
                         result.push([vertices[b], vertices[b + 1], vertices[b + 2], bones[v]]);
                     }
-                    if (result.length == needPoint) {
 
-                    }
-                    else if (result.length < needPoint) {
-                        let n = needPoint - result.length;
-                        for (let i = 0; i < n; i++) {
-                            result.push([0, 0, 0, 0]);
-                        }
-                    }
-                    else {
-                        result = result.sort((a: any, b: any) => {
-                            return b[2] - a[2];
-                        });
+                    if(result.length > needPoint) {
+                        console.error(`The max number of bones (${needPoint}) that can affect a vertex in FastRender mode. `);
                         result.length = needPoint;
+                        this.isNormalRender = true;
                     }
 
-                    for (let i = 0; i < result.length; i++) {
+                    for (let i = 0; i < needPoint; i++) {
                         let v: any = result[i];
+                        if (!v) continue
                         vertexArray[offset + i * 4] = v[0];
                         vertexArray[offset + i * 4 + 1] = v[1];
                         vertexArray[offset + i * 4 + 2] = v[2];

--- a/src/layaAir/laya/spine/optimize/SketonOptimise.ts
+++ b/src/layaAir/laya/spine/optimize/SketonOptimise.ts
@@ -379,6 +379,7 @@ export class SkinAttach {
                     let deform = null;//slot.deform; TODO
                     let parse = new AttachmentParse();
                     parse.init(attach, boneIndex, i, deform, slot);
+                    if (parse.isNormalRender) this.isNormalRender = true;
                     let tempType = SlotUtils.checkAttachment(parse ? parse.sourceData : null);
                     if (tempType < type) {
                         type = tempType;


### PR DESCRIPTION
1. For a situation where more than 4 bones affect a vertex, switch to NormalRender.（针对一个顶点超过4个骨骼影响的情况，切换为NormalRender）
2. Try to add a default width and height（尝试增加一个默认的宽高）.
3. Default loading state, specify the image as srgb（默认加载状态，指定图片为srgb）.