### PR TITLE
fix: LayoutBox skipHidden 不响应子节点 visible 动态变化

### DIFF
--- a/src/layaAir/laya/ui/HBox.ts
+++ b/src/layaAir/laya/ui/HBox.ts
@@ -72,7 +72,7 @@ export class HBox extends LayoutBox {
     }
 
     protected changeItems(): void {
-        this._itemChanged = false;
+        super.changeItems();
 
         const items: UIComponent[] = [];
         let maxChildHeight = 0;      // 子项最大高度（用于对齐/可能用于自适应高）

--- a/src/layaAir/laya/ui/LayoutBox.ts
+++ b/src/layaAir/laya/ui/LayoutBox.ts
@@ -24,6 +24,8 @@ export class LayoutBox extends Box {
     protected _skipHidden: boolean = false;
     /** 自适应模式, 默认值为 AUTO_SIZE_NONE。*/
     protected _autoSizeMode: string = LayoutBox.AUTO_SIZE_NONE;
+    /** @internal */
+    private _childVisibleStates: boolean[] | null = null;
     /**
      * @zh 子对象的间隔。
      * @en The space between child objects.
@@ -77,6 +79,10 @@ export class LayoutBox extends Box {
      */
     protected changeItems(): void {
         this._itemChanged = false;
+        if (this._skipHidden && this.numChildren > 0) {
+            this._snapshotVisibility();
+            this.callLater(this._detectVisibilityChange);
+        }
     }
 
     /** 
@@ -95,6 +101,30 @@ export class LayoutBox extends Box {
 
     private onResize(e: Event): void {
         this._setItemChanged();
+    }
+
+    private _snapshotVisibility(): void {
+        let n = this.numChildren;
+        if (!this._childVisibleStates)
+            this._childVisibleStates = [];
+        this._childVisibleStates.length = n;
+        for (let i = 0; i < n; i++) {
+            this._childVisibleStates[i] = (this.getChildAt(i) as Sprite).visible;
+        }
+    }
+
+    private _detectVisibilityChange(): void {
+        if (!this._skipHidden || !this._childVisibleStates || this._destroyed) return;
+        let n = this.numChildren;
+        let states = this._childVisibleStates;
+        if (n !== states.length) return;
+        for (let i = 0; i < n; i++) {
+            if ((this.getChildAt(i) as Sprite).visible !== states[i]) {
+                this._setItemChanged();
+                return;
+            }
+        }
+        this.callLater(this._detectVisibilityChange);
     }
 
     /**

--- a/src/layaAir/laya/ui/VBox.ts
+++ b/src/layaAir/laya/ui/VBox.ts
@@ -77,7 +77,7 @@ export class VBox extends LayoutBox {
     }
 
     protected changeItems(): void {
-        this._itemChanged = false;
+        super.changeItems();
 
         const items: UIComponent[] = [];
         let maxChildWidth = 0;       // 子项最大宽（用于对齐/可能用于自适应宽）


### PR DESCRIPTION
## 问题描述

VBox/HBox 的 `skipHidden` 属性在子节点 `visible` 动态变化时不会自动重新布局。

原问题链接：https://ask.layaair.com/d/54815-vBox-skipHidden-shu-xing-bu-qi-zuo-yong

## 修复内容

1. **LayoutBox.ts**：在 `changeItems()` 中增加子节点可见性快照与 `callLater` 轮询检测，当检测到子节点 `visible` 状态变化时自动触发重新布局。
2. **VBox.ts / HBox.ts**：将 `changeItems()` 中的 `this._itemChanged = false` 改为 `super.changeItems()`，确保 LayoutBox 的检测逻辑能够执行。

## 改动文件

- `src/layaAir/laya/ui/LayoutBox.ts`
- `src/layaAir/laya/ui/VBox.ts`
- `src/layaAir/laya/ui/HBox.ts`