### PR TITLE
fix(forum-54993): fix clearAllCache never executing due to toClear being zeroed before check

### DIFF
--- a/src/layaAir/platforms/minigame/MgCacheManager.ts
+++ b/src/layaAir/platforms/minigame/MgCacheManager.ts
@@ -117,8 +117,9 @@ export class MgCacheManager {
 
         if (this.toClear != 0) {
             this.running = true;
+            let clearFlag = this.toClear;
             this.toClear = 0;
-            if ((this.toClear & 2) !== 0)
+            if ((clearFlag & 2) !== 0)
                 this.doClearAllCache().then(() => this.running = false);
             else
                 this.clearSpace(0).then(() => this.saveDirtyManifests()).then(() => this.running = false);


### PR DESCRIPTION
修复论坛反馈：wx热更新拿不到最新资源

`MgCacheManager.clearAllCache()` 中 `toClear` 标志位在检查前就被清零，导致清理逻辑永远不会执行。

论坛帖子：https://ask.layaair.com/d/54993