### PR TITLE
fix(forum-54979): fix Physics2D memory leak on body disable/enable cycle

### DIFF
--- a/src/layaAir/laya/physics/Collider2D/ColliderBase.ts
+++ b/src/layaAir/laya/physics/Collider2D/ColliderBase.ts
@@ -338,6 +338,7 @@ export class ColliderBase extends Component {
     /**@internal*/
     protected _onDisable(): void {
         this._box2DBody && Physics2D.I._factory.removeBody(this._physics2DManager.box2DWorld, this._box2DBody);
+        this._box2DBodyDef && Physics2D.I._factory.destroyData(this._box2DBodyDef);
         this._box2DBody = null;
         this._box2DBodyDef = null;
         this.owner.off(SpriteGlobalTransform.CHANGED, this, this._needupdataShapeAttribute);
@@ -345,6 +346,7 @@ export class ColliderBase extends Component {
 
     protected _onDestroy(): void {
         this._box2DBody && Physics2D.I._factory.removeBody(this._physics2DManager.box2DWorld, this._box2DBody);
+        this._box2DBodyDef && Physics2D.I._factory.destroyData(this._box2DBodyDef);
         this._box2DBodyDef && Physics2D.I._factory.destroyData(this._box2DBodyDef);
         this._box2DBody = null;
         this._box2DBodyDef = null;

--- a/src/layaAir/laya/physics/factory/physics2DwasmFactory.ts
+++ b/src/layaAir/laya/physics/factory/physics2DwasmFactory.ts
@@ -1028,7 +1028,7 @@ export class physics2DwasmFactory implements IPhysics2DFactory {
         def.fixedRotation = rigidbodyDef.fixedRotation;
         def.gravityScale = rigidbodyDef.gravityScale;
         def.linearDamping = rigidbodyDef.linearDamping;
-        def.linearVelocity = new this.box2d.b2Vec2(this.convertLayaValueToPhysics(world, rigidbodyDef.linearVelocity.x), this.convertLayaValueToPhysics(world, rigidbodyDef.linearVelocity.y));
+        def.linearVelocity.Set(this.convertLayaValueToPhysics(world, rigidbodyDef.linearVelocity.x), this.convertLayaValueToPhysics(world, rigidbodyDef.linearVelocity.y));
         def.type = this.getbodyType(rigidbodyDef.type);
         return def;
     }


### PR DESCRIPTION
## Summary
- 修复 2D 物理 wasm 层两处内存泄漏
- `ColliderBase._onDisable()` 中 `_box2DBodyDef` 未调用 `destroyData` 释放 wasm 堆内存
- `createBodyDef()` 中每次 `new b2Vec2()` 赋值给 `linearVelocity` 造成泄漏，改为 `.Set()` 原地修改

论坛反馈: https://ask.layaair.com/d/54979

🤖 Generated with [LayaBot](https://github.com/nicedoc/LayaBot)