### PR TITLE
fix(forum-54975): TimeLine first label at time 0 not firing LABEL event

### DIFF
--- a/src/layaAir/laya/tween/TimeLine.ts
+++ b/src/layaAir/laya/tween/TimeLine.ts
@@ -258,6 +258,11 @@ export class TimeLine extends EventDispatcher {
                         tTween = Tween.from(tTweenData.target, tTweenData.data, tTweenData.duration, tTweenData.ease, Handler.create(this, this._animComplete));
                     this._tweenDic.push(tTween);
                 }
+            } else if (tTweenData.type == 1) {
+                if (time >= tTweenData.startTime) {
+                    this._index = Math.max(this._index, i + 1);
+                    this.event(Event.LABEL, tTweenData.data);
+                }
             }
         }
     }
@@ -369,7 +374,7 @@ export class TimeLine extends EventDispatcher {
         var tCurrTime: number = this._currTime += tFrameTime * this.scale;
         this._lastTime = tNow;
 
-        if (this._tweenDataList.length != 0 && this._index < this._tweenDataList.length) {
+        while (this._tweenDataList.length != 0 && this._index < this._tweenDataList.length) {
             var tTweenData: tweenData = this._tweenDataList[this._index];
             if (tCurrTime >= tTweenData.startTime) {
                 this._index++;
@@ -384,6 +389,8 @@ export class TimeLine extends EventDispatcher {
                 } else {
                     this.event(Event.LABEL, tTweenData.data);
                 }
+            } else {
+                break;
             }
         }
     }


### PR DESCRIPTION
修复论坛反馈 https://ask.layaair.com/d/54975

`gotoTime()` 中处理当前活跃 tween 的循环只处理了 type==0（tween 动画），跳过了 type==1（label），导致 `play(0)` 时第一个 label 事件永远不会被触发。