### PR TITLE
fix(forum-55072): FrameAnimation frames setter should respect _index for initial frame

### DIFF
--- a/src/layaAir/laya/components/FrameAnimation.ts
+++ b/src/layaAir/laya/components/FrameAnimation.ts
@@ -178,7 +178,7 @@ export class FrameAnimation extends Component {
                 this._frame = this._count - 1;
             else {
                 this._reversed = false;
-                this._frame = 0;
+                this._frame = (this._index > 0 && this._index < this._count) ? this._index : 0;
             }
 
             if (this._stretchMode === AnimationStretchMode.ResizeToFit) {


### PR DESCRIPTION
修复论坛反馈：FrameAnimation 的 frames setter 未考虑 _index，导致初始帧设置不正确。

论坛帖子: https://ask.layaair.com/d/55072-shuo-2ge-xin-uizhong-yu-dao-de-xiao-bug

🤖 Generated with [LayaBot](https://github.com/nicholasguan/LayaBot)