### PR TITLE
fix(Camera): fix enableBlitDepth check in canblitDepth getter

### DIFF
--- a/src/layaAir/laya/RenderDriver/RenderModuleData/RuntimeModuleData/3D/3DRenderProcess/RTRender3DProcess.ts
+++ b/src/layaAir/laya/RenderDriver/RenderModuleData/RuntimeModuleData/3D/3DRenderProcess/RTRender3DProcess.ts
@@ -200,8 +200,12 @@ export class RTRender3DProcess implements IRender3DProcess {
         }
         if ((depthMode & DepthTextureMode.Depth) != 0) {
             Camera.depthPass.getTarget(camera, DepthTextureMode.Depth, camera.depthTextureFormat);
-            this._renderPass.mainRenderpass.depthTarget = (<RenderTexture>camera.depthTexture)._renderTarget;
-            Camera.depthPass._setupDepthModeShaderValue(DepthTextureMode.Depth, camera);
+            if (camera.canblitDepth) {
+                depthMode &= ~DepthTextureMode.Depth;
+            } else {
+                this._renderPass.mainRenderpass.depthTarget = (<RenderTexture>camera.depthTexture)._renderTarget;
+                Camera.depthPass._setupDepthModeShaderValue(DepthTextureMode.Depth, camera);
+            }
         }
         if ((depthMode & DepthTextureMode.DepthNormals) != 0) {
             Camera.depthPass.getTarget(camera, DepthTextureMode.DepthNormals, camera.depthTextureFormat);
@@ -217,6 +221,9 @@ export class RTRender3DProcess implements IRender3DProcess {
         this.renderDepth(camera);
         this.initRenderpass(camera, context);
         this.renderFowarAddCameraPass(context, this._renderPass);
+        if (camera.canblitDepth && camera.depthTexture) {
+            Camera.depthPass._setupDepthModeShaderValue(DepthTextureMode.Depth, camera);
+        }
     }
 
     renderFowarAddCameraPass(context: IRenderContext3D, renderpass: RTForwardAddRP): void {

--- a/src/layaAir/laya/RenderDriver/RenderModuleData/WebModuleData/3D/WebForwardAddRP/WebRender3DProcess.ts
+++ b/src/layaAir/laya/RenderDriver/RenderModuleData/WebModuleData/3D/WebForwardAddRP/WebRender3DProcess.ts
@@ -185,8 +185,14 @@ export class WebRender3DProcess implements IRender3DProcess {
         if ((depthMode & DepthTextureMode.Depth) != 0) {
 
             Camera.depthPass.getTarget(camera, DepthTextureMode.Depth, camera.depthTextureFormat);
-            this._renderPass.mainRenderpass.depthTarget = (<RenderTexture>camera.depthTexture)._renderTarget;
-            Camera.depthPass._setupDepthModeShaderValue(DepthTextureMode.Depth, camera);
+            if (camera.canblitDepth) {
+                // blit depth 模式: 不需要单独的 depth pass, 也不在此时绑定深度纹理
+                // 深度来自 forward pass 的 depthStencilTexture, 在 forward pass 结束后绑定
+                depthMode &= ~DepthTextureMode.Depth;
+            } else {
+                this._renderPass.mainRenderpass.depthTarget = (<RenderTexture>camera.depthTexture)._renderTarget;
+                Camera.depthPass._setupDepthModeShaderValue(DepthTextureMode.Depth, camera);
+            }
         }
         if ((depthMode & DepthTextureMode.DepthNormals) != 0) {
             Camera.depthPass.getTarget(camera, DepthTextureMode.DepthNormals, camera.depthTextureFormat);
@@ -258,6 +264,11 @@ export class WebRender3DProcess implements IRender3DProcess {
         this._renderDepth(camera);
         this._initRenderPass(camera, context);
         this._renderForwardAddCameraPass(context, this._renderPass);
+        // blit depth 模式: forward pass 结束后再绑定深度纹理给 shader
+        // 此时深度附件不再被写入, 可安全作为 TextureBinding 采样
+        if (camera.canblitDepth && camera.depthTexture) {
+            Camera.depthPass._setupDepthModeShaderValue(DepthTextureMode.Depth, camera);
+        }
     }
 
 

--- a/src/layaAir/laya/d3/core/Camera.ts
+++ b/src/layaAir/laya/d3/core/Camera.ts
@@ -884,7 +884,7 @@ export class Camera extends BaseCamera {
      * @zh 相机是否可以绘制深度纹理。
      */
     get canblitDepth() {
-        return this._canBlitDepth && this._internalRenderTexture && this._internalRenderTexture.depthStencilFormat != null;
+        return this._canBlitDepth && this._internalRenderTexture && this._internalRenderTexture.depthStencilFormat != null && this._cacheDepthTexture != null;
     }
 
     /**

--- a/src/layaAir/laya/d3/depthMap/DepthPass.ts
+++ b/src/layaAir/laya/d3/depthMap/DepthPass.ts
@@ -93,7 +93,13 @@ export class DepthPass {
                 var near = camera.nearPlane;
                 this._zBufferParams.setValue(1.0 - far / near, far / near, (near - far) / (near * far), 1 / near);
                 camera._shaderValues.setVector(DepthPass.DEFINE_SHADOW_BIAS, DepthPass.SHADOW_BIAS);
-                camera._shaderValues.setTexture(DepthPass.DEPTHTEXTURE, this._depthTexture);
+                // enableBlitDepth 模式: _depthTexture 是 _cacheDepthTexture (整个 RT),
+                // 需要传 depthStencilTexture (独立深度纹理) 给 shader, 避免 color 附件读写冲突
+                if (camera.canblitDepth && this._depthTexture && (this._depthTexture as any).depthStencilTexture) {
+                    camera._shaderValues.setTexture(DepthPass.DEPTHTEXTURE, (this._depthTexture as any).depthStencilTexture);
+                } else {
+                    camera._shaderValues.setTexture(DepthPass.DEPTHTEXTURE, this._depthTexture);
+                }
                 camera._shaderValues.setVector(DepthPass.DEPTHZBUFFERPARAMS, this._zBufferParams);
                 break;
             case DepthTextureMode.DepthNormals:


### PR DESCRIPTION
Ensure _cacheDepthTexture is not null before returning true in canblitDepth getter to prevent errors when using enableBlitDepth with WebGPU.