### PR TITLE
feat: Line2D support clip (cherry-pick to 3.3)

### DIFF
--- a/src/layaAir/laya/Line2D/shader/2DLine.fs
+++ b/src/layaAir/laya/Line2D/shader/2DLine.fs
@@ -22,6 +22,7 @@ vec2 dotToline(in vec2 a, vec2 b,in vec2 p){
 
 
 void main(){
+    clip();
     vec2 p = dotToline(v_linePionts.xy, v_linePionts.zw, v_position);
     float d = v_lineWidth*0.5 - length(p - v_position);
     

--- a/src/layaAir/laya/Line2D/shader/2DLine.vs
+++ b/src/layaAir/laya/Line2D/shader/2DLine.vs
@@ -53,12 +53,14 @@ void main(){
     vec3 yDir;
     lineMat(left,right,xDir,yDir,v_lineWidth);
  
-    transfrom(a_position.xy,xDir,yDir,v_position);
-   
-  
+    vec2 globalPos;
+    transfrom(a_position.xy,xDir,yDir,globalPos);
+    v_position = globalPos;
+
+    clip(globalPos);
+
     vec2 viewPos;
-    getViewPos(v_position,viewPos);
-    clip(viewPos);
+    getViewPos(globalPos,viewPos);
     vec4 pos;
     getProjectPos(viewPos,pos);
     gl_Position = pos;


### PR DESCRIPTION
## Summary
- Cherry-pick of https://github.com/Lurenyiabc/LayaAir/commit/1da63aa96ceba339b02ef36890cf21b3a6d9434e to 3.3 branch
- **2DLine.fs**: Add `clip()` call at the beginning of `main()` for fragment-level clipping
- **2DLine.vs**: Change clip coordinate from `viewPos` to `globalPos` (world space), introduce local variable `globalPos` for cleaner data flow

## Test plan
- [ ] Verify Line2D rendering with clip enabled in browser
- [ ] Verify Line2D rendering without clip (no regression)