### PR TITLE
fix: Bridge3DScene3D render order causes dynamically created Bridge3DSprite invisible

### DIFF
--- a/src/layaAir/laya/bridge/Bridge3DSceneHolder.ts
+++ b/src/layaAir/laya/bridge/Bridge3DSceneHolder.ts
@@ -96,7 +96,7 @@ export class Bridge3DSceneHolder implements IBridge3DSceneHolder {
 
         // Add to stage if needed
         if (!this._isAddedToStage && this._bridge3DList.length > 0) {
-            ILaya.stage.addChild(scene3d);
+            ILaya.stage.addChildAt(scene3d, 0);
             this._isAddedToStage = true;
         }
 


### PR DESCRIPTION
## Problem
  当 Bridge3DSprite 在场景加载后动态创建时（如代码中 new 或 Loader.createNodes），
  Bridge3DScene3D 通过 addChild() 被添加到 stage 末尾，排在 2D Scene 之后。
  导致 2D 渲染 Bridge3DRenderElement 时，3D 数据还未更新，粒子等3D内容不可见。

  静态放置在场景中的 Bridge3DSprite 不受影响，因为场景反序列化时
  Bridge3DScene3D 先于 2D Scene 被添加到 stage。

  ## Fix
  Bridge3DSceneHolder.registerBridge3D() 中将 addChild 改为 addChildAt(scene3d, 0)，
  确保 Bridge3DScene3D 始终在 stage 最前面渲染。

  ## Change
  - `src/layaAir/laya/bridge/Bridge3DSceneHolder.ts` line 99