### PR TITLE
fix: Evaluate transitions for finished animator states when speed=0/s…

### DIFF
--- a/src/layaAir/laya/components/Animator2D.ts
+++ b/src/layaAir/laya/components/Animator2D.ts
@@ -266,7 +266,19 @@ export class Animator2D extends Animator2DBase {
 
         var delta = this.owner.timer.delta / 1000.0;
         delta = this._applyUpdateMode(delta);
-        if (0 == this.speed || 0 == delta) return;
+        if (0 == this.speed || 0 == delta) {
+            // speed=0或delta=0时仍需检查已完成状态的转换（用户可能在动画结束后设置了新参数）
+            for (var i = 0, n = this._controllerLayers.length; i < n; i++) {
+                var controllerLayer = this._controllerLayers[i];
+                if (!controllerLayer.enable) continue;
+                var playStateInfo = controllerLayer._playStateInfo!;
+                if (playStateInfo._finish && controllerLayer._playType == 0) {
+                    var animatorState = playStateInfo._currentState!;
+                    this._applyTransition(i, animatorState._eventtransition(playStateInfo._normalizedPlayTime, this.parameters, false));
+                }
+            }
+            return;
+        }
         var needRender = true;//TODO:有渲染节点才可将needRender变为true
 
         for (var i = 0, n = this._controllerLayers.length; i < n; i++) {
@@ -308,14 +320,16 @@ export class Animator2D extends Animator2DBase {
                     }
                     playStateInfo = controllerLayer._playStateInfo!;
                     animatorState = playStateInfo._currentState!;
+                    // 转换后finish状态可能已变化，需要重新判断
+                    let curFinish = playStateInfo._finish;
                     if (needRender) {
                         this._updateClipDatas(animatorState, addtive, playStateInfo);
-                        if (!finish) {
+                        if (!curFinish) {
                             this._setClipDatasToNode(animatorState, addtive, controllerLayer.defaultWeight);
                             this._updateEventScript(animatorState, playStateInfo);
                         }
                     }
-                    finish || this._updateStateFinish(animatorState, playStateInfo);
+                    curFinish || this._updateStateFinish(animatorState, playStateInfo);
                     break;
             }
         }

--- a/src/layaAir/laya/d3/component/Animator/Animator.ts
+++ b/src/layaAir/laya/d3/component/Animator/Animator.ts
@@ -1506,8 +1506,21 @@ export class Animator extends Component {
         let timer = this.owner._scene.timer;
         let delta = timer.delta / 1000.0;//Laya.timer.delta已包含Laya.timer.scale
         delta = this._applyUpdateMode(delta);
-        if (this._speed === 0 || delta === 0)//delta为0无需更新,可能造成crossWeight计算值为NaN
+        if (this._speed === 0 || delta === 0) {//delta为0无需更新,可能造成crossWeight计算值为NaN
+            // speed=0或delta=0时仍需检查已完成状态的转换（用户可能在动画结束后设置了新参数）
+            for (var i = 0, n = this._controllerLayers.length; i < n; i++) {
+                var controllerLayer: AnimatorControllerLayer = this._controllerLayers[i];
+                if (!controllerLayer.enable) continue;
+                var playStateInfo: AnimatorPlayState = controllerLayer._playStateInfo!;
+                if (playStateInfo._finish && controllerLayer._playType == 0) {
+                    var animatorState: AnimatorState = playStateInfo.currentState!;
+                    this._applyTransition(animatorState, i, animatorState._eventtransition(playStateInfo._normalizedPlayTime, this.animatorParams));
+                }
+            }
+            this._LateUpdateEvents.invoke();
+            this._LateUpdateEvents.clear();
             return;
+        }
         if (!Stat.enableAnimatorUpdate)
             return;
         var needRender = true;//TODO:有渲染节点才可将needRender变为true
@@ -1519,6 +1532,9 @@ export class Animator extends Component {
                 continue;
             var playStateInfo: AnimatorPlayState = controllerLayer._playStateInfo!;
             if (this.sleep && playStateInfo._finish && controllerLayer._playType == 0) {
+                // sleep模式下仍需检查已完成状态的转换（用户可能在动画结束后设置了新参数）
+                var animatorState: AnimatorState = playStateInfo.currentState!;
+                this._applyTransition(animatorState, i, animatorState._eventtransition(playStateInfo._normalizedPlayTime, this.animatorParams));
                 continue;
             }
             var crossPlayStateInfo: AnimatorPlayState = controllerLayer._crossPlayStateInfo!;


### PR DESCRIPTION
…leep=true

- Animator3D: Check transitions in sleep mode before skipping finished layers
- Animator3D: Evaluate finished state transitions when speed=0 or delta=0
- Animator2D: Evaluate finished state transitions when speed=0 or delta=0
- Animator2D: Re-read finish flag after transition to fix first-frame rendering of new state