### PR TITLE
fix(forum-55011): Slider mouseUp only fire CHANGED when value changed

### DIFF
--- a/src/layaAir/laya/ui/Slider.ts
+++ b/src/layaAir/laya/ui/Slider.ts
@@ -71,6 +71,7 @@ export class Slider extends UIComponent {
     protected _ty: number;
     protected _maxMove: number;
     protected _globalSacle: Point;
+    private _startValue: number;
 
     /**
      * @en Creates an instance of Slider.
@@ -125,6 +126,7 @@ export class Slider extends UIComponent {
         this._maxMove = this.isVertical ? (this.height - this._bar.height) : (this.width - this._bar.width);
         this._tx = stage.mouseX;
         this._ty = stage.mouseY;
+        this._startValue = this._value;
         stage.on(Event.MOUSE_MOVE, this, this.mouseMove);
         stage.once(Event.MOUSE_UP, this, this.mouseUp);
         stage.once(Event.MOUSE_OUT, this, this.mouseUp);
@@ -157,7 +159,8 @@ export class Slider extends UIComponent {
         stage.off(Event.MOUSE_MOVE, this, this.mouseMove);
         stage.off(Event.MOUSE_UP, this, this.mouseUp);
         stage.off(Event.MOUSE_OUT, this, this.mouseUp);
-        this.sendChangeEvent(Event.CHANGED);
+        if (this._value != this._startValue)
+            this.sendChangeEvent(Event.CHANGED);
         this.hideValueText();
     }
 


### PR DESCRIPTION
## Summary
- 修复经典UI Slider 在 mouseUp 时无条件派发 CHANGED 事件的问题
- 现在仅当 value 实际发生变化时才触发 CHANGED 事件

## 论坛反馈
https://ask.layaair.com/d/55011

🤖 Generated with [LayaBot](https://github.com/nicengi/LayaBot)