### PR TITLE
Laya air 3.3 spine4.2小游戏中的全局修复

### DIFF
--- a/src/layaAir/jsLibs/spine-core-4.2.js
+++ b/src/layaAir/jsLibs/spine-core-4.2.js
@@ -10206,3 +10206,5 @@ var spine;
     }
     spine.Triangulator = Triangulator;
 })(spine || (spine = {}));
+// LayaBox_Modify
+window.spine = spine;


### PR DESCRIPTION
4.2的spine尾部缺失 window.spine = spine; 导致小游戏环境中无法使用spine