### PR TITLE
fix: simplify AnimatorState islooping getter logic

### DIFF
--- a/src/layaAir/laya/d3/component/Animator/AnimatorState.ts
+++ b/src/layaAir/laya/d3/component/Animator/AnimatorState.ts
@@ -184,7 +184,7 @@ export class AnimatorState extends EventDispatcher implements IClone {
      * @zh 动画是否循环播放。
      */
     get islooping() {
-        if (0 != this._isLooping) {
+        if (this._isLooping) {
             return 1 == this._isLooping;
         }
         return this._clip.islooping;


### PR DESCRIPTION
修正配置文件中没有这个字段时状态识别错误。
示例: unity 导出插件会遗漏