### PR TITLE
fix(particle): add mesh null check in _advanceDistance to prevent crash

### DIFF
--- a/src/layaAir/laya/particle/d3/ShurikenParticleSystem.ts
+++ b/src/layaAir/laya/particle/d3/ShurikenParticleSystem.ts
@@ -1805,6 +1805,9 @@ export class ShurikenParticleSystem extends GeometryElement implements IClone {
      * @internal
      */
     protected _advanceDistance(emitTime: number, elapsedTime: number): void {
+        if (this._ownerRender.renderMode === 4 && !this._ownerRender.mesh)
+            return;
+
         let position = this._owner.transform.position;
         let offsetDistance: number = Vector3.distance(position, this._emissionLastPosition);
 


### PR DESCRIPTION
When rateOverDistance is enabled in mesh mode without mesh assigned, _advanceDistance would attempt to access uninitialized _instanceVertex. Added null check to safely return early in this case.