### PR TITLE
fix: remove duplicate case statement (删除重复的 case 表达式)

### DIFF
--- a/src/layaAir/laya/RenderDriver/NoRenderDriver/DriverDevice/NoRenderDeviceFactory.ts
+++ b/src/layaAir/laya/RenderDriver/NoRenderDriver/DriverDevice/NoRenderDeviceFactory.ts
@@ -462,8 +462,6 @@ export class NoRenderShaderData extends ShaderData {
                 return this.getVector(uniformIndex);
             case ShaderDataType.Color:
                 return this.getColor(uniformIndex);
-            case ShaderDataType.Matrix4x4:
-                return this.getMatrix4x4(uniformIndex);
             case ShaderDataType.Texture2D:
             case ShaderDataType.TextureCube:
             case ShaderDataType.Texture2DArray:


### PR DESCRIPTION
remove duplicate `ShaderDataType.Matrix4x4` case in `NoRenderShaderData.getShaderData`