### PR TITLE
fix(forum-54975): TimeLine first label at time 0 not firing LABEL event

### DIFF
--- a/src/layaAir/laya/tween/TimeLine.ts
+++ b/src/layaAir/laya/tween/TimeLine.ts
@@ -258,6 +258,11 @@ export class TimeLine extends EventDispatcher {
                         tTween = Tween.from(tTweenData.target, tTweenData.data, tTweenData.duration, tTweenData.ease, Handler.create(this, this._animComplete));
                     this._tweenDic.push(tTween);
                 }
+            } else if (tTweenData.type == 1) {
+                if (time >= tTweenData.startTime) {
+                    this._index = Math.max(this._index, i + 1);
+                    this.event(Event.LABEL, tTweenData.data);
+                }
             }
         }
     }


### PR DESCRIPTION
修复论坛反馈 https://ask.layaair.com/d/54975

## 问题
`play(0)` 时 `gotoTime()` 只处理 type==0（tween）的数据项，但会推进 `_index`，导致 startTime=0 的第一个 label 被跳过，`LABEL` 事件永远不触发。

## 修复
`gotoTime()` 现在同时处理 label 类型的数据项，确保 label 事件正常触发。

🤖 Generated with [LayaBot](https://github.com/nicengi/LayaBot)