### PR TITLE
fix(forum-54904): ChainShape2D loop=true crashes when vertex count < 3

### DIFF
--- a/src/layaAir/laya/physics/Shape/ChainShape2D.ts
+++ b/src/layaAir/laya/physics/Shape/ChainShape2D.ts
@@ -70,6 +70,9 @@ export class ChainShape2D extends Physics2DShapeBase {
         if (!LayaEnv.isPlaying || !this._body || !this._box2DBody) return;
         var len: number = this._datas.length;
         if (len % 2 == 1) throw "ChainCollider datas lenth must a multiplier of 2";
+        var pointCount: number = len >> 1;
+        // Box2D CreateChain requires >= 2 vertices, CreateLoop requires >= 3
+        if (pointCount < 2 || (this._loop && pointCount < 3)) return;
         let shape: any = this._box2DShape ? Physics2D.I._factory.getShape(this._box2DShape, this._shapeDef.shapeType) : Physics2D.I._factory.getShapeByDef(this._box2DShapeDef, this._shapeDef.shapeType);
         Physics2D.I._factory.set_ChainShape_data(shape, this.pivotoffx, this.pivotoffy, this._datas, this._loop, this.scaleX, this.scaleY);
     }


### PR DESCRIPTION
## Summary
- Fix ChainShape2D `_updateShapeData` crashing when `loop=true` with fewer than 3 vertices
- Default vertex data has only 2 points, but Box2D `CreateLoop` requires at least 3

## References
- 论坛反馈: https://ask.layaair.com/d/54904
- TAPD: https://www.tapd.cn/56535312/bugtrace/bugs/view/1156535312001023636

🤖 Generated with [Claude Code](https://claude.com/claude-code)