### PR TITLE
fix(forum-54972): 2D粒子在native模式下不显示

### DIFF
--- a/src/layaAir/laya/particle/d2/ShurikenParticle2DRenderer.ts
+++ b/src/layaAir/laya/particle/d2/ShurikenParticle2DRenderer.ts
@@ -792,6 +792,10 @@ export class ShurikenParticle2DRenderer extends BaseRenderNode2D {
             let element = createRenderElement(geometry);
             this._renderElements.push(element);
         }
+
+        if (this.owner) {
+            this.owner._struct.renderElements = this._renderElements;
+        }
     }
 
     private _updateParticleBuffer(startActive: number, endActive: number) {


### PR DESCRIPTION
## Summary
- 修复 `ShurikenParticle2DRenderer` 在 `_createRenderElements()` 重建渲染元素后未同步到 native struct，导致 native 打包下粒子不显示的问题

## 论坛反馈
https://ask.layaair.com/d/54972

🤖 Generated with [LayaBot](https://github.com/nicengi/LayaBot)