### PR TITLE
fix(physics2d): correct coordinate transform for retina and dynamic w…

### DIFF
--- a/src/layaAir/laya/physics/Collider2D/ColliderBase.ts
+++ b/src/layaAir/laya/physics/Collider2D/ColliderBase.ts
@@ -10,6 +10,8 @@ import { Utils } from "../../utils/Utils";
 import { SpriteGlobalTransform } from "../../display/SpriteGlobaTransform";
 import { TransformKind } from "../../display/SpriteConst";
 
+const _tempWorldPoint: Point = new Point();
+
 /**
  * @en 2DPhysics Collider base class
  * @zh 2D物理碰撞体基类
@@ -315,7 +317,8 @@ export class ColliderBase extends Component {
      * @param y 像素坐标的 y 值。
      */
     getWorldPoint(x: number, y: number): Readonly<Point> {
-        return this.owner.globalTrans.localToGlobal(x, y);
+        let p = this.owner.globalTrans.localToGlobal(x, y);
+        return _tempWorldPoint.setTo(Physics2D.toPhysicsX(p.x), Physics2D.toPhysicsY(p.y));
     }
 
     /**@internal 通知rigidBody 更新shape 属性值 */
@@ -328,7 +331,7 @@ export class ColliderBase extends Component {
         //非dynamic类型下设置位置
         if (this._type != "dynamic" && (flag & (TransformKind.Pos | TransformKind.Rotation | TransformKind.Scale))) {
             if(flag & (TransformKind.Pos | TransformKind.Rotation | TransformKind.Scale)){
-                this._box2DBody && Physics2D.I._factory.set_RigibBody_Transform(this._box2DBody, sp.globalTrans.x, sp.globalTrans.y, Utils.toRadian(this.owner.globalTrans.rotation));
+                this._box2DBody && Physics2D.I._factory.set_RigibBody_Transform(this._box2DBody, Physics2D.toPhysicsX(sp.globalTrans.x), Physics2D.toPhysicsY(sp.globalTrans.y), Utils.toRadian(this.owner.globalTrans.rotation));
                 this._box2DBody && Physics2D.I._factory.set_rigidBody_Awake(this._box2DBody, true);
             }
         }

--- a/src/layaAir/laya/physics/Physics2D.ts
+++ b/src/layaAir/laya/physics/Physics2D.ts
@@ -128,6 +128,20 @@ export class Physics2D extends EventDispatcher {
     }
 
 
+    /**
+     * @en Convert a value from globalTrans space to design resolution (physics) space by removing stage scale.
+     * @zh 将 globalTrans 空间的值转换为设计分辨率（物理空间），剥离 Stage 缩放。
+     */
+    static toPhysicsX(v: number): number { return v / ILaya.stage.clientScaleX; }
+    static toPhysicsY(v: number): number { return v / ILaya.stage.clientScaleY; }
+
+    /**
+     * @en Convert a value from design resolution (physics) space to globalTrans space by restoring stage scale.
+     * @zh 将设计分辨率（物理空间）的值转换回 globalTrans 空间，恢复 Stage 缩放。
+     */
+    static toRenderX(v: number): number { return v * ILaya.stage.clientScaleX; }
+    static toRenderY(v: number): number { return v * ILaya.stage.clientScaleY; }
+
     // 下面考虑也放到ISceneComponentManager里面去处理，在update里面设置重设根节点之后再更新这个方法
     /**
      * @en Manually triggers an update of the physics world after setting the `worldRoot`.

--- a/src/layaAir/laya/physics/Physics2DDebugDraw.ts
+++ b/src/layaAir/laya/physics/Physics2DDebugDraw.ts
@@ -1,5 +1,6 @@
 import { Laya } from "../../Laya";
 import { Scene } from "../display/Scene";
+import { Physics2D } from "./Physics2D";
 import { CommandBuffer2D } from "../display/Scene2DSpecial/RenderCMD2D/CommandBuffer2D";
 import { DrawMesh2DCMD } from "../display/Scene2DSpecial/RenderCMD2D/DrawMesh2DCMD";
 import { Color } from "../maths/Color";
@@ -55,6 +56,9 @@ export class Physics2DDebugDraw {
     }
 
     private render(): void {
+        this._matrix.identity();
+        this._matrix.scale(Physics2D.toRenderX(1), Physics2D.toRenderY(1));
+
         let area2D = this._scene._area2Ds.size > 0 ? this._scene._area2Ds.values().next().value._struct : null;
         //drawMesh cmds
         this._cmdBuffer.setRenderTarget(null, false);

--- a/src/layaAir/laya/physics/Physics2DWorldManager.ts
+++ b/src/layaAir/laya/physics/Physics2DWorldManager.ts
@@ -406,12 +406,6 @@ export class Physics2DWorldManager implements IElementComponentManager {
             }
         };
         this._JSRayCastcallback.ReportFixture = callback.bind(this);
-        let scaleX = ILaya.stage.clientScaleX;
-        let scaleY = ILaya.stage.clientScaleY;
-        startPos.x *= scaleX;
-        startPos.y *= scaleY;
-        endPos.x *= scaleX;
-        endPos.y *= scaleY;
         Physics2D.I._factory.RayCast(this._box2DWorld, this._JSRayCastcallback, startPos, endPos);
     }
 

--- a/src/layaAir/laya/physics/RigidBody.ts
+++ b/src/layaAir/laya/physics/RigidBody.ts
@@ -300,10 +300,7 @@ export class RigidBody extends ColliderBase {
         _tempP0.x = pos.x;
         _tempP0.y = pos.y;
         let globalPos = this.owner.parent.localToGlobal(_tempP0);
-        // 处理缩放，其余设置transform时候使用的是globalTrans是正确的
-        globalPos.x = globalPos.x * ILaya.stage.clientScaleX;
-        globalPos.y = globalPos.y * ILaya.stage.clientScaleY;
-        factory.set_RigibBody_Transform(this._box2DBody, globalPos.x, globalPos.y, rotateValue);//重新给个setPos的接口
+        factory.set_RigibBody_Transform(this._box2DBody, Physics2D.toPhysicsX(globalPos.x), Physics2D.toPhysicsY(globalPos.y), rotateValue);
         factory.set_rigidBody_Awake(this._box2DBody, true);
         Physics2D.I._addRigidBody(this);
     }
@@ -320,8 +317,8 @@ export class RigidBody extends ColliderBase {
         }
         var pos = Vector2.TEMP;
         Physics2D.I._factory.get_RigidBody_Position(this._box2DBody, pos);
-        _tempP0.x = pos.x;
-        _tempP0.y = pos.y;
+        _tempP0.x = Physics2D.toRenderX(pos.x);
+        _tempP0.y = Physics2D.toRenderY(pos.y);
         let localPos = this.owner.parent.globalToLocal(_tempP0);
         _tempP0.x = localPos.x;
         _tempP0.y = localPos.y;
@@ -391,7 +388,7 @@ export class RigidBody extends ColliderBase {
         if (this._type == "static") {
             // 静态刚体这样设置
             let owner: Sprite = this.owner;
-            this._bodyDef.position.setValue(owner.globalTrans.x, owner.globalTrans.y);
+            this._bodyDef.position.setValue(Physics2D.toPhysicsX(owner.globalTrans.x), Physics2D.toPhysicsY(owner.globalTrans.y));
             this._bodyDef.angle = Utils.toRadian(owner.globalTrans.rotation);
             this._bodyDef.allowSleep = false;
             this._bodyDef.angularVelocity = 0;
@@ -406,7 +403,7 @@ export class RigidBody extends ColliderBase {
         }
 
         let owner: Sprite = this.owner;
-        this._bodyDef.position.setValue(owner.globalTrans.x, owner.globalTrans.y);
+        this._bodyDef.position.setValue(Physics2D.toPhysicsX(owner.globalTrans.x), Physics2D.toPhysicsY(owner.globalTrans.y));
         this._bodyDef.angle = Utils.toRadian(owner.globalTrans.rotation);
         this._bodyDef.fixedRotation = !this._allowRotation;
         this._bodyDef.allowSleep = this._allowSleep;
@@ -469,7 +466,7 @@ export class RigidBody extends ColliderBase {
         if (Physics2D.I._factory.get_rigidBody_IsAwake(this._box2DBody)) {
             var pos = Vector2.TEMP;
             factory.get_RigidBody_Position(this._box2DBody, pos);
-            pos.setValue(pos.x, pos.y);
+            pos.setValue(Physics2D.toRenderX(pos.x), Physics2D.toRenderY(pos.y));
             this.owner.globalTrans.setPos(pos.x, pos.y);
             this.owner.globalTrans.rotation = Utils.toAngle(factory.get_RigidBody_Angle(this._box2DBody));
         }
@@ -631,7 +628,7 @@ export class RigidBody extends ColliderBase {
     setAngle(value: number): void {
         if (!this._box2DBody) return;
         var factory = Physics2D.I._factory;
-        factory.set_RigibBody_Transform(this._box2DBody, this.owner.globalTrans.x, this.owner.globalTrans.y, Utils.toRadian(value));
+        factory.set_RigibBody_Transform(this._box2DBody, Physics2D.toPhysicsX(this.owner.globalTrans.x), Physics2D.toPhysicsY(this.owner.globalTrans.y), Utils.toRadian(value));
         factory.set_rigidBody_Awake(this._box2DBody, true);
     }
 
@@ -684,7 +681,8 @@ export class RigidBody extends ColliderBase {
      * @param y 像素坐标的 y 值。
      */
     getWorldPoint(x: number, y: number): Readonly<Point> {
-        return this.owner.globalTrans.localToGlobal(x, y);
+        let p = this.owner.globalTrans.localToGlobal(x, y);
+        return _tempP0.setTo(Physics2D.toPhysicsX(p.x), Physics2D.toPhysicsY(p.y));
     }
 
     /**
@@ -696,6 +694,6 @@ export class RigidBody extends ColliderBase {
      * @param y 像素坐标的 y 值。
      */
     getLocalPoint(x: number, y: number): Readonly<Point> {
-        return this.owner.globalTrans.globalToLocal(x, y);
+        return this.owner.globalTrans.globalToLocal(Physics2D.toRenderX(x), Physics2D.toRenderY(y));
     }
 }

--- a/src/layaAir/laya/physics/Shape/Physics2DShapeBase.ts
+++ b/src/layaAir/laya/physics/Shape/Physics2DShapeBase.ts
@@ -148,15 +148,15 @@ export class Physics2DShapeBase implements IClone {
      * 获得节点的全局缩放X
      */
     protected get scaleX(): number {
-        return (<Sprite>this._body.owner).globalScaleX;
+        return Physics2D.toPhysicsX((<Sprite>this._body.owner).globalScaleX);
     }
 
     /**
      * @internal
-     * 获得节点的全局缩放Y
+     * 获得节点的全局缩放Y（剥离 stage scale，在设计分辨率空间下）
      */
     protected get scaleY(): number {
-        return (<Sprite>this._body.owner).globalScaleY;
+        return Physics2D.toPhysicsY((<Sprite>this._body.owner).globalScaleY);
     }
 
     /**@internal 创建获得相对于描点x的偏移 */
@@ -277,6 +277,7 @@ export class Physics2DShapeBase implements IClone {
      * @zh 销毁形状
      */
     destroy(): void {
+        if (!this._box2DBody || !this._box2DShape) return;
         Physics2D.I._factory.destroyShape(this._physics2DManager.box2DWorld, this._box2DBody, this._box2DShape);
         Physics2D.I._factory.destroyData(this._box2DFilter);
         // Destroy the template b2Shape allocated in createShapeDef before destroying the b2FixtureDef

--- a/src/layaAir/laya/physics/StaticCollider.ts
+++ b/src/layaAir/laya/physics/StaticCollider.ts
@@ -57,7 +57,7 @@ export class StaticCollider extends ColliderBase {
     private _setBodyDefValue(): void {
         // 静态刚体这样设置
         let owner: Sprite = this.owner;
-        this._bodyDef.position.setValue(owner.globalTrans.x, owner.globalTrans.y);
+        this._bodyDef.position.setValue(Physics2D.toPhysicsX(owner.globalTrans.x), Physics2D.toPhysicsY(owner.globalTrans.y));
         this._bodyDef.angle = Utils.toRadian(owner.globalTrans.rotation);
         this._bodyDef.allowSleep = false;
         this._bodyDef.angularVelocity = 0;

--- a/src/layaAir/laya/physics/joint/DistanceJoint.ts
+++ b/src/layaAir/laya/physics/joint/DistanceJoint.ts
@@ -161,7 +161,7 @@ export class DistanceJoint extends JointBase {
                 this.selfBody.owner.on("bodyCreated", this, this._createJoint);
                 return;
             }
-            def.localAnchorB.setValue(point.x * ILaya.stage.clientScaleX, point.y * ILaya.stage.clientScaleY);
+            def.localAnchorB.setValue(point.x, point.y);
             this.selfBody.owner.on("shapeChange", this, this._refeahJoint);
             if (this.otherBody) {
                 def.bodyA = this.otherBody.getBox2DBody();
@@ -171,7 +171,7 @@ export class DistanceJoint extends JointBase {
                     return;
                 }
                 point = this.getBodyAnchor(this.otherBody, this.otherAnchor[0], this.otherAnchor[1]);
-                def.localAnchorA.setValue(point.x * ILaya.stage.clientScaleX, point.y * ILaya.stage.clientScaleY);
+                def.localAnchorA.setValue(point.x, point.y);
                 this.otherBody.owner.on("shapeChange", this, this._refeahJoint);
             } else {
                 if (!Physics2D.I._emptyBody) {

--- a/src/layaAir/laya/physics/joint/MouseJoint.ts
+++ b/src/layaAir/laya/physics/joint/MouseJoint.ts
@@ -95,8 +95,12 @@ export class MouseJoint extends JointBase {
             var def: physics2D_MouseJointJointDef = MouseJoint._temp || (MouseJoint._temp = new physics2D_MouseJointJointDef());
             if (this.anchor) {
                 var anchorPos: Point = this.selfBody.owner.localToGlobal(Point.TEMP.setTo(this.anchor[0], this.anchor[1]), false, this._physics2DManager.getRootSprite());
+                anchorPos.x = Physics2D.toPhysicsX(anchorPos.x);
+                anchorPos.y = Physics2D.toPhysicsY(anchorPos.y);
             } else {
                 anchorPos = this._physics2DManager.getRootSprite().globalToLocal(Point.TEMP.setTo(ILaya.InputManager.mouseX, ILaya.InputManager.mouseY));
+                anchorPos.x = Physics2D.toPhysicsX(anchorPos.x);
+                anchorPos.y = Physics2D.toPhysicsY(anchorPos.y);
             }
             if (!Physics2D.I._emptyBody) Physics2D.I._emptyBody = Physics2D.I._factory.createBody(this._physics2DManager.box2DWorld, null);
             def.bodyA = Physics2D.I._emptyBody;
@@ -136,7 +140,7 @@ export class MouseJoint extends JointBase {
 
     /**@internal */
     private _onMouseMove(): void {
-        if (this._joint) this._factory.set_MouseJoint_target(this._joint, ILaya.InputManager.mouseX, ILaya.InputManager.mouseY);
+        if (this._joint) this._factory.set_MouseJoint_target(this._joint, Physics2D.toPhysicsX(ILaya.InputManager.mouseX), Physics2D.toPhysicsY(ILaya.InputManager.mouseY));
     }
 
     /**@internal */

--- a/src/layaAir/laya/spine/Spine2DRenderNode.ts
+++ b/src/layaAir/laya/spine/Spine2DRenderNode.ts
@@ -47,7 +47,7 @@ export class Spine2DRenderNode extends BaseRenderNode2D {
      * @zh 物理更新模式。
      * @en The physics update mode. 
      **/
-    physicsUpdate = 2;
+    physicsUpdate = 0;
 
     /** @deprecated 状态-停止 */
     static readonly STOPPED: number = 0;


### PR DESCRIPTION
…indow scaling

Add centralized Physics2D.toPhysicsX/Y and toRenderX/Y conversion methods. Box2D now consistently works in design resolution space, stripping Stage scale at all physics-render boundaries. Fixes position drift, shape scaling, joint anchors, debug draw and raycasting issues in retina/HiDPI mode and during dynamic window resizing.

Generated with [Claude Code](https://claude.ai/code)