### PR TITLE
fix:Spine Bug

### DIFF
--- a/src/layaAir/laya/resource/Texture2D.ts
+++ b/src/layaAir/laya/resource/Texture2D.ts
@@ -283,6 +283,8 @@ export class Texture2D extends BaseTexture {
     _canRead: boolean = false;
     /**@internal */
     _pixels: Uint8Array;
+    /** @internal */
+    _premultiplyAlpha : boolean = false;
 
     /**
      * @en Creates an instance of Texture2D.
@@ -307,6 +309,7 @@ export class Texture2D extends BaseTexture {
         this._dimension = TextureDimension.Tex2D;
         this._gammaSpace = sRGB;
         this._canRead = canRead;
+        this._premultiplyAlpha = premultiplyAlpha;
         this._texture = LayaGL.textureContext.createTextureInternal(this._dimension, width, height, format, mipmap, sRGB, premultiplyAlpha);
         return;
     }

--- a/src/layaAir/laya/spine/Spine2DRenderNode.ts
+++ b/src/layaAir/laya/spine/Spine2DRenderNode.ts
@@ -25,6 +25,10 @@ import { SpineEmptyRender } from "./optimize/SpineEmptyRender";
 import { Texture2D } from "../resource/Texture2D";
 import { Mesh2D } from "../resource/Mesh2D";
 import { Vector3 } from "../maths/Vector3";
+import { Vector4 } from "../maths/Vector4";
+import { Matrix4x4 } from "../maths/Matrix4x4";
+import { Color } from "../maths/Color";
+import { ShaderDefines2D } from "../webgl/shader/d2/ShaderDefines2D";
 
 
 /**动画开始播放调度
@@ -163,6 +167,28 @@ export class Spine2DRenderNode extends BaseRenderNode2D implements ISpineSkeleto
 
         Vector2.TEMP.setValue(context.width, context.height);
         shaderData.setVector2(BaseRenderNode2D.BASERENDERSIZE, Vector2.TEMP);
+
+        if (this._renderAlpha !==  context.globalAlpha) {
+            let scolor = this.spineItem.getSpineColor();
+            let a = scolor.a * context.globalAlpha;
+            let color = shaderData.getColor(BaseRenderNode2D.BASERENDER2DCOLOR) || new Color();
+            color.setValue(scolor.r , scolor.g , scolor.b , a);
+            shaderData.setColor(BaseRenderNode2D.BASERENDER2DCOLOR, color);
+            this._renderAlpha =  context.globalAlpha;
+        }
+        
+        // 兼容 colorfilter
+        let filter = context._colorFiler;
+        if (filter) {
+            this._spriteShaderData.addDefine(ShaderDefines2D.FILTERCOLOR);
+            Matrix4x4.TEMP.cloneByArray(filter._mat);
+            shaderData.setMatrix4x4(ShaderDefines2D.UNIFORM_COLORMAT, Matrix4x4.TEMP);
+            Vector4.TEMP.setValue(filter._alpha[0], filter._alpha[1], filter._alpha[2], filter._alpha[3]);
+            shaderData.setVector(ShaderDefines2D.UNIFORM_COLORALPHA, Vector4.TEMP);
+        }else{
+            this._spriteShaderData.removeDefine(ShaderDefines2D.FILTERCOLOR);
+        }
+
         context._copyClipInfoToShaderData(shaderData);
 
         this._lightReceive && this._updateLight();
@@ -505,11 +531,10 @@ export class Spine2DRenderNode extends BaseRenderNode2D implements ISpineSkeleto
         state.update(delta);
 
         //@ts-ignore
-        this._currentPlayTime = state.getCurrentPlayTime(this.trackIndex);
+        let currentPlayTime = this._currentPlayTime = state.getCurrentPlayTime(this.trackIndex);
 
         // 使用当前动画和事件设置骨架
         state.apply(this._skeleton);
-
 
         // spine在state.apply中发送事件，开发者可能会在事件中进行destory等操作，导致无法继续执行
         if (!this._state || !this._skeleton) {
@@ -517,7 +542,7 @@ export class Spine2DRenderNode extends BaseRenderNode2D implements ISpineSkeleto
         }
         // 计算骨骼的世界SRT(world SRT)
         this._skeleton.updateWorldTransform();
-        this.spineItem.render(this._currentPlayTime);
+        this.spineItem.render(currentPlayTime);
         this.owner.repaint();
     }
 
@@ -597,7 +622,8 @@ export class Spine2DRenderNode extends BaseRenderNode2D implements ISpineSkeleto
             this._pause = true;
             this._clearUpdate();
             //this.timer.clear(this, this._update);
-            this._state.update(-this._currentPlayTime);
+            // this._state.update(-this._currentPlayTime);
+            this._state.clearTrack(this.trackIndex);
             this._currentPlayTime = 0;
             this.event(Event.STOPPED);
 
@@ -843,7 +869,7 @@ export class Spine2DRenderNode extends BaseRenderNode2D implements ISpineSkeleto
             // renderNode._materials.push(mat);
         } else {
             mat = this._materials[this._renderElements.length];
-            SpineShaderInit.SetSpineBlendMode(blendMode, mat);
+            SpineShaderInit.SetSpineBlendMode(blendMode, mat , this.templet.premultipliedAlpha);
             mat.setTextureByIndex(SpineShaderInit.SpineTexture, texture);
         }
         return mat;

--- a/src/layaAir/laya/spine/SpineTemplet.ts
+++ b/src/layaAir/laya/spine/SpineTemplet.ts
@@ -70,6 +70,7 @@ export class SpineTemplet extends Resource {
         this._textures = {};
         this.sketonOptimise = new SketonOptimise();
     }
+
     /** @internal */
     get _mainTexture(): Texture2D {
         let i = 0;
@@ -97,6 +98,16 @@ export class SpineTemplet extends Resource {
      * @zh Spine动画的主混合模式
      */
     mainBlendMode: number = 0;
+
+    private _premultipliedAlpha = true;
+    /**
+     * @en Switch for premultipliedAlpha.
+     * @zh 透明预乘的开关。
+     */
+    public get premultipliedAlpha() {
+        return this._premultipliedAlpha;
+    }
+   
 
     /**
      * @en The base path of the Spine animation resources
@@ -127,12 +138,20 @@ export class SpineTemplet extends Resource {
             mat.setShaderName("SpineStandard");
             SpineShaderInit.initSpineMaterial(mat);
             mat.setTextureByIndex(SpineShaderInit.SpineTexture, texture);
+
             if (texture.gammaCorrection != 1) {
                 mat.addDefine(ShaderDefines2D.GAMMATEXTURE);
             } else {
                 mat.removeDefine(ShaderDefines2D.GAMMATEXTURE);
             }
-            SpineShaderInit.SetSpineBlendMode(blendMode, mat);
+
+            SpineShaderInit.SetSpineBlendMode(blendMode, mat , this.premultipliedAlpha);
+
+            if (this._premultipliedAlpha) {
+                mat.addDefine(SpineShaderInit.SPINE_PREMULTIPLYALPHA);
+            }else{
+                mat.removeDefine(SpineShaderInit.SPINE_PREMULTIPLYALPHA);
+            }
             //mat.color = this.owner.spineColor;
             //mat.setVector2("u_size",new Vector2(Laya.stage.width,Laya.stage.height));
             mat._addReference();
@@ -152,7 +171,7 @@ export class SpineTemplet extends Resource {
     }
 
     /** @internal */
-    _parse(desc: string | ArrayBuffer, atlas: spine.TextureAtlas, textures: Record<string, Texture2D>): void {
+    _parse(desc: string | ArrayBuffer, atlas: spine.TextureAtlas, textures: Record<string, Texture2D> , premultipliedAlpha = true): void {
 
         let atlasLoader = new spine.AtlasAttachmentLoader(atlas);
         if (desc instanceof ArrayBuffer) {
@@ -172,7 +191,8 @@ export class SpineTemplet extends Resource {
         this.height = this.skeletonData.height;
         this.offsetX = this.skeletonData.x;
         this.offsetY = this.skeletonData.y;
-        this.sketonOptimise.checkMainAttach(this.skeletonData);
+        this._premultipliedAlpha = premultipliedAlpha;
+        this.sketonOptimise.checkMainAttach(this.skeletonData );
     }
 
     /**

--- a/src/layaAir/laya/spine/SpineTempletLoader.ts
+++ b/src/layaAir/laya/spine/SpineTempletLoader.ts
@@ -7,6 +7,7 @@ import { Utils } from "../utils/Utils";
 import { SpineTemplet } from "./SpineTemplet";
 import { SpineTexture } from "./SpineTexture";
 
+const _premultipliedAlpha = false;
 /**
  * @en SpineTempletLoader class used for loading Spine skeleton data and atlas.
  * @zh SpineTempletLoader 类用于加载 Spine 骨骼数据和图集。
@@ -52,7 +53,7 @@ class SpineTempletLoader implements IResourceLoader {
             atlasPages.push({
                 url, type: Loader.TEXTURE2D,
                 propertyParams: {
-                    premultiplyAlpha: true
+                    premultiplyAlpha: _premultipliedAlpha
                 },
                 constructParams:[0,0,TextureFormat.R8G8B8A8,false,false,true,true]
             });
@@ -61,11 +62,13 @@ class SpineTempletLoader implements IResourceLoader {
 
         return Laya.loader.load(atlasPages, null, task.progress?.createCallback()).then((res: Array<Texture2D>) => {
             let textures: Record<string, Texture2D> = {}
+            let premultipliedAlpha = true;
 
             for (var i = 0; i < res.length; i++) {
                 let tex = res[i];
                 if (tex) tex._addReference();
                 let pages = atlas.pages;
+                premultipliedAlpha = tex._premultiplyAlpha && premultipliedAlpha;
                 // 默认长度 = 1
                 let page = pages[i];
                 //@ts-ignore
@@ -94,7 +97,7 @@ class SpineTempletLoader implements IResourceLoader {
                 }
             }
 
-            templet._parse(desc, atlas, textures);
+            templet._parse(desc, atlas, textures , premultipliedAlpha);
             return templet;
         });
     }
@@ -107,7 +110,7 @@ class SpineTempletLoader implements IResourceLoader {
                 url: basePath + page.name,
                 type: Loader.TEXTURE2D,
                 propertyParams: {
-                    premultiplyAlpha: true
+                    premultiplyAlpha: _premultipliedAlpha
                 },
                 constructParams:[0,0,TextureFormat.R8G8B8A8,false,false,true,true]
             }
@@ -115,16 +118,18 @@ class SpineTempletLoader implements IResourceLoader {
             null, task.progress?.createCallback()).then((res: Array<Texture2D>) => {
                 let textures: Record<string, Texture2D> = {}
                 let pages = atlas.pages;
+                let premultipliedAlpha = true;
                 for (let i = 0, len = res.length; i < len; i++) {
                     let tex = res[i];
                     if (tex) tex._addReference();
+                    premultipliedAlpha = tex._premultiplyAlpha && premultipliedAlpha;
                     let page = pages[i];
                     textures[page.name] = tex;
                     //@ts-ignore
                     page.setTexture(new SpineTexture(tex));
                 }
 
-                templet._parse(desc, atlas, textures);
+                templet._parse(desc, atlas, textures , premultipliedAlpha);
                 return templet;
             });
     }

--- a/src/layaAir/laya/spine/files/SpineFragment.glsl
+++ b/src/layaAir/laya/spine/files/SpineFragment.glsl
@@ -6,16 +6,17 @@
 vec4 getColor(){
     vec4 color = texture2D(u_spineTexture, v_texcoord.xy);//vec4(1.0,0.0,0.0,1.0);
     #ifndef GAMMATEXTURE
-        //��linear����
+        //linear
         #ifdef GAMMASPACE
             color.xyz = linearToGamma(color.xyz);    
         #endif
     #else
-        //gamma����
+        //gamma
         #ifndef GAMMASPACE
             color.xyz = gammaToLinear(color.xyz);
         #endif
     #endif
+    
     return color*v_color;
 }
 

--- a/src/layaAir/laya/spine/files/SpineVertex.glsl
+++ b/src/layaAir/laya/spine/files/SpineVertex.glsl
@@ -121,6 +121,11 @@ void getVertexInfo(vec4 pos, inout vertexInfo info){
         info.color = a_color;
     #endif
     info.color *= u_baseRenderColor;
+
+    #ifdef PREMULTIPLYALPHA
+        info.color.rgb = info.color.rgb * info.color.a;
+    #endif
+    
     #ifdef UV
         info.uv = a_uv;
     #endif

--- a/src/layaAir/laya/spine/material/SpineShaderInit.ts
+++ b/src/layaAir/laya/spine/material/SpineShaderInit.ts
@@ -42,11 +42,13 @@ export class SpineShaderInit {
      * @en Set the blend mode for Spine material.
      * @param value The blend mode value.
      * @param mat The material to set the blend mode for.
+     * @param premultipliedAlpha Whether to premultiply the alpha channel.
      * @zh 设置 Spine 材质的混合模式。
      * @param value 混合模式值。
      * @param mat 要设置混合模式的材质。
+     * @param premultipliedAlpha 是否预乘alpha通道。
      */
-    static SetSpineBlendMode(value: number, mat: Material) {
+    static SetSpineBlendMode(value: number, mat: Material , premultipliedAlpha = true) {
         switch (value) {
             case 1: //Additive 
                 mat.blend = RenderState.BLEND_ENABLE_ALL;
@@ -69,8 +71,7 @@ export class SpineShaderInit {
                 break;
             default://nomal
                 mat.blend = RenderState.BLEND_ENABLE_ALL;
-
-                mat.blendSrc = RenderState.BLENDPARAM_ONE;
+                mat.blendSrc = premultipliedAlpha ? RenderState.BLENDPARAM_ONE:RenderState.BLENDPARAM_SRC_ALPHA;
                 mat.blendDst = RenderState.BLENDPARAM_ONE_MINUS_SRC_ALPHA;
         }
     }
@@ -146,6 +147,8 @@ export class SpineShaderInit {
      */
     static SPINE_GPU_INSTANCE:ShaderDefine;
 
+    static SPINE_PREMULTIPLYALPHA:ShaderDefine;
+
     /**
      * @en TextureSV Mesh Descript.
      * @zh 纹理 Spine 顶点属性描述。
@@ -188,6 +191,7 @@ export class SpineShaderInit {
         SpineShaderInit.SPINE_RB = Shader3D.getDefineByName("SPINE_RB");
         SpineShaderInit.SPINE_UV = Shader3D.getDefineByName("COLOR");
         SpineShaderInit.SPINE_COLOR = Shader3D.getDefineByName("UV");
+        SpineShaderInit.SPINE_PREMULTIPLYALPHA = Shader3D.getDefineByName("PREMULTIPLYALPHA");
         
         SpineShaderInit.SIMPLE_SIMPLEANIMATORPARAMS = Shader3D.propertyNameToID("u_SimpleAnimatorParams");
         SpineShaderInit.SIMPLE_SIMPLEANIMATORTEXTURE = Shader3D.propertyNameToID("u_SimpleAnimatorTexture");

--- a/src/layaAir/laya/spine/normal/SpineSkeletonRenderer.ts
+++ b/src/layaAir/laya/spine/normal/SpineSkeletonRenderer.ts
@@ -337,7 +337,7 @@ export class SpineSkeletonRenderer extends SpineNormalRenderBase implements ISpi
 
         let clipper = this.clipper;
         this.clearBatch();
-        let premultipliedAlpha = true;//this.premultipliedAlpha;
+        // let premultipliedAlpha = this.templet.premultipliedAlpha;
         let twoColorTint = this.twoColorTint;
         let blendMode: spine.BlendMode | null = null;
 
@@ -423,23 +423,24 @@ export class SpineSkeletonRenderer extends SpineNormalRenderBase implements ISpi
                 finalColor.g = skeletonColor.g * slotColor.g * attachmentColor.g;
                 finalColor.b = skeletonColor.b * slotColor.b * attachmentColor.b;
                 finalColor.a = skeletonColor.a * slotColor.a * attachmentColor.a;
-                if (premultipliedAlpha) {
-                    finalColor.r *= finalColor.a;
-                    finalColor.g *= finalColor.a;
-                    finalColor.b *= finalColor.a;
-                }
+                // if (premultipliedAlpha) {
+                //     finalColor.r *= finalColor.a;
+                //     finalColor.g *= finalColor.a;
+                //     finalColor.b *= finalColor.a;
+                // }
                 let darkColor = this.tempColor2;
                 if (!slot.darkColor)
                     darkColor.set(0, 0, 0, 1.0);
                 else {
-                    if (premultipliedAlpha) {
-                        darkColor.r = slot.darkColor.r * finalColor.a;
-                        darkColor.g = slot.darkColor.g * finalColor.a;
-                        darkColor.b = slot.darkColor.b * finalColor.a;
-                    } else {
+                    // if (premultipliedAlpha) {
+                    //     darkColor.r = slot.darkColor.r * finalColor.a;
+                    //     darkColor.g = slot.darkColor.g * finalColor.a;
+                    //     darkColor.b = slot.darkColor.b * finalColor.a;
+                    // } else {
                         darkColor.setFromColor(slot.darkColor);
-                    }
-                    darkColor.a = premultipliedAlpha ? 1.0 : 0.0;
+                    // }
+                    // darkColor.a = premultipliedAlpha ? 1.0 : 0.0;
+                    // finalColor.rgb = ((texColor.a - 1.0) * v_dark.a + 1.0 - texColor.rgb) * v_dark.rgb + texColor.rgb * v_light.rgb;
                 }
 
                 let slotBlendMode = slot.data.blendMode;

--- a/src/layaAir/laya/spine/optimize/AnimationRender.ts
+++ b/src/layaAir/laya/spine/optimize/AnimationRender.ts
@@ -9,13 +9,13 @@ import { SpineMeshUtils } from "../mesh/SpineMeshUtils";
 import { AttachmentParse } from "./AttachmentParse";
 import { IBCreator } from "./IBCreator";
 import { MultiRenderData } from "./MultiRenderData";
+import { SketonOptimise } from "./SketonOptimise";
 import { VBCreator } from "./VBCreator";
 import { ChangeDeform } from "./change/ChangeDeform";
 import { ChangeDrawOrder } from "./change/ChangeDrawOrder";
 import { ChangeRGBA } from "./change/ChangeRGBA";
 import { ChangeSlot } from "./change/ChangeSlot";
 import { IChange } from "./interface/IChange";
-import { IPreRender } from "./interface/IPreRender";
 import { IVBChange } from "./interface/IVBChange";
 
 export type FrameRenderData = {
@@ -149,7 +149,7 @@ export class AnimationRender {
      * @zh 缓存动画的骨骼变换。
      * @param preRender 用于缓存的预渲染器。
      */
-    cacheBones(preRender: IPreRender) {
+    cacheBones(preRender: SketonOptimise) {
         let duration = preRender._play(this.name);
         let totalFrame = Math.round(duration / step) || 1;
         for (let i = 0; i <= totalFrame; i++) {
@@ -172,7 +172,7 @@ export class AnimationRender {
      * @param animation 要检查的spine动画。
      * @param preRender 要使用的预渲染器。
      */
-    check(animation: spine.Animation, preRender: IPreRender) {
+    check(animation: spine.Animation, preRender: SketonOptimise) {
         this.name = animation.name;
 
         let timeline = animation.timelines;

--- a/src/layaAir/laya/spine/optimize/AttachmentParse.ts
+++ b/src/layaAir/laya/spine/optimize/AttachmentParse.ts
@@ -112,7 +112,7 @@ export class AttachmentParse {
      * @param deform 变形数组。
      * @param slot 插槽数据。
      */
-    init(attachment: spine.Attachment, boneIndex: number, slotId: number, deform: number[], slot: spine.SlotData) {
+    init(attachment: spine.Attachment, boneIndex: number, slotId: number, deform: number[], slot: spine.SlotData ) {
         this.slotId = slotId;
         this.sourceData = attachment;
         this.attachment = attachment.name;
@@ -221,6 +221,7 @@ export class AttachmentParse {
             this.indexCount = this.indexArray.length;
         }
 
+
         if (attchmentColor) {
             if (attchmentColor.a != 1 || attchmentColor.r != 1 || attchmentColor.g != 1 && attchmentColor.b != 1) {
                 this.lightColor = attchmentColor;
@@ -228,12 +229,8 @@ export class AttachmentParse {
             color.r = slotColor.r * attchmentColor.r;
             color.g = slotColor.g * attchmentColor.g;
             color.b = slotColor.b * attchmentColor.b;
-            let a = color.a = slotColor.a * attchmentColor.a;
-            //预乘
-            color.r *= a;
-            color.g *= a;
-            color.b *= a;
         }
+        
 
         return true;
     }

--- a/src/layaAir/laya/spine/optimize/SketonOptimise.ts
+++ b/src/layaAir/laya/spine/optimize/SketonOptimise.ts
@@ -1,28 +1,21 @@
-import { IRenderElement2D } from "../../RenderDriver/DriverDesign/2DRenderPass/IRenderElement2D";
-import { IndexFormat } from "../../RenderEngine/RenderEnum/IndexFormat";
-import { TextureFormat } from "../../RenderEngine/RenderEnum/TextureFormat";
-import { Graphics } from "../../display/Graphics";
-import { Mesh2D } from "../../resource/Mesh2D";
 import { Texture2D } from "../../resource/Texture2D";
 import { Spine2DRenderNode } from "../Spine2DRenderNode";
 import { ESpineRenderType } from "../SpineSkeleton";
 import { SpineTemplet } from "../SpineTemplet";
-import { AnimationRender, FrameRenderData } from "./AnimationRender";
+import { AnimationRender } from "./AnimationRender";
 import { AttachmentParse } from "./AttachmentParse";
 import { IBCreator } from "./IBCreator";
-import { MultiRenderData } from "./MultiRenderData";
 import { SlotUtils } from "./SlotUtils";
 import { SpineNormalRender } from "./SpineNormalRender";
 import { SpineOptimizeRender } from "./SpineOptimizeRender";
 import { VBBoneCreator, VBCreator, VBRigBodyCreator } from "./VBCreator";
-import { IPreRender } from "./interface/IPreRender";
 import { ISpineOptimizeRender } from "./interface/ISpineOptimizeRender";
 
 /**
  * @en SketonOptimise class used for skeleton optimization.
  * @zh SketonOptimise 类用于骨骼优化。
  */
-export class SketonOptimise implements IPreRender {
+export class SketonOptimise {
     /**
      * @en Switch for normal rendering mode.
      * @zh 普通渲染模式的开关。
@@ -37,6 +30,7 @@ export class SketonOptimise implements IPreRender {
      * @zh 缓存模式的开关。
      */
     static cacheSwitch: boolean = false;
+
     /**
      * @en Indicates whether caching is possible.
      * @zh 表示是否可以缓存。
@@ -141,13 +135,14 @@ export class SketonOptimise implements IPreRender {
      * @zh 检查并初始化主附件。
      * @param skeletonData 要检查的骨骼数据。
      */
-    checkMainAttach(skeletonData: spine.SkeletonData) {
+    checkMainAttach(skeletonData: spine.SkeletonData ) {
         // return;
-        this.sketon = new window.spine.Skeleton(skeletonData);
+        this.sketon = new spine.Skeleton(skeletonData);
         //@ts-ignore
-        this._stateData = new window.spine.AnimationStateData(this.sketon.data);
+        this._stateData = new spine.AnimationStateData(this.sketon.data);
         // 动画状态类
-        this._state = new window.spine.AnimationState(this._stateData);
+        this._state = new spine.AnimationState(this._stateData);
+
         this.attachMentParse(skeletonData);
         this.initAnimation(skeletonData.animations);
     }
@@ -173,7 +168,7 @@ export class SketonOptimise implements IPreRender {
             if (i != 0) {
                 skinAttach.copyFrom(defaultSkinAttach);
             }
-            skinAttach.attachMentParse(skin, slots);
+            skinAttach.attachMentParse( skin , slots );
             this.skinAttachArray.push(skinAttach);
             // if (i != 0) {
             //     defaultSkinAttach.mainVB._cloneBones(skinAttach.mainVB)
@@ -358,7 +353,6 @@ export class SkinAttach {
      * @param slots spine插槽数据数组。
      */
     attachMentParse(skinData: spine.Skin, slots: spine.SlotData[]) {
-        
         let type: ESpineRenderType = ESpineRenderType.rigidBody;
         let vertexBones = 0;
         let attachments = skinData.attachments;
@@ -381,7 +375,7 @@ export class SkinAttach {
                     let attach = attachment[key];
                     let deform = null;//slot.deform; TODO
                     let parse = new AttachmentParse();
-                    
+
                     parse.init(attach, boneIndex, i, deform, slot);
                     // if (parse.isNormalRender) this.isNormalRender = true;
                     vertexBones = Math.max(vertexBones , parse.vertexBones);

--- a/src/layaAir/laya/spine/optimize/SkinRenderUpdate.ts
+++ b/src/layaAir/laya/spine/optimize/SkinRenderUpdate.ts
@@ -131,8 +131,7 @@ export class SkinRenderUpdate {
         }
 
         let needUpdateMesh = SpineMeshUtils._updateSpineSubMesh(mesh, frameData);
-        let needUpdateRender = this.handleRender(skindata, frame, renderNode, mesh);
-        return needUpdateMesh || needUpdateRender;
+        return this.handleRender(skindata, frame, renderNode, mesh , needUpdateMesh);
     }
 
     private updateCurrentChanges(currentChanges: IVBChange[], lastFrame: number, frame: number, skindata: SkinAniRenderData) {
@@ -162,7 +161,7 @@ export class SkinRenderUpdate {
         return needUpload;
     }
 
-    private handleRender(skindata: SkinAniRenderData, frame: number, renderNode: Spine2DRenderNode, mesh: Mesh2D): boolean {
+    private handleRender(skindata: SkinAniRenderData, frame: number, renderNode: Spine2DRenderNode, mesh: Mesh2D , forceUpdateMesh = false): boolean {
         let frameData = skindata.getFrameData(frame);
         let mulitRenderData = frameData.mulitRenderData;
         let mats = this.cacheMaterials[mulitRenderData.id] || this.createMaterials(mulitRenderData);
@@ -173,7 +172,7 @@ export class SkinRenderUpdate {
             this.currentMaterials = mats;
         }
 
-        return !renderNode._onMeshChange(mesh) || needUpdate;;
+        return !renderNode._onMeshChange(mesh , forceUpdateMesh) || needUpdate;
     }
 
     private createMaterials(mulitRenderData: MultiRenderData): Material[] {

--- a/src/layaAir/laya/spine/optimize/SpineNormalRender.ts
+++ b/src/layaAir/laya/spine/optimize/SpineNormalRender.ts
@@ -60,7 +60,7 @@ export class SpineNormalRender implements ISpineOptimizeRender {
         let scolor = skeleton.color;
 
         this._spineColor = new Color(scolor.r, scolor.g, scolor.b, scolor.a);
-        let color =  renderNode._spriteShaderData.getColor(BaseRenderNode2D.BASERENDER2DCOLOR) || new Color();
+        let color = renderNode._spriteShaderData.getColor(BaseRenderNode2D.BASERENDER2DCOLOR) || new Color();
         color.setValue(scolor.r, scolor.g, scolor.b , scolor.a );
         if (renderNode._renderAlpha !== undefined) {
             color.a *= renderNode._renderAlpha;

--- a/src/layaAir/laya/spine/optimize/SpineOptimizeRender.ts
+++ b/src/layaAir/laya/spine/optimize/SpineOptimizeRender.ts
@@ -201,6 +201,7 @@ export class SpineOptimizeRender implements ISpineOptimizeRender {
         this._nodeOwner = renderNode;
         let scolor = skeleton.color;
 
+        this.spineColor = new Color(scolor.r, scolor.g, scolor.b, scolor.a);
         let color = renderNode._spriteShaderData.getColor(BaseRenderNode2D.BASERENDER2DCOLOR) || new Color();
         color.setValue(scolor.r, scolor.g, scolor.b, scolor.a);
         if (renderNode._renderAlpha !== undefined) {

--- a/src/layaAir/laya/spine/optimize/change/ChangeRGBA.ts
+++ b/src/layaAir/laya/spine/optimize/change/ChangeRGBA.ts
@@ -85,19 +85,20 @@ export class ChangeRGBA implements IVBChange {
             let attachment = attachmentPos.attachment;
             let r, g, b, a;
             let attachmentColor = attachment.lightColor;
+            
             if (!attachmentColor) {
-                r = color.r * color.a;
-                g = color.g * color.a;
-                b = color.b * color.a;
+                r = color.r;
+                g = color.g;
+                b = color.b;
                 a = color.a;
             }
             else {
-                r = color.r * color.a * attachmentColor.r;
-                g = color.g * color.a * attachmentColor.g;
-                b = color.b * color.a * attachmentColor.b;
+                r = color.r * attachmentColor.r;
+                g = color.g * attachmentColor.g;
+                b = color.b * attachmentColor.b;
                 a = color.a * attachmentColor.a;
             }
-            
+
             let n = attachment.vertexCount;
             for (let i = 0; i < n; i++) {
                 vbData[offset + i * vertexSize + 2] = r;

--- a/src/layaAir/laya/spine/optimize/interface/IPreRender.ts
+++ b/src/layaAir/laya/spine/optimize/interface/IPreRender.ts
@@ -1,5 +1,0 @@
-export interface IPreRender {
-    canCache:boolean;
-    _updateState(delta:number):spine.Bone[];
-    _play(animationName:string):number;
-}


### PR DESCRIPTION
1.Rendering error caused when all slot.alpha are 0.(当所有的slot.alpha为0 时，导致的渲染错误) 2.Last frame update error.(最后一帧更新错误)
3.Merge code error.(合并代码错误)
feat:
1.Check image pre multiplication to determine if spine has enabled premultipliedAlpha.(检查图片预乘来判断spine是否开启预乘)