### PR TITLE
fix(forum-54966): getChildAt should return null instead of throwing on out-of-range index

### DIFF
--- a/src/layaAir/laya/display/Node.ts
+++ b/src/layaAir/laya/display/Node.ts
@@ -430,7 +430,7 @@ export class Node extends EventDispatcher {
             }
             return node;
         } else {
-            throw new OutOfRangeError(index);
+            return null;
         }
     }
 
@@ -492,7 +492,7 @@ export class Node extends EventDispatcher {
         if (index >= 0 && index < this.numChildren)
             return <T>this._$children[index];
         else
-            throw new OutOfRangeError(index);
+            return null;
     }
 
     /**
@@ -758,7 +758,7 @@ export class Node extends EventDispatcher {
             }
             return node;
         } else {
-            throw new OutOfRangeError(index);
+            return null;
         }
     }
 


### PR DESCRIPTION
## Summary
- `getChildAt` 在 3.3 中索引越界时抛出 `OutOfRangeError`，与文档注释（返回 null）不一致
- 恢复为返回 null 的行为，与文档描述保持一致
- 同步修复到 Master3.0 分支

## 论坛帖子
https://ask.layaair.com/d/54966

🤖 Generated with [Claude Code](https://claude.com/claude-code)