### PR TITLE
优化字体加载实现方式以便支持小游戏环境

### DIFF
--- a/src/layaAir/laya/loaders/TTFFontLoader.ts
+++ b/src/layaAir/laya/loaders/TTFFontLoader.ts
@@ -1,55 +1,8 @@
-import { ILaya } from "../../ILaya";
-import { LayaEnv } from "../../LayaEnv";
-import { IResourceLoader, ILoadTask, Loader } from "../net/Loader";
-import { URL } from "../net/URL";
-import { Browser } from "../utils/Browser";
-import { Utils } from "../utils/Utils";
-
-const testString = "LayaTTFFont";
-
+import { ILoadTask, IResourceLoader, Loader } from "../net/Loader";
 class TTFFontLoader implements IResourceLoader {
 
     load(task: ILoadTask) {
-        let fontName = Utils.replaceFileExtension(Utils.getBaseName(task.url), "");
-        if (LayaEnv.isConch) {
-            return task.loader.fetch(task.url, "arraybuffer").then(data => {
-                if (data)
-                    (window as any)["conch"].registerFont(fontName, data);
-                return { family: fontName };
-            });
-        }
-        else if ((window as any).FontFace) {
-            let fontFace: any = new (window as any).FontFace(fontName, "url('" + URL.postFormatURL(URL.formatURL(task.url)) + "')");
-            (document as any).fonts.add(fontFace);
-            return fontFace.load().then(() => {
-                return fontFace;
-            });
-        }
-        else {
-            let fontTxt = "40px " + fontName;
-            let txtWidth = Browser.measureText(testString, fontTxt).width;
-
-            let fontStyle: any = Browser.createElement("style");
-            fontStyle.type = "text/css";
-            document.body.appendChild(fontStyle);
-            fontStyle.textContent = "@font-face { font-family:'" + fontName + "'; src:url('" + URL.postFormatURL(URL.formatURL(task.url)) + "');}";
-
-            return new Promise((resolve) => {
-                let checkComplete = () => {
-                    if (Browser.measureText(testString, fontTxt).width != txtWidth)
-                        complete();
-                };
-                let complete = () => {
-                    ILaya.systemTimer.clear(this, checkComplete);
-                    ILaya.systemTimer.clear(this, complete);
-
-                    resolve({ family: fontName });
-                };
-
-                ILaya.systemTimer.once(10000, this, complete);
-                ILaya.systemTimer.loop(20, this, checkComplete);
-            });
-        }
+        return task.loader.fetch(task.url, "font", task.progress.createCallback(), task.options);
     }
 }
 

--- a/src/layaAir/laya/net/Loader.ts
+++ b/src/layaAir/laya/net/Loader.ts
@@ -62,7 +62,8 @@ interface ContentTypeMap {
     "xml": XML,
     "arraybuffer": ArrayBuffer,
     "image": HTMLImageElement | ImageBitmap,
-    "sound": HTMLAudioElement
+    "sound": HTMLAudioElement,
+    "font": FontFace,
 }
 
 var typeIdCounter = 0;
@@ -749,6 +750,10 @@ export class Loader extends EventDispatcher {
         }
         else if (item.contentType == "sound") {
             Loader.downloader.audio(item, url, item.originalUrl, item.onProgress, (data: any, error: string) =>
+                this.completeItem(item, data, error));
+        }
+        else if (item.contentType == "font") {
+            Loader.downloader.font(item, url, item.originalUrl, item.onProgress, (data: any, error: string) =>
                 this.completeItem(item, data, error));
         }
         else {


### PR DESCRIPTION
将字体加载的实现从 TTFFontLoader 挪到 Donwloader 中，与图片/音频这类平台相关的功能对应。
小游戏平台实现使用平台的接口重写 Download.font 函数即可实现支持。

例如微信小游戏适配
```ts
Laya.Downloader.prototype.font = function (owner: any, url: string, originalUrl: string, onProgress: (progress: number) => void, onComplete: (data: any, error?: string) => void) {
	let path = url; // 如有需要在此实现下载、缓存、逻辑，这里假设字体在小游戏包内
	const family = wx.loadFont(path);
	if (family) {
		onComplete({ family })
	} else {
		onComplete(null, 'load font failed');
	}
};
```