### PR TITLE
Typo Errors Fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ npm run start
 
 #### Build
 
-In the root directory of the engine, rrun the followingcommand from the command line. After that, a build folder will be generated in the root directory, where the compiled engine is located. As shown below:
+In the root directory of the engine, run the following command from the command line. After that, a build folder will be generated in the root directory, where the compiled engine is located. As shown below:
 
 ```bash
 npm run build


### PR DESCRIPTION
Corrected "rrun" to "run" &
"followingcommand" to "following command" in [README.md].

This pull request addresses a minor typo found in the repository. The typo has been corrected to improve clarity and maintain the quality of the documentation.

This change is purely cosmetic and does not affect functionality.