### PR TITLE
fix(forum-54983): move Sprite2DCount stats from Node to Sprite

### DIFF
--- a/src/layaAir/laya/display/Node.ts
+++ b/src/layaAir/laya/display/Node.ts
@@ -12,8 +12,6 @@ import { type Sprite } from "./Sprite";
 import { type Sprite3D } from "../d3/core/Sprite3D";
 import { type Scene3D } from "../d3/core/scene/Scene3D";
 import { type GWidget } from "../ui2/GWidget"
-import { LayaGL } from "../layagl/LayaGL"
-import { StatElement } from "../layagl/StatisticsContext"
 
 const ARRAY_EMPTY: any[] = [];
 const initBits = NodeFlags.ACTIVE;
@@ -1225,7 +1223,6 @@ export class Node extends EventDispatcher {
         }
 
         this._onActive();
-        LayaGL.statAgent.recordCountData(StatElement.C_Sprite2DCount, 1);
 
         for (let child of this._children) {
             if ((child._bits & NodeFlags.ACTIVE) !== 0 && (child._bits & NodeFlags.NOT_IN_PAGE) === 0)
@@ -1247,7 +1244,6 @@ export class Node extends EventDispatcher {
      */
     _inActiveHierarchy(activeChangeScripts: any[], fromSetter?: boolean): void {
         this._onInActive();
-        LayaGL.statAgent.recordCountData(StatElement.C_Sprite2DCount, -1);
 
         if (this._components) {
             for (let i = 0, n = this._components.length; i < n; i++) {

--- a/src/layaAir/laya/display/Sprite.ts
+++ b/src/layaAir/laya/display/Sprite.ts
@@ -24,6 +24,7 @@ import { Component } from "../components/Component";
 import { SpriteGlobalTransform } from "./SpriteGlobaTransform";
 import { IRenderStruct2D } from "../RenderDriver/RenderModuleData/Design/2D/IRenderStruct2D";
 import { LayaGL } from "../layagl/LayaGL";
+import { StatElement } from "../layagl/StatisticsContext";
 import { ShaderData } from "../RenderDriver/DriverDesign/RenderDevice/ShaderData";
 import { IRender2DPass } from "../RenderDriver/RenderModuleData/Design/2D/IRender2DPass";
 import { BlendMode, BlendModeHandler } from "../webgl/canvas/BlendMode";
@@ -263,6 +264,18 @@ export class Sprite extends Node {
         this._struct = LayaGL.render2DRenderPassFactory.createRenderStruct2D();
         this._struct.owner = this;
         this._globalTrans = new SpriteGlobalTransform(this);
+    }
+
+    /** @internal */
+    protected _onActive(): void {
+        super._onActive();
+        LayaGL.statAgent.recordCountData(StatElement.C_Sprite2DCount, 1);
+    }
+
+    /** @internal */
+    protected _onInActive(): void {
+        super._onInActive();
+        LayaGL.statAgent.recordCountData(StatElement.C_Sprite2DCount, -1);
     }
 
     /** @internal */


### PR DESCRIPTION
## Summary
- 修复 Sprite2DCount 统计方式错误：统计逻辑原在 Node 基类的 `_activeHierarchy`/`_inActiveHierarchy` 中，导致 3D 节点也被计入
- 将统计逻辑移至 Sprite 类的 `_onActive`/`_onInActive`，确保只统计 2D 节点

## 论坛反馈
https://ask.layaair.com/d/54983

🤖 Generated with [LayaBot](https://github.com/nicx519y/LayaBot)