### PR TITLE
feat：文件扩展

### DIFF
--- a/src/layaAir/laya/net/URL.ts
+++ b/src/layaAir/laya/net/URL.ts
@@ -48,6 +48,8 @@ export class URL {
         "glsl": "glsl.txt",
         "skel": "skel.bin",
         "lavm": "lavm.json",
+        "bp": "bp.json",
+        "tres":"tres.json"
     };
 
     /**


### PR DESCRIPTION
In the minigame environment, .bp and .tres files support the parsing of .json suffixes.(minigame环境下.bp与.tres文件支持加.json后缀的解析)