### PR TITLE
fix: Alipay mini-game WebSocket binary data received as Base64 string

### DIFF
--- a/src/layaAir/platforms/minigame/MgWebSocket.ts
+++ b/src/layaAir/platforms/minigame/MgWebSocket.ts
@@ -28,9 +28,26 @@ export class MgWebSocket implements IWebSocket {
         this.ws.onClose(() => this.onClose());
         this.ws.onError(err => this.onError(err));
         this.ws.onMessage(msg => {
-            if (msg.data)
-                this.onMessage(msg.data);
+            if (msg.data){
+                var data:any = msg.data;
+                if (data.isBuffer) {
+                    // 对齐web转成arrayBuffer;
+                    data = this.base64ToArrayBuffer(data.data);
+                }
+                this.onMessage(data);
+            }
         });
+    }
+
+    /** 将 Base64 字符串转为 ArrayBuffer */
+    private base64ToArrayBuffer(base64: string): ArrayBuffer {
+        const binary = atob(base64);
+        const len = binary.length;
+        const bytes = new Uint8Array(len);
+        for (let i = 0; i < len; i++) {
+            bytes[i] = binary.charCodeAt(i);
+        }
+        return bytes.buffer;
     }
 
     close(): void {


### PR DESCRIPTION
Alipay mini-game old versions (< 10.5.16) do not return ArrayBuffer directly for WebSocket binary messages. Instead, the platform returns data as a Base64-encoded string with isBuffer set to true. This causes onMessage to receive a string instead of ArrayBuffer, inconsistent with web platform behavior.

Fix: detect isBuffer flag in onMessage callback, decode Base64 string and convert to ArrayBuffer to align with web platform behavior.

Note: Alipay 10.5.16+ natively supports ArrayBuffer, this fix only affects backward compatibility with older versions.