### PR TITLE
一些项目的修改经验

### DIFF
--- a/src/layaAir/laya/RenderDriver/WebGLDriver/RenderDevice/WebGLEngine.ts
+++ b/src/layaAir/laya/RenderDriver/WebGLDriver/RenderDevice/WebGLEngine.ts
@@ -315,7 +315,7 @@ export class WebGLEngine extends EventDispatcher implements IRenderEngine {
         this._activeTextures = [];
         this._GLTextureContext = this.isWebGL2 ? new GL2TextureContext(this) : new GLTextureContext(this);
         this._GLRenderDrawContext = new GLRenderDrawContext(this);
-        canvas.addEventListener("webglcontextlost", this.webglContextLost)
+        canvas.addEventListener("webglcontextlost", (e: any) => this.webglContextLost(e))
     }
 
     webglContextLost(e: any) {

--- a/src/layaAir/laya/display/Input.ts
+++ b/src/layaAir/laya/display/Input.ts
@@ -190,6 +190,7 @@ export class Input extends Text {
         style.border = 'none';
         style.outline = 'none';
         style.zIndex = '1';
+        style.touchAction = 'none';
 
         input.addEventListener('input', Input._processInputting);
 
@@ -227,7 +228,7 @@ export class Input extends Text {
     }
 
     private static _stopEvent(e: any): void {
-        if (e.type == 'touchmove')
+        if (e.type == 'touchmove' && !ILaya.Browser.onIOS)
             e.preventDefault();
         e.stopPropagation && e.stopPropagation();
     }

--- a/src/layaAir/laya/display/Sprite.ts
+++ b/src/layaAir/laya/display/Sprite.ts
@@ -140,6 +140,7 @@ export class Sprite extends Node {
      * @param destroyChild 是否删除子节点。默认为 true。
      */
     destroy(destroyChild: boolean = true): void {
+        this._filterArr && (this.filters = []);
         super.destroy(destroyChild);
         this._style && this._style.recover();
         this._cacheStyle && this._cacheStyle.recover();

--- a/src/layaAir/laya/display/Sprite.ts
+++ b/src/layaAir/laya/display/Sprite.ts
@@ -2036,6 +2036,13 @@ export class Sprite extends Node {
         return !!(this._repaint & SpriteConst.REPAINT_CACHE);
     }
 
+    protected override _onInActive() {
+        super._onInActive();
+        if (this._getCacheStyle().renderTexture) {
+            this.repaint();
+        }
+    }
+
     /**
     * @en Callback when a child node changes.
     * @param child The child node that has changed.

--- a/src/layaAir/laya/display/Text.ts
+++ b/src/layaAir/laya/display/Text.ts
@@ -1381,13 +1381,15 @@ export class Text extends Sprite {
         let applyLineFill = (line: ITextLine, lineWidth: number) => {
             line.gapCount = 0;
             line.appliedFillWidth = 0;
-            if (!enableLineFill || line.fillWidth <= 0)
+            if (!enableLineFill || line.fillWidth <= 0) {
                 return lineWidth;
+            }
 
             let maxFillWidth = Math.floor(Math.max(0, rectWidth - lineWidth - 1));
             let fillWidth = Math.min(Math.floor(line.fillWidth), maxFillWidth);
-            if (fillWidth <= 0)
+            if (fillWidth <= 0) {
                 return lineWidth;
+            }
 
             let cmd = line.cmd;
             let prevTextCmd: ITextCmd = null;
@@ -1409,8 +1411,9 @@ export class Text extends Sprite {
                 cmd = cmd.next;
             }
 
-            if (line.gapCount == 0)
+            if (line.gapCount == 0) {
                 return lineWidth;
+            }
 
             let base = Math.floor(fillWidth / line.gapCount);
             let rem = fillWidth % line.gapCount;
@@ -1446,6 +1449,10 @@ export class Text extends Sprite {
                 let line = this._lines[i];
                 // `addLine()` 缓存的宽度可能还是换行中间态，HTML 分段或跨 cmd 挪字后要按最终链表重算。
                 let actualWidth = getLineWidth(line);
+                if (enablePunctuationLineFill && line.softWrap) {
+                    let targetFillWidth = Math.max(0, rectWidth - actualWidth);
+                    line.fillWidth = Math.max(line.fillWidth, targetFillWidth);
+                }
                 if (actualWidth != line.width)
                     line.width = Math.round(actualWidth);
                 line.width = Math.round(applyLineFill(line, actualWidth));
@@ -1618,6 +1625,11 @@ export class Text extends Sprite {
             return true;
         };
 
+        let markCurrentLineSoftWrap = () => {
+            if (curLine)
+                curLine.softWrap = true;
+        };
+
         let addLine = (last?: boolean) => {
             lineX = 0;
             if (curLine) {
@@ -1662,6 +1674,7 @@ export class Text extends Sprite {
             curLine.fillWidth = 0;
             curLine.gapCount = 0;
             curLine.appliedFillWidth = 0;
+            curLine.softWrap = false;
             this._lines.push(curLine);
             lastCmd = null;
 
@@ -1711,8 +1724,6 @@ export class Text extends Sprite {
                                 let movedWidth = 0;
                                 if (movedText.length > 0)
                                     movedWidth += getTextWidth(movedText);
-                                if (tw != null)
-                                    movedWidth += tw;
                                 recordLineFillWidth(movedWidth);
                             }
                             j = startIndex + wb;
@@ -1744,10 +1755,11 @@ export class Text extends Sprite {
                                     }
                                     else if (isPunc && totalLen == 0) {
                                         if (textLen > 1)
-                                            recordLineFillWidth(getMovedWidthFromSplit(cmd, textLen - 1) + (tw || 0));
+                                            recordLineFillWidth(getMovedWidthFromSplit(cmd, textLen - 1));
                                         else if (cmd.x > 0)
-                                            recordLineFillWidth(getMovedWidthFromSplit(cmd, 0) + (tw || 0));
+                                            recordLineFillWidth(getMovedWidthFromSplit(cmd, 0));
                                     }
+                                    markCurrentLineSoftWrap();
                                     addLine();
                                     if (forbidLineEnd) { //再次检查禁排行尾符号不能留在上一行末尾
                                         if (splitCmd(cmd, textLen - 1)) //将最后一个字符移到下一行
@@ -1770,7 +1782,8 @@ export class Text extends Sprite {
                                 else if (cmdBoundary > 0) {
                                     if (cmdBoundary > textLen - (maxWordLength - totalLen)) { //限制字符个数，超过的不看做一个单词
                                         if (isPunc && totalLen == 0)
-                                            recordLineFillWidth(getMovedWidthFromSplit(cmd, cmdBoundary) + (tw || 0));
+                                            recordLineFillWidth(getMovedWidthFromSplit(cmd, cmdBoundary));
+                                        markCurrentLineSoftWrap();
                                         addLine();
                                         splitCmd(cmd, cmdBoundary);
                                         moveCmds(cmd.next);
@@ -1806,8 +1819,6 @@ export class Text extends Sprite {
                                 let movedWidth = 0;
                                 if (movedChar)
                                     movedWidth += getTextWidth(movedChar);
-                                if (tw != null)
-                                    movedWidth += tw;
                                 recordLineFillWidth(movedWidth);
                                 arrPartCh = arrCh.slice(startIndex, j);
                                 part = arrPartCh.join("");
@@ -1834,6 +1845,7 @@ export class Text extends Sprite {
 
                 if (part.length > 0)
                     addCmd(part, style, wordWidth);
+                markCurrentLineSoftWrap();
                 addLine();
 
                 startIndex = j;
@@ -1910,6 +1922,7 @@ export class Text extends Sprite {
                             let remainWidth = rectWidth - lineX;
                             if (htmlObj.width > 0 && remainWidth < htmlObj.width + 1) {
                                 if (lineX > 0) { //如果已经是开始位置了，就算放不下也不换行
+                                    markCurrentLineSoftWrap();
                                     addLine();
                                 }
                             }
@@ -2282,6 +2295,7 @@ export interface ITextLine {
     fillWidth: number;
     gapCount: number;
     appliedFillWidth: number;
+    softWrap: boolean;
 }
 
 const cmdPool: Array<ITextCmd> = [];

--- a/src/layaAir/laya/display/Text.ts
+++ b/src/layaAir/laya/display/Text.ts
@@ -2347,7 +2347,7 @@ function getWordBoundaryIndex(text: string, nextChar?: string): number | null {
     return testResult.index < text.length ? testResult.index : null;
 }
 
-const emojiRegex = createEmojiRegex();
+let emojiRegex: RegExp = null; // 安卓微信小程序不支持emoji-regex-xs，延迟生成。主要靠应用层覆盖 Text.splitStr
 const normalizeCR = /\r\n/g;
 const escapeCharsPattern = /\\(\w)/g;
 const escapeSequence: any = { "\\n": "\n", "\\t": "\t" };
@@ -2376,6 +2376,9 @@ function defaultSplitStr(text: string): string[] {
     //     const result = Array.from(segments).map(s => s.segment);
     //     return result;
     // }
+    if (emojiRegex == null) {
+        emojiRegex = createEmojiRegex();
+    }
     const arrCh: string[] = [];
     let pos = 0;
     text.replace(emojiRegex, function (match, offset) {

--- a/src/layaAir/laya/display/Text.ts
+++ b/src/layaAir/laya/display/Text.ts
@@ -74,6 +74,7 @@ export class Text extends Sprite {
     static _passwordChar = "●";
 
     static splitStr: (text: string) => string[] = defaultSplitStr;
+    static punctuationChars: number[] = Array.from(".,，。、!！；;”’)）]】}》").map(char => char.charCodeAt(0));
 
     /**
      * @en Dictionary of bitmap fonts.
@@ -185,6 +186,8 @@ export class Text extends Sprite {
     protected _hideText: boolean;
     private _updatingLayout: boolean;
     private _fontSizeScale: number;
+    private _singleLineAutoFill: boolean = false;
+    private _lineFillRemainderPolicy: "ltr" | "rtl" = "ltr";
 
     /**
      * @internal
@@ -576,6 +579,37 @@ export class Text extends Sprite {
     set wordWrap(value: boolean) {
         if (this._wordWrap != value) {
             this._wordWrap = value;
+            this.markChanged();
+        }
+    }
+
+    /**
+     * @en Whether to automatically add spacing to fill a single line when width is explicitly set.
+     * @zh 在显式设置宽度时，是否自动增加字间距以撑满单行。
+     */
+    get singleLineAutoFill(): boolean {
+        return this._singleLineAutoFill;
+    }
+
+    set singleLineAutoFill(value: boolean) {
+        if (this._singleLineAutoFill != value) {
+            this._singleLineAutoFill = value;
+            this.markChanged();
+        }
+    }
+
+    /**
+     * @en Remainder allocation policy for line fill.
+     * @zh 行补空白时的余数分配策略。
+     */
+    get lineFillRemainderPolicy(): "ltr" | "rtl" {
+        return this._lineFillRemainderPolicy;
+    }
+
+    set lineFillRemainderPolicy(value: "ltr" | "rtl") {
+        value = value === "rtl" ? "rtl" : "ltr";
+        if (this._lineFillRemainderPolicy != value) {
+            this._lineFillRemainderPolicy = value;
             this.markChanged();
         }
     }
@@ -1141,6 +1175,10 @@ export class Text extends Sprite {
         let rectHeight = this._isHeightSet ? (this._height - padding[0] - padding[2]) : Number.MAX_VALUE;
         let bfont = this._bitmapFont;
         let alignItems = this._textStyle.alignItems == "middle" ? 1 : (this._textStyle.alignItems == "bottom" ? 2 : 0);
+        let enablePunctuationLineFill = wordWrap && this._overflow != Text.SHRINK;
+        let enableSingleLineAutoFill = this._singleLineAutoFill && !this._wordWrap && this._isWidthSet
+            && this._overflow != Text.SHRINK;
+        let enableLineFill = enablePunctuationLineFill || enableSingleLineAutoFill;
 
         let lineX: number, lineY: number;
         let curLine: ITextLine;
@@ -1168,6 +1206,235 @@ export class Text extends Sprite {
                 let ret = Browser.context.measureText(text);
                 Browser.context.font = t;
                 return ret ? ret.width : 100;
+            }
+        };
+
+        let getLastCharWidth = (text: string, font: string, curFontSize: number) => {
+            let arrCh = Text.splitStr(text);
+            if (arrCh.length == 0)
+                return 0;
+
+            return getTextWidth2(arrCh[arrCh.length - 1], font, curFontSize);
+        };
+
+        let getLineWidth = (line: ITextLine) => {
+            let width = 0;
+            let cmd = line.cmd;
+            while (cmd) {
+                width += cmd.width;
+                cmd = cmd.next;
+            }
+            return width;
+        };
+
+        let recordLineFillWidth = (width: number) => {
+            if (!enablePunctuationLineFill || width <= 0 || !curLine)
+                return;
+
+            curLine.fillWidth += width;
+        };
+
+        let applyTextCmdText = (cmd: ITextCmd, source: ITextCmd, text: string, width?: number) => {
+            if (!cmd.wt)
+                cmd.wt = new WordText();
+
+            cmd.obj = null;
+            cmd.wt.setText(text);
+            cmd.wt.splitRender = this._singleCharRender;
+            cmd.style = source.style;
+            cmd.ctxFont = source.ctxFont;
+            cmd.fontSize = source.fontSize;
+            if (width == null)
+                width = getTextWidth2(text, cmd.ctxFont, cmd.fontSize);
+            cmd.width = cmd.wt.width = width;
+            cmd.height = source.height;
+            cmd.y = source.y;
+            cmd.next = null;
+            cmd.prev = null;
+            cmd.linkEnd = false;
+        };
+
+        let splitLineTextCmds = (line: ITextLine, gapExtras: number[]) => {
+            let cmd = line.cmd;
+            let newHead: ITextCmd = null;
+            let newLast: ITextCmd = null;
+            let prevTextTail: ITextCmd = null;
+            let x = 0;
+            let gapIndex = 0;
+
+            while (cmd) {
+                let next = cmd.next;
+                if (cmd.obj || !cmd.wt || cmd.wt.text.length == 0) {
+                    cmd.x = x;
+                    cmd.prev = newLast;
+                    cmd.next = null;
+                    if (newLast)
+                        newLast.next = cmd;
+                    else
+                        newHead = cmd;
+                    newLast = cmd;
+                    x += cmd.width;
+                    prevTextTail = null;
+                }
+                else {
+                    let arrCh = Text.splitStr(cmd.wt.text);
+                    let source: ITextCmd = cmd;
+                    let sourceLinkEnd = cmd.linkEnd;
+                    let charWidths: number[] = [];
+
+                    if (arrCh.length > 1) {
+                        let prefixText = "";
+                        let prefixWidth = 0;
+                        for (let i = 0, n = arrCh.length; i < n; i++) {
+                            let charWidth: number;
+                            if (i == n - 1) {
+                                // 最后一个字符直接吸收剩余宽度，避免整串拆字后累计宽度超过原命令宽度。
+                                charWidth = Math.max(0, source.width - prefixWidth);
+                            }
+                            else {
+                                prefixText += arrCh[i];
+                                let measuredWidth = getTextWidth2(prefixText, source.ctxFont, source.fontSize);
+                                charWidth = Math.max(0, measuredWidth - prefixWidth);
+                                prefixWidth = measuredWidth;
+                            }
+                            charWidths.push(charWidth);
+                        }
+                    }
+
+                    if (prevTextTail) {
+                        let extra = gapExtras[gapIndex++];
+                        if (extra > 0) {
+                            prevTextTail.width += extra;
+                            x += extra;
+                        }
+                    }
+
+                    for (let i = 0, n = arrCh.length; i < n; i++) {
+                        let charCmd = i == 0 ? cmd : (cmdPool.length > 0 ? cmdPool.pop() : <any>{});
+                        applyTextCmdText(charCmd, source, arrCh[i], charWidths[i] ?? source.width);
+                        charCmd.x = x;
+                        charCmd.linkEnd = i == n - 1 ? sourceLinkEnd : false;
+                        charCmd.prev = newLast;
+                        if (newLast)
+                            newLast.next = charCmd;
+                        else
+                            newHead = charCmd;
+                        newLast = charCmd;
+
+                        if (i < n - 1) {
+                            let extra = gapExtras[gapIndex++];
+                            if (extra > 0)
+                                charCmd.width += extra;
+                        }
+
+                        // 这里按真实宽度累计，避免字符级 rounding 误差压到最后一个字上。
+                        x += charCmd.width;
+                    }
+
+                    prevTextTail = newLast;
+                }
+
+                cmd = next;
+            }
+
+            if (newLast)
+                newLast.next = null;
+            if (newHead)
+                newHead.prev = null;
+            line.cmd = newHead;
+        };
+
+        let applyLineFill = (line: ITextLine, lineWidth: number) => {
+            line.gapCount = 0;
+            line.appliedFillWidth = 0;
+            if (!enableLineFill || line.fillWidth <= 0)
+                return lineWidth;
+
+            let maxFillWidth = Math.floor(Math.max(0, rectWidth - lineWidth - 1));
+            let fillWidth = Math.min(Math.floor(line.fillWidth), maxFillWidth);
+            if (fillWidth <= 0)
+                return lineWidth;
+
+            let cmd = line.cmd;
+            let prevTextCmd: ITextCmd = null;
+            while (cmd) {
+                if (!cmd.obj && cmd.wt && cmd.wt.text.length > 0) {
+                    let charCount = Text.splitStr(cmd.wt.text).length;
+                    if (charCount > 0) {
+                        if (prevTextCmd)
+                            line.gapCount++;
+                        if (charCount > 1)
+                            line.gapCount += charCount - 1;
+                        prevTextCmd = cmd;
+                    }
+                }
+                else {
+                    prevTextCmd = null;
+                }
+
+                cmd = cmd.next;
+            }
+
+            if (line.gapCount == 0)
+                return lineWidth;
+
+            let base = Math.floor(fillWidth / line.gapCount);
+            let rem = fillWidth % line.gapCount;
+            let gapExtras = new Array<number>(line.gapCount).fill(base);
+            if (rem > 0) {
+                if (this._lineFillRemainderPolicy === "rtl") {
+                    for (let i = line.gapCount - rem; i < line.gapCount; i++)
+                        gapExtras[i] += 1;
+                }
+                else {
+                    for (let i = 0; i < rem; i++)
+                        gapExtras[i] += 1;
+                }
+            }
+
+            splitLineTextCmds(line, gapExtras);
+
+            line.appliedFillWidth = fillWidth;
+            return getLineWidth(line);
+        };
+
+        let applyLineFillToLines = () => {
+            if (!enableLineFill)
+                return;
+
+            if (enableSingleLineAutoFill && this._lines.length == 1) {
+                let line = this._lines[0];
+                // 单行自动撑满只在显式宽度且最终仍为单行时生效。
+                line.fillWidth = Math.max(line.fillWidth, Math.max(0, rectWidth - getLineWidth(line)));
+            }
+
+            for (let i = 0, n = this._lines.length; i < n; i++) {
+                let line = this._lines[i];
+                // `addLine()` 缓存的宽度可能还是换行中间态，HTML 分段或跨 cmd 挪字后要按最终链表重算。
+                let actualWidth = getLineWidth(line);
+                if (actualWidth != line.width)
+                    line.width = Math.round(actualWidth);
+                line.width = Math.round(applyLineFill(line, actualWidth));
+            }
+        };
+
+        let applySingleLineAutoFillToFinalLine = () => {
+            if (!enableSingleLineAutoFill || this._lines.length != 1)
+                return;
+
+            let line = this._lines[0];
+            if (line.appliedFillWidth > 0)
+                return;
+
+            let actualWidth = getLineWidth(line);
+            if (actualWidth != line.width)
+                line.width = Math.round(actualWidth);
+
+            line.fillWidth = Math.max(line.fillWidth, Math.max(0, rectWidth - actualWidth));
+            let filledWidth = applyLineFill(line, actualWidth);
+            if (filledWidth != actualWidth) {
+                line.width = Math.round(filledWidth);
+                calcTextSize();
             }
         };
 
@@ -1358,6 +1625,9 @@ export class Text extends Sprite {
             curLine = linePool.length > 0 ? linePool.pop() : <any>{};
             curLine.x = 0;
             curLine.y = lineY;
+            curLine.fillWidth = 0;
+            curLine.gapCount = 0;
+            curLine.appliedFillWidth = 0;
             this._lines.push(curLine);
             lastCmd = null;
 
@@ -1400,7 +1670,7 @@ export class Text extends Sprite {
                 //如果是标点符号，还需要保证不在行首
                 if (noBreakWord && ((ccode >= 65 && ccode <= 90) || (ccode >= 97 && ccode <= 122) //英文字符
                     || (ccode >= 48 && ccode <= 57) // 0-9
-                    || (isPunc = punctuationChars.includes(ccode)))) {
+                    || (isPunc = Text.punctuationChars.includes(ccode)))) {
                     let wb = part.length > 0 ? ((testResult = wordBoundaryTest.exec(part)) ? testResult.index : null) : 0;
                     if (wb > 0) { //边界在文本中间
                         if (wb > part.length - maxWordLength) { //限制字符个数，超过的不看做一个单词
@@ -1423,6 +1693,12 @@ export class Text extends Sprite {
                                 testResult = wordBoundaryTest.exec(cmd.wt.text);
                                 let textLen = cmd.wt.text.length;
                                 if (testResult == null) { //边界就在文本的末尾
+                                    if (isPunc && totalLen == 0) {
+                                        if (textLen > 1)
+                                            recordLineFillWidth(getLastCharWidth(cmd.wt.text, cmd.ctxFont, cmd.fontSize));
+                                        else if (cmd.x > 0)
+                                            recordLineFillWidth(cmd.width);
+                                    }
                                     addLine();
                                     if (isPunc && totalLen == 0) { //再次检查标点符号不能在行首
                                         if (splitCmd(cmd, textLen - 1)) //将最后一个字符移到下一行
@@ -1468,7 +1744,10 @@ export class Text extends Sprite {
                         if (isPunc) { //标点符号不允许在行首
                             let b = 1;
                             if (j - b > startIndex || lineX > 0) { //这里有个边界判断，如果只剩一个字符了，并且在行头，就不能移动了
+                                let movedChar = arrCh[j - b];
                                 j -= b; //回退一个字符
+                                if (movedChar)
+                                    recordLineFillWidth(getTextWidth(movedChar));
                                 arrPartCh = arrCh.slice(startIndex, j);
                                 part = arrPartCh.join("");
                                 wordWidth = null; //part指向的字符串已改变，wordWidth无效
@@ -1567,6 +1846,7 @@ export class Text extends Sprite {
             }
 
             addLine(true);
+            applyLineFillToLines();
             calcTextSize();
         };
 
@@ -1687,6 +1967,8 @@ export class Text extends Sprite {
 
             if (done || linesDeleted)
                 calcTextSize();
+
+            applySingleLineAutoFillToFinalLine();
         }
 
         if (this._onPostLayout)
@@ -1923,6 +2205,9 @@ export interface ITextLine {
     height: number;
     width: number;
     cmd: ITextCmd;
+    fillWidth: number;
+    gapCount: number;
+    appliedFillWidth: number;
 }
 
 const cmdPool: Array<ITextCmd> = [];
@@ -1958,7 +2243,6 @@ function cleanCmd(cmd: ITextCmd, releaseObj: boolean) {
 
 const emojiRegex = createEmojiRegex();
 const wordBoundaryTest = /[a-zA-Z0-9\!-\+\/_]+$/;
-const punctuationChars = Array.from(".,，。、!！；;”’)）]】}》").map(char => char.charCodeAt(0));
 const normalizeCR = /\r\n/g;
 const escapeCharsPattern = /\\(\w)/g;
 const escapeSequence: any = { "\\n": "\n", "\\t": "\t" };

--- a/src/layaAir/laya/display/Text.ts
+++ b/src/layaAir/laya/display/Text.ts
@@ -76,6 +76,7 @@ export class Text extends Sprite {
     static splitStr: (text: string) => string[] = defaultSplitStr;
     static punctuationChars: number[] = Array.from(".,，。、!！；;”’)）]】}》").map(char => char.charCodeAt(0));
     static lineEndForbiddenChars: number[] = Array.from("(（<《[［{｛【〈〔“‘「『").map(char => char.charCodeAt(0));
+    static wordBoundaryTest: RegExp = /(?:[+-]?\d+(?:\.\d+)*(?:[%％])?|[a-zA-Z0-9\!-\+\/_]+(?:\.[0-9\!-\+\/_]+)*)$/;
 
     /**
      * @en Dictionary of bitmap fonts.
@@ -1681,8 +1682,6 @@ export class Text extends Sprite {
             let wordWidth = 0;
             let startIndex = 0;
             let isPunc: boolean;
-            let testResult: RegExpExecArray;
-
             const arrCh = Text.splitStr(text);
             const chNum = arrCh.length;
             for (let j = maybeIndex; j < chNum; j++) {
@@ -1704,7 +1703,7 @@ export class Text extends Sprite {
                 if (noBreakWord && ((ccode >= 65 && ccode <= 90) || (ccode >= 97 && ccode <= 122) //英文字符
                     || (ccode >= 48 && ccode <= 57) // 0-9
                     || (isPunc = Text.punctuationChars.includes(ccode)))) {
-                    let wb = part.length > 0 ? ((testResult = wordBoundaryTest.exec(part)) ? testResult.index : null) : 0;
+                    let wb = getWordBoundaryIndex(part, cc);
                     if (wb > 0) { //边界在文本中间
                         if (wb > part.length - maxWordLength) { //限制字符个数，超过的不看做一个单词
                             if (isPunc) {
@@ -1732,9 +1731,9 @@ export class Text extends Sprite {
                                 if (cmd.obj != null)
                                     break;
 
-                                testResult = wordBoundaryTest.exec(cmd.wt.text);
+                                let cmdBoundary = getWordBoundaryIndex(cmd.wt.text, cc);
                                 let textLen = cmd.wt.text.length;
-                                if (testResult == null) { //边界就在文本的末尾
+                                if (cmdBoundary == null) { //边界就在文本的末尾
                                     let lastCmdChar = getLastSplitChar(cmd.wt.text);
                                     let forbidLineEnd = totalLen == 0 && lastCmdChar != null && Text.lineEndForbiddenChars.includes(lastCmdChar.charCodeAt(0));
                                     if (forbidLineEnd) {
@@ -1768,12 +1767,12 @@ export class Text extends Sprite {
                                     newLine = true;
                                     break;
                                 }
-                                else if (testResult.index > 0) {
-                                    if (testResult.index > textLen - (maxWordLength - totalLen)) { //限制字符个数，超过的不看做一个单词
+                                else if (cmdBoundary > 0) {
+                                    if (cmdBoundary > textLen - (maxWordLength - totalLen)) { //限制字符个数，超过的不看做一个单词
                                         if (isPunc && totalLen == 0)
-                                            recordLineFillWidth(getMovedWidthFromSplit(cmd, testResult.index) + (tw || 0));
+                                            recordLineFillWidth(getMovedWidthFromSplit(cmd, cmdBoundary) + (tw || 0));
                                         addLine();
-                                        splitCmd(cmd, testResult.index);
+                                        splitCmd(cmd, cmdBoundary);
                                         moveCmds(cmd.next);
 
                                         newLine = true;
@@ -2316,8 +2315,25 @@ function cleanCmd(cmd: ITextCmd, releaseObj: boolean) {
         cmd.wt.cleanCache();
 }
 
+function getWordBoundaryIndex(text: string, nextChar?: string): number | null {
+    if (text.length == 0)
+        return 0;
+
+    let testText = text;
+    if (nextChar) {
+        let ccode = nextChar.charCodeAt(0);
+        if (ccode >= 48 && ccode <= 57)
+            testText += nextChar;
+    }
+
+    let testResult = Text.wordBoundaryTest.exec(testText);
+    if (!testResult)
+        return null;
+
+    return testResult.index < text.length ? testResult.index : null;
+}
+
 const emojiRegex = createEmojiRegex();
-const wordBoundaryTest = /[a-zA-Z0-9\!-\+\/_]+$/;
 const normalizeCR = /\r\n/g;
 const escapeCharsPattern = /\\(\w)/g;
 const escapeSequence: any = { "\\n": "\n", "\\t": "\t" };

--- a/src/layaAir/laya/display/Text.ts
+++ b/src/layaAir/laya/display/Text.ts
@@ -73,6 +73,8 @@ export class Text extends Sprite {
     static _testWord: string = "游";
     static _passwordChar = "●";
 
+    static splitStr: (text: string) => string[] = defaultSplitStr;
+
     /**
      * @en Dictionary of bitmap fonts.
      * @zh 位图字体字典。
@@ -1279,9 +1281,17 @@ export class Text extends Sprite {
         };
 
         let splitCmd = (cmd: ITextCmd, pos: number) => {
-            let ccode = cmd.wt.text.charCodeAt(pos);
-            if (isLowSurrogate(ccode))
-                pos--;
+            const arrCh = Text.splitStr(cmd.wt.text);
+            let text = "";
+            for (let index = 0; index < arrCh.length; index++) {
+                const ch = arrCh[index];
+                const tmp = text + ch;
+                if (tmp.length > pos) {
+                    break;
+                }
+                text = tmp;
+            }
+            pos = text.length;
             if (pos == 0)
                 return false;
 
@@ -1370,34 +1380,22 @@ export class Text extends Sprite {
             let isPunc: boolean;
             let testResult: RegExpExecArray;
 
-            let isEmoji = emojiTest.test(text);
-            if (!bfont && !isEmoji) {
-                //优化2，预算第几个字符会超出，减少遍历及字符宽度度量
-                maybeIndex = Math.floor(remainWidth / charWidth);
-                if (maybeIndex != 0)
-                    wordWidth = getTextWidth(text.substring(0, maybeIndex));
-            }
-
-            let len = text.length;
-            for (let j = maybeIndex; j < len; j++) {
-                let cc = text.charAt(j);
-                let ccode = cc.charCodeAt(0);
-
-                if (isEmoji && isHighSurrogate(ccode) && j + 1 < len)
-                    cc += text.charAt(j + 1);
-
+            const arrCh = Text.splitStr(text);
+            const chNum = arrCh.length;
+            for (let j = maybeIndex; j < chNum; j++) {
+                let cc = arrCh[j];
                 tw = getTextWidth(cc);
                 wordWidth += tw;
 
                 if (wordWidth <= remainWidth || j === startIndex && lineX === 0) { //一行如果连一个字符都放不下，强制放一个
-                    if (cc.length > 1) //emoji
-                        j++;
                     continue;
                 }
 
-                let part = text.substring(startIndex, j);
+                let arrPartCh = arrCh.slice(startIndex, j);
+                let part = arrPartCh.join("");
                 wordWidth -= tw;
 
+                let ccode = cc.charCodeAt(0);
                 //如果换行位置是字母或标点符号，需要向前查找单词的边界，避免单词被拆开
                 //如果是标点符号，还需要保证不在行首
                 if (noBreakWord && ((ccode >= 65 && ccode <= 90) || (ccode >= 97 && ccode <= 122) //英文字符
@@ -1407,7 +1405,7 @@ export class Text extends Sprite {
                     if (wb > 0) { //边界在文本中间
                         if (wb > part.length - maxWordLength) { //限制字符个数，超过的不看做一个单词
                             j = startIndex + wb;
-                            part = text.substring(startIndex, j);
+                            part = part.substring(0, wb);
                             wordWidth = null; //part指向的字符串已改变，wordWidth无效
                             tw = null; //j指向的字符已改变，tw无效
                         }
@@ -1468,10 +1466,11 @@ export class Text extends Sprite {
                     }
                     else { //边界就在文本的末尾
                         if (isPunc) { //标点符号不允许在行首
-                            let b = (isEmoji && j >= 1 && isLowSurrogate(text.charCodeAt(j - 1))) ? 2 : 1;
+                            let b = 1;
                             if (j - b > startIndex || lineX > 0) { //这里有个边界判断，如果只剩一个字符了，并且在行头，就不能移动了
                                 j -= b; //回退一个字符
-                                part = text.substring(startIndex, j);
+                                arrPartCh = arrCh.slice(startIndex, j);
+                                part = arrPartCh.join("");
                                 wordWidth = null; //part指向的字符串已改变，wordWidth无效
                                 tw = null; //j指向的字符已改变，tw无效
                             }
@@ -1492,17 +1491,18 @@ export class Text extends Sprite {
                     j += maybeIndex - 1;
                 else if (tw != null) { //一个优化，如果是单字符遍历，而且j还是指向当前字符，那么直接用tw就行
                     wordWidth = tw;
-                    if (cc.length > 1)
-                        j++;
                 }
-                else if (isEmoji && isHighSurrogate(text.charCodeAt(j)))
-                    j++;
 
-                if (wordWidth == null && j < len - 1)
-                    wordWidth = getTextWidth(text.substring(startIndex, j + 1));
+                if (wordWidth == null && j < chNum - 1) {
+                    const arrTmpCh = arrCh.slice(startIndex, j + 1);
+                    const tmpText = arrTmpCh.join("");
+                    wordWidth = getTextWidth(tmpText);
+                }
             }
 
-            addCmd(text.substring(startIndex, len), style);
+            const arrLastCh = arrCh.slice(startIndex, chNum);
+            const lastText = arrLastCh.join("");
+            addCmd(lastText, style);
         };
 
         let calcTextSize = () => {
@@ -1667,14 +1667,14 @@ export class Text extends Sprite {
                         let space = cmd.x + cmd.width - rectWidth;
                         let remove = space < 5 ? 2 : space < 10 ? 1 : 0; //视剩余空间删减字符数量
                         let min = cmd === curLine.cmd ? 1 : 0; //如果是这行的第一个元素，则至少保留一个字符
-                        let i = cmd.wt.text.length;
+                        const arrLineCh = Text.splitStr(cmd.wt.text);
+                        let i = arrLineCh.length;
                         while (i > min && remove > 0) {
-                            if (isLowSurrogate(cmd.wt.text.charCodeAt(i - 1)))
-                                i--;
+                            arrLineCh.pop();
                             i--;
                             remove--;
                         }
-                        cmd.wt.setText(cmd.wt.text.substring(0, i) + ellipsisStr);
+                        cmd.wt.setText(arrLineCh.join("") + ellipsisStr);
                     }
                     cmd.width = cmd.wt.width = getTextWidth2(cmd.wt.text, cmd.ctxFont, cmd.fontSize);
                     cmd.next = null;
@@ -1956,7 +1956,7 @@ function cleanCmd(cmd: ITextCmd, releaseObj: boolean) {
         cmd.wt.cleanCache();
 }
 
-const emojiTest = /[\uD800-\uDBFF][\uDC00-\uDFFF]/;
+const emojiRegex = createEmojiRegex();
 const wordBoundaryTest = /[a-zA-Z0-9\!-\+\/_]+$/;
 const punctuationChars = Array.from(".,，。、!！；;”’)）]】}》").map(char => char.charCodeAt(0));
 const normalizeCR = /\r\n/g;
@@ -1969,10 +1969,39 @@ function getReplaceStr(word: string): string {
     return escapeSequence[word];
 }
 
-function isHighSurrogate(c: number): boolean {
-    return c >= 0xD800 && c <= 0xDBFF;
+// 从emoji-regex-xs抄的
+function createEmojiRegex() {
+    const r = String.raw;
+    const e = r`\p{Emoji}(?:\p{EMod}|[\u{E0020}-\u{E007E}]+\u{E007F}|\uFE0F?\u20E3?)`;
+    return new RegExp(r`\p{RI}{2}|(?![#*\d](?!\uFE0F?\u20E3))${e}(?:\u200D${e})*`, 'gu');
 }
 
-function isLowSurrogate(c: number): boolean {
-    return c >= 0xDC00 && c <= 0xDFFF;
+function defaultSplitStr(text: string): string[] {
+    // 可以考虑使用浏览器标准，只有现代浏览器支持
+    // if (typeof (Intl) == "object" && typeof (Intl.Segmenter) == "function") {
+    //     const segmenter = new Intl.Segmenter(undefined, { granularity: 'grapheme' });
+
+    //     // 使用分段器
+    //     const segments = segmenter.segment(text);
+
+    //     // 转换为数组
+    //     const result = Array.from(segments).map(s => s.segment);
+    //     return result;
+    // }
+    const arrCh: string[] = [];
+    let pos = 0;
+    text.replace(emojiRegex, function (match, offset) {
+        if (pos < offset) {
+            const tmp = text.substring(pos, offset);
+            arrCh.push(...tmp);
+        };
+        arrCh.push(match);
+        pos = offset + match.length;
+        return match; // 返回原值，不改变字符串
+    });
+    if (pos < text.length) {
+        const tmp = text.substring(pos);
+        arrCh.push(...tmp);
+    }
+    return arrCh;
 }

--- a/src/layaAir/laya/display/Text.ts
+++ b/src/layaAir/laya/display/Text.ts
@@ -1227,6 +1227,25 @@ export class Text extends Sprite {
             return width;
         };
 
+        let getCmdChainWidth = (cmd: ITextCmd) => {
+            let width = 0;
+            while (cmd) {
+                width += cmd.width;
+                cmd = cmd.next;
+            }
+            return width;
+        };
+
+        let getMovedWidthFromSplit = (cmd: ITextCmd, pos: number) => {
+            let width = getCmdChainWidth(cmd.next);
+            if (cmd.wt && pos < cmd.wt.text.length) {
+                let text = cmd.wt.text.substring(pos);
+                if (text.length > 0)
+                    width += getTextWidth2(text, cmd.ctxFont, cmd.fontSize);
+            }
+            return width;
+        };
+
         let recordLineFillWidth = (width: number) => {
             if (!enablePunctuationLineFill || width <= 0 || !curLine)
                 return;
@@ -1674,6 +1693,15 @@ export class Text extends Sprite {
                     let wb = part.length > 0 ? ((testResult = wordBoundaryTest.exec(part)) ? testResult.index : null) : 0;
                     if (wb > 0) { //边界在文本中间
                         if (wb > part.length - maxWordLength) { //限制字符个数，超过的不看做一个单词
+                            if (isPunc) {
+                                let movedText = part.substring(wb);
+                                let movedWidth = 0;
+                                if (movedText.length > 0)
+                                    movedWidth += getTextWidth(movedText);
+                                if (tw != null)
+                                    movedWidth += tw;
+                                recordLineFillWidth(movedWidth);
+                            }
                             j = startIndex + wb;
                             part = part.substring(0, wb);
                             wordWidth = null; //part指向的字符串已改变，wordWidth无效
@@ -1695,9 +1723,9 @@ export class Text extends Sprite {
                                 if (testResult == null) { //边界就在文本的末尾
                                     if (isPunc && totalLen == 0) {
                                         if (textLen > 1)
-                                            recordLineFillWidth(getLastCharWidth(cmd.wt.text, cmd.ctxFont, cmd.fontSize));
+                                            recordLineFillWidth(getMovedWidthFromSplit(cmd, textLen - 1) + (tw || 0));
                                         else if (cmd.x > 0)
-                                            recordLineFillWidth(cmd.width);
+                                            recordLineFillWidth(getMovedWidthFromSplit(cmd, 0) + (tw || 0));
                                     }
                                     addLine();
                                     if (isPunc && totalLen == 0) { //再次检查标点符号不能在行首
@@ -1714,6 +1742,8 @@ export class Text extends Sprite {
                                 }
                                 else if (testResult.index > 0) {
                                     if (testResult.index > textLen - (maxWordLength - totalLen)) { //限制字符个数，超过的不看做一个单词
+                                        if (isPunc && totalLen == 0)
+                                            recordLineFillWidth(getMovedWidthFromSplit(cmd, testResult.index) + (tw || 0));
                                         addLine();
                                         splitCmd(cmd, testResult.index);
                                         moveCmds(cmd.next);
@@ -1746,8 +1776,12 @@ export class Text extends Sprite {
                             if (j - b > startIndex || lineX > 0) { //这里有个边界判断，如果只剩一个字符了，并且在行头，就不能移动了
                                 let movedChar = arrCh[j - b];
                                 j -= b; //回退一个字符
+                                let movedWidth = 0;
                                 if (movedChar)
-                                    recordLineFillWidth(getTextWidth(movedChar));
+                                    movedWidth += getTextWidth(movedChar);
+                                if (tw != null)
+                                    movedWidth += tw;
+                                recordLineFillWidth(movedWidth);
                                 arrPartCh = arrCh.slice(startIndex, j);
                                 part = arrPartCh.join("");
                                 wordWidth = null; //part指向的字符串已改变，wordWidth无效

--- a/src/layaAir/laya/display/Text.ts
+++ b/src/layaAir/laya/display/Text.ts
@@ -75,6 +75,7 @@ export class Text extends Sprite {
 
     static splitStr: (text: string) => string[] = defaultSplitStr;
     static punctuationChars: number[] = Array.from(".,，。、!！；;”’)）]】}》").map(char => char.charCodeAt(0));
+    static lineEndForbiddenChars: number[] = Array.from("(（<《[［{｛【〈〔“‘「『").map(char => char.charCodeAt(0));
 
     /**
      * @en Dictionary of bitmap fonts.
@@ -1225,12 +1226,9 @@ export class Text extends Sprite {
             }
         };
 
-        let getLastCharWidth = (text: string, font: string, curFontSize: number) => {
+        let getLastSplitChar = (text: string) => {
             let arrCh = Text.splitStr(text);
-            if (arrCh.length == 0)
-                return 0;
-
-            return getTextWidth2(arrCh[arrCh.length - 1], font, curFontSize);
+            return arrCh.length > 0 ? arrCh[arrCh.length - 1] : null;
         };
 
         let getLineWidth = (line: ITextLine) => {
@@ -1737,14 +1735,28 @@ export class Text extends Sprite {
                                 testResult = wordBoundaryTest.exec(cmd.wt.text);
                                 let textLen = cmd.wt.text.length;
                                 if (testResult == null) { //边界就在文本的末尾
-                                    if (isPunc && totalLen == 0) {
+                                    let lastCmdChar = getLastSplitChar(cmd.wt.text);
+                                    let forbidLineEnd = totalLen == 0 && lastCmdChar != null && Text.lineEndForbiddenChars.includes(lastCmdChar.charCodeAt(0));
+                                    if (forbidLineEnd) {
+                                        if (textLen > 1)
+                                            recordLineFillWidth(getMovedWidthFromSplit(cmd, textLen - 1));
+                                        else if (cmd.x > 0)
+                                            recordLineFillWidth(getMovedWidthFromSplit(cmd, 0));
+                                    }
+                                    else if (isPunc && totalLen == 0) {
                                         if (textLen > 1)
                                             recordLineFillWidth(getMovedWidthFromSplit(cmd, textLen - 1) + (tw || 0));
                                         else if (cmd.x > 0)
                                             recordLineFillWidth(getMovedWidthFromSplit(cmd, 0) + (tw || 0));
                                     }
                                     addLine();
-                                    if (isPunc && totalLen == 0) { //再次检查标点符号不能在行首
+                                    if (forbidLineEnd) { //再次检查禁排行尾符号不能留在上一行末尾
+                                        if (splitCmd(cmd, textLen - 1)) //将最后一个字符移到下一行
+                                            moveCmds(cmd.next);
+                                        else if (cmd.x > 0) //如果命令不在行首，整个命令移到下一行
+                                            moveCmds(cmd);
+                                    }
+                                    else if (isPunc && totalLen == 0) { //再次检查标点符号不能在行首
                                         if (splitCmd(cmd, textLen - 1)) //将最后一个字符移到下一行
                                             moveCmds(cmd.next);
                                         else if (cmd.x > 0) //如果命令不在行首，整个命令移到下一行
@@ -1805,6 +1817,19 @@ export class Text extends Sprite {
                             }
                         }
                         //else 做默认处理即可
+                    }
+                }
+
+                let tailChar = part.length > 0 ? getLastSplitChar(part) : null;
+                if (tailChar && Text.lineEndForbiddenChars.includes(tailChar.charCodeAt(0))) {
+                    let b = 1;
+                    if (j - b > startIndex || lineX > 0) {
+                        j -= b; //回退一个禁排行尾字符
+                        recordLineFillWidth(getTextWidth(tailChar));
+                        arrPartCh = arrCh.slice(startIndex, j);
+                        part = arrPartCh.join("");
+                        wordWidth = null; //part指向的字符串已改变，wordWidth无效
+                        tw = null; //j指向的字符已改变，tw无效
                     }
                 }
 
@@ -2298,7 +2323,6 @@ const escapeCharsPattern = /\\(\w)/g;
 const escapeSequence: any = { "\\n": "\n", "\\t": "\t" };
 const ellipsisStr = "…";
 const maxWordLength = 20;
-
 function getReplaceStr(word: string): string {
     return escapeSequence[word];
 }

--- a/src/layaAir/laya/display/Text.ts
+++ b/src/layaAir/laya/display/Text.ts
@@ -186,6 +186,7 @@ export class Text extends Sprite {
     protected _hideText: boolean;
     private _updatingLayout: boolean;
     private _fontSizeScale: number;
+    private _lineFill: boolean = false;
     private _singleLineAutoFill: boolean = false;
     private _lineFillRemainderPolicy: "ltr" | "rtl" = "ltr";
 
@@ -579,6 +580,21 @@ export class Text extends Sprite {
     set wordWrap(value: boolean) {
         if (this._wordWrap != value) {
             this._wordWrap = value;
+            this.markChanged();
+        }
+    }
+
+    /**
+     * @en Whether to fill the remaining width of a wrapped line after line-break adjustment.
+     * @zh 在自动换行发生挪字调整后，是否补字间距以撑满该行剩余宽度。
+     */
+    get lineFill(): boolean {
+        return this._lineFill;
+    }
+
+    set lineFill(value: boolean) {
+        if (this._lineFill != value) {
+            this._lineFill = value;
             this.markChanged();
         }
     }
@@ -1175,7 +1191,7 @@ export class Text extends Sprite {
         let rectHeight = this._isHeightSet ? (this._height - padding[0] - padding[2]) : Number.MAX_VALUE;
         let bfont = this._bitmapFont;
         let alignItems = this._textStyle.alignItems == "middle" ? 1 : (this._textStyle.alignItems == "bottom" ? 2 : 0);
-        let enablePunctuationLineFill = wordWrap && this._overflow != Text.SHRINK;
+        let enablePunctuationLineFill = this._lineFill && wordWrap && this._overflow != Text.SHRINK;
         let enableSingleLineAutoFill = this._singleLineAutoFill && !this._wordWrap && this._isWidthSet
             && this._overflow != Text.SHRINK;
         let enableLineFill = enablePunctuationLineFill || enableSingleLineAutoFill;

--- a/src/layaAir/laya/html/HtmlParser.ts
+++ b/src/layaAir/laya/html/HtmlParser.ts
@@ -145,6 +145,16 @@ export class HtmlParser {
 
                         this._style.fontSize = XMLUtils.getInt(XMLIterator.attributes, "size", this._style.fontSize);
                         let color: string = XMLIterator.getAttribute("color");
+
+                        let strokeColor: string = XMLIterator.getAttribute("strokecolor");
+                        let strokeSize: string = XMLIterator.getAttribute("stroke");
+                        if (strokeColor != null) {
+                            this._style.strokeColor = strokeColor;
+                            (<any>this._style).colorChanged = true;
+                        }
+                        if(strokeSize != null) {
+                            this._style.stroke = Number(strokeSize);
+                        }
                         if (color != null) {
                             this._style.color = color;
                             (<any>this._style).colorChanged = true;

--- a/src/layaAir/laya/loaders/TextureLoader.ts
+++ b/src/layaAir/laya/loaders/TextureLoader.ts
@@ -123,7 +123,7 @@ export class Texture2DLoader implements IResourceLoader {
                                 return null;
                         }
                         else if (ktxInfo.dimension == TextureDimension.Tex2D) {
-                            tex = Texture2D._parseKTX(data, propertyParams, constructParams);
+                            tex = Texture2D._parseKTX(ktxInfo, propertyParams, constructParams);
                         }
                         break;
                     case "pvr":

--- a/src/layaAir/laya/net/HttpRequest.ts
+++ b/src/layaAir/laya/net/HttpRequest.ts
@@ -89,6 +89,9 @@ export class HttpRequest extends EventDispatcher {
         http.onload = (e: any) => {
             this._onLoad(e);
         }
+        http.ontimeout = (e: any) => {
+            this.error("timeout");
+        }
 
         http.send(data);
     }
@@ -180,7 +183,7 @@ export class HttpRequest extends EventDispatcher {
      */
     protected clear(): void {
         var http: any = this._http;
-        http.onerror = http.onabort = http.onprogress = http.onload = null;
+        http.onerror = http.onabort = http.onprogress = http.onload = http.ontimeout = null;
     }
 
     /**

--- a/src/layaAir/laya/renders/Context.ts
+++ b/src/layaAir/laya/renders/Context.ts
@@ -1002,7 +1002,7 @@ export class Context {
                 break;
             case 7://destination
                 shaderdata.setInt(Shader3D.BLEND_SRC, RenderState.BLENDPARAM_ZERO);
-                shaderdata.setInt(Shader3D.BLEND_DST, RenderState.BLENDPARAM_ZERO);
+                shaderdata.setInt(Shader3D.BLEND_DST, RenderState.BLENDPARAM_ONE_MINUS_SRC_ALPHA);
                 break;
             case 9:// not premul alpha
                 shaderdata.setInt(Shader3D.BLEND_SRC, RenderState.BLENDPARAM_SRC_ALPHA);

--- a/src/layaAir/laya/renders/RenderSprite.ts
+++ b/src/layaAir/laya/renders/RenderSprite.ts
@@ -328,8 +328,12 @@ export class RenderSprite {
             //计算cache画布的大小
             Stat.canvasBitmap++;
 
-            let w = tRec.width * scaleInfo.x + marginLeft + marginRight;  //,
-            let h = tRec.height * scaleInfo.y + marginTop + marginBottom;
+            //overscan: _calculateCacheRect 会对小数 bounds 做 floor，内容右/下沿最多可被裁 ~2px，
+            //且抗锯齿/描边外延会紧贴 RT 边界。四周各补 2px 透明边避免内容被裁切，
+            //同时 tRec 同步平移，保证 blit 回贴仍为 1:1 像素映射（仅 cacheAs=bitmap 路径使用，不影响 mask）。
+            const cachePad = 2;
+            let w = tRec.width * scaleInfo.x + marginLeft + marginRight + cachePad * 2;  //,
+            let h = tRec.height * scaleInfo.y + marginTop + marginBottom + cachePad * 2;
             let rt = new RenderTexture2D(w, h, RenderTargetFormat.R8G8B8A8);
             let ctx = new Context();
             ctx.copyState(context);
@@ -346,8 +350,8 @@ export class RenderSprite {
                 所以为了rt能正确的包含节点的渲染效果，应该偏移一下节点再渲染，具体就是取节点在rt坐标系下的值
                 当使用这个rt的时候，要反向偏移，即偏移rt在节点坐标系下的值
             */
-            tRec.x -= marginLeft;   //margin要算到偏移中
-            tRec.y -= marginTop;
+            tRec.x -= marginLeft + cachePad;   //margin要算到偏移中
+            tRec.y -= marginTop + cachePad;
             this._next._fun(sprite, ctx, -tRec.x, -tRec.y);
             ctx.endRender();
             Render2DSimple.rendercontext2D.invertY = tempY;
@@ -380,7 +384,14 @@ export class RenderSprite {
             var tRec = _cacheStyle.cacheRect;
             context._material = sprite.graphics.material;
             let rt = _cacheStyle.renderTexture;
-            rt && context._drawRenderTexture(rt, x + tRec.x, y + tRec.y, rt.width, rt.height, null, 1, [0, 1, 1, 1, 1, 0, 0, 0]);
+            if (rt) {
+                // 回贴按设备像素对齐（与文本直绘的 drawTexAlign 一致），
+                // 避免节点/父链位于小数坐标时整张 RT 被双线性重采样导致模糊。
+                let preAlign = context.drawTexAlign;
+                context.drawTexAlign = true;
+                context._drawRenderTexture(rt, x + tRec.x, y + tRec.y, rt.width, rt.height, null, 1, [0, 1, 1, 1, 1, 0, 0, 0]);
+                context.drawTexAlign = preAlign;
+            }
             context._material = null;
         } else {
             if (!RenderSprite.cacheNormalEnable) {

--- a/src/layaAir/laya/renders/RenderSprite.ts
+++ b/src/layaAir/laya/renders/RenderSprite.ts
@@ -636,8 +636,11 @@ export class RenderSprite {
 
         let tex = cache.renderTexture;
         let rect = cache.cacheRect;
+        let preAlign = ctx.drawTexAlign;
+        ctx.drawTexAlign = true;
         ctx._drawRenderTexture(tex,
             x + rect.x, y + rect.y, tex.width, tex.height, null, 1, [0, 1, 1, 1, 1, 0, 0, 0])
+        ctx.drawTexAlign = preAlign;
     }
 }
 

--- a/src/layaAir/laya/renders/RenderSprite.ts
+++ b/src/layaAir/laya/renders/RenderSprite.ts
@@ -330,7 +330,7 @@ export class RenderSprite {
 
             //overscan: _calculateCacheRect 会对小数 bounds 做 floor，内容右/下沿最多可被裁 ~2px，
             //且抗锯齿/描边外延会紧贴 RT 边界。四周各补 2px 透明边避免内容被裁切，
-            //同时 tRec 同步平移，保证 blit 回贴仍为 1:1 像素映射（仅 cacheAs=bitmap 路径使用，不影响 mask）。
+            //同时 tRec 同步平移，保证 blit 回贴仍为 1:1 像素映射。
             const cachePad = 2;
             let w = tRec.width * scaleInfo.x + marginLeft + marginRight + cachePad * 2;  //,
             let h = tRec.height * scaleInfo.y + marginTop + marginBottom + cachePad * 2;
@@ -350,9 +350,17 @@ export class RenderSprite {
                 所以为了rt能正确的包含节点的渲染效果，应该偏移一下节点再渲染，具体就是取节点在rt坐标系下的值
                 当使用这个rt的时候，要反向偏移，即偏移rt在节点坐标系下的值
             */
-            tRec.x -= marginLeft + cachePad;   //margin要算到偏移中
-            tRec.y -= marginTop + cachePad;
-            this._next._fun(sprite, ctx, -tRec.x, -tRec.y);
+            let offX = tRec.x - marginLeft - cachePad;   //margin和cachePad要算到偏移中
+            let offY = tRec.y - marginTop - cachePad;
+            this._next._fun(sprite, ctx, -offX, -offY);
+            /*
+                注意：若当前节点同时带有 mask，_next._fun 执行的正是 _mask。
+                _mask 内部会重新调用 _calculateCacheRect 并直接修改 _cacheStyle.cacheRect，
+                会将前面减去的 cachePad 偏移冲掉，导致后续 blit 回贴时丢失补偿，使得整体向右下偏移 cachePad(2px)。
+                因此必须在 _next 执行完毕后，强制将计算好的 offX/offY 写回 _cacheStyle.cacheRect。
+            */
+            _cacheStyle.cacheRect.x = offX;
+            _cacheStyle.cacheRect.y = offY;
             ctx.endRender();
             Render2DSimple.rendercontext2D.invertY = tempY;
             //临时，恢复

--- a/src/layaAir/laya/resource/Texture2D.ts
+++ b/src/layaAir/laya/resource/Texture2D.ts
@@ -249,8 +249,7 @@ export class Texture2D extends BaseTexture {
     /**
      * @internal
      */
-    static _parseKTX(data: ArrayBuffer, propertyParams: TexturePropertyParams = null, constructParams: TextureConstructParams = null) {
-        let ktxInfo = KTXTextureInfo.getKTXTextureInfo(data);
+    static _parseKTX(ktxInfo: KTXTextureInfo, propertyParams: TexturePropertyParams = null, constructParams: TextureConstructParams = null) {
 
         let texture = new Texture2D(ktxInfo.width, ktxInfo.height, ktxInfo.format, ktxInfo.mipmapCount > 1, false, ktxInfo.sRGB);
 

--- a/src/layaAir/laya/spine/Spine2DRenderNode.ts
+++ b/src/layaAir/laya/spine/Spine2DRenderNode.ts
@@ -35,6 +35,10 @@ import { ShaderDefines2D } from "../webgl/shader/d2/ShaderDefines2D";
 import { Matrix4x4 } from "../maths/Matrix4x4";
 import { Vector4 } from "../maths/Vector4";
 
+export interface IPlayTrackAniOptions {
+    start?: number,
+}
+
 /**
  * @en The spine animation consists of three parts: `SpineTemplet`, `SpineSkeletonRender`, and `SpineSkeleton`.
  * - Event.PLAYED Used for animation start playing dispatch
@@ -460,6 +464,9 @@ export class Spine2DRenderNode extends BaseRenderNode2D implements ISpineSkeleto
                 // console.log("dispose:", entry);
             },
             complete: (entry: any) => {
+                if (entry.trackIndex != 0) {
+                    return;
+                }
                 // console.log("complete:", entry);
                 this.event(Event.END);
                 if (entry.loop) { // 如果多次播放,发送complete事件
@@ -469,6 +476,9 @@ export class Spine2DRenderNode extends BaseRenderNode2D implements ISpineSkeleto
                 }
             },
             event: (entry: any, event: any) => {
+                if (entry.trackIndex != 0) {
+                    return;
+                }
                 let eventData = {
                     audioValue: event.data.audioPath,
                     audioPath: event.data.audioPath,
@@ -555,6 +565,34 @@ export class Spine2DRenderNode extends BaseRenderNode2D implements ISpineSkeleto
             this._update();
             this.event(Event.PLAYED);
         }
+    }
+
+    /**
+     * @zh 播放叠轨动画。
+     * @param nameOrIndex 动画名字或者索引。
+     * @param loop 是否循环播放。
+     * @param options 播放选项。
+     * @returns 
+     */
+    public playTrackAni(nameOrIndex: string | number, loop: boolean, options?: IPlayTrackAniOptions) {
+        if (typeof nameOrIndex == "number") {
+            nameOrIndex = this.getAniNameByIndex(nameOrIndex);
+        }else{
+            let hasAni = !!this.templet.findAnimation(nameOrIndex);
+            if (!hasAni) return
+        }
+        const start = options && typeof (options.start) == "number" ? options.start : 0;
+        const trackEntry = this._state.setAnimation(1, nameOrIndex, loop);
+        if (trackEntry) {
+            trackEntry.animationStart = start;
+        }
+    }
+
+    /**
+     * @zh 停止叠轨动画。
+     */
+    public stopTrackAni(): void {
+        this._state.clearTrack(1);
     }
 
     private _update(): void {

--- a/src/layaAir/laya/ui/List.ts
+++ b/src/layaAir/laya/ui/List.ts
@@ -726,7 +726,7 @@ export class List extends Box {
         let scrollValue = this._scrollBar!.value;
         let lineX = (this._isVertical ? this.repeatX : this.repeatY);
         let lineY = (this._isVertical ? this.repeatY : this.repeatX);
-        let scrollLine = Math.floor(scrollValue / this._cellSize);
+        let scrollLine = Math.floor(Math.max(scrollValue, 0) / this._cellSize);
 
         if (!this.cacheContent) {
             let index = scrollLine * lineX;

--- a/src/layaAir/laya/utils/Delegate.ts
+++ b/src/layaAir/laya/utils/Delegate.ts
@@ -8,6 +8,8 @@ const ITEM_LAYOUT = 4; //callback,target,args,flag(0-deleted,1-normal,2-once)
  * 它支持一次性回调，并且可以管理具有不同目标对象和参数的回调函数。
  */
 export class Delegate {
+    static delegateInvokeCatchError: (error: any) => void;
+
     private _flag: number;
     private _items: Array<any>;
 
@@ -154,6 +156,9 @@ export class Delegate {
             }
             catch (err: any) {
                 console.error(err);
+                if (Delegate.delegateInvokeCatchError) {
+                    Delegate.delegateInvokeCatchError(err);
+                }
             }
             if (arr[i + 3] === 2) {
                 arr[i + 3] = 0;

--- a/src/layaAir/laya/utils/Timer.ts
+++ b/src/layaAir/laya/utils/Timer.ts
@@ -14,6 +14,7 @@ export class Timer {
     /**@private */
     static _mid: number = 1;
 
+    static timerHandlerCatchError: (error: any) => void;
 
     /**
      * @en Scale of the clock hand.
@@ -483,12 +484,20 @@ class TimerHandler {
      * @param withClear 是否在执行后清除处理程序。
      */
     run(withClear: boolean): void {
-        var caller: any = this.caller;
-        if (caller && caller.destroyed) return this.clear();
-        var method: Function = this.method;
-        var args: any[] = this.args;
-        withClear && this.clear();
-        if (method == null) return;
-        args ? method.apply(caller, args) : method.call(caller);
+        try {
+            var caller: any = this.caller;
+            if (caller && caller.destroyed) return this.clear();
+            var method: Function = this.method;
+            var args: any[] = this.args;
+            withClear && this.clear();
+            if (method == null) return;
+            args ? method.apply(caller, args) : method.call(caller);
+        } catch (error) {
+            if (Timer.timerHandlerCatchError) {
+                Timer.timerHandlerCatchError(error);
+            } else {
+                throw error;
+            }
+        }
     }
 }


### PR DESCRIPTION
[简单支持叠轨动画](https://github.com/layabox/LayaAir/commit/b1bd40bf5caa8417a91ab05065ed8fd62fa54bd2)
可以做一些简单的叠轨融合效果。

[HttpRequest处理ontimeout](https://github.com/layabox/LayaAir/commit/cc8db6c05642bc6eb6580c958fb47a9cdc8d52b5)
不处理超时的话，有些情况会导致逻辑卡死。

[修正List滚动到负数时引起的bug](https://github.com/layabox/LayaAir/commit/e761913bbbe5ae0b3d0662ac20f6d481429e8298)
解决List开启回弹效果时，滚动位置为负数，会导致List item对象不停的重建。

[HtmlParser支持文字描边](https://github.com/layabox/LayaAir/commit/666f9c890275d8ffeb3a5f0a2fc9f0eedf016eeb)
富文本描边，懂得都懂。

[定时器触发时，进行try catch，增加代码健壮性](https://github.com/layabox/LayaAir/commit/0a69987711ff170b225878bc80d955f691a2c75d)
定时器回调代码崩溃的话，整个逻辑就卡住了。所以try catch继续。catch回调可以做一些数据上报之类的事情。

[Delegate执行时try catch可以回调给逻辑层](https://github.com/layabox/LayaAir/commit/d7a2c1119aa7607ef7474a9d75633f6c467a7b6a)
catch回调可以做一些数据上报之类的事情。

[优化emoji排版](https://github.com/layabox/LayaAir/commit/b24a08a2064e48535f4807daa628b9ab6026957f)
根据最新的emoji标准进行排版，单个可见字符不被换行拆分。
比如"🇨🇳"不会被拆分成两个。
已知问题“👩‍👩‍👧‍👦”在逻辑上算是一个可见字符，但是在各个平台上，可能会显示出多个字符。

[修正使用blendMode = "destination-out"配合image抠图时，透明部分也被扣掉的bug](https://github.com/layabox/LayaAir/commit/875ae1e56ed0e67bb7dd3298e4c193d58ec38882)
修正透明抠图bug。



