### PR TITLE
fix(forum-54964): Physics2D destroy callLater closure captures null

### DIFF
--- a/src/layaAir/laya/physics/Physics2DWorldManager.ts
+++ b/src/layaAir/laya/physics/Physics2DWorldManager.ts
@@ -415,8 +415,9 @@ export class Physics2DWorldManager implements IElementComponentManager {
     destroy(): void {
         Physics2D.I._factory.removeBody(this._box2DWorld, Physics2D.I._emptyBody);
         Physics2D.I._emptyBody = null;
+        let box2DWorld = this._box2DWorld;
         Laya.timer.callLater(this, () => {
-            Physics2D.I._factory.destroyWorld(this._box2DWorld);
+            Physics2D.I._factory.destroyWorld(box2DWorld);
         })
         if (this._debugDraw) {
             this._debugDraw.destroy();


### PR DESCRIPTION
## Summary
- `Physics2DWorldManager.destroy()` 中 `callLater` 回调通过 `this._box2DWorld` 引用物理世界，但同步代码紧接着将其置 null，导致回调执行时物理世界未被真正销毁
- 修复：在 `callLater` 前用局部变量保存 `_box2DWorld`，回调中使用局部变量

## 论坛帖子
https://ask.layaair.com/d/54964

## Test plan
- [ ] 创建带 2D 物理的场景，切换/销毁场景后确认物理世界被正确销毁
- [ ] 确认 destroy 后重新创建物理场景能正常工作

🤖 Generated with [Claude Code](https://claude.com/claude-code)