### PR TITLE
fix(forum-55139): lock Light2D RenderTextures to prevent destroyUnusedResources from reclaiming them

### DIFF
--- a/src/layaAir/laya/Light2D/FreeformLight2D.ts
+++ b/src/layaAir/laya/Light2D/FreeformLight2D.ts
@@ -256,6 +256,7 @@ export class FreeformLight2D extends BaseLight2D {
             this._texLight.destroy(); //可能有风险
         const tex = this._texLight = new RenderTexture(width, height, RenderTargetFormat.R8G8B8A8, null, false, this.antiAlias ? 4 : 1);
         tex.wrapModeU = tex.wrapModeV = WrapMode.Clamp;
+        tex.lock = true;
         if (!this._cmdRT)
             this._cmdRT = Set2DRTCMD.create(tex, true, Color.CLEAR, false);
         else this._cmdRT.renderTexture = tex;

--- a/src/layaAir/laya/Light2D/SpotLight2D.ts
+++ b/src/layaAir/laya/Light2D/SpotLight2D.ts
@@ -245,6 +245,7 @@ export class SpotLight2D extends BaseLight2D {
             this._texLight.destroy(); //可能有风险
         const tex = this._texLight = new RenderTexture(width, height, RenderTargetFormat.R8G8B8A8, null, false, this.antiAlias ? 4 : 1);
         tex.wrapModeU = tex.wrapModeV = WrapMode.Clamp;
+        tex.lock = true;
         if (!this._cmdRT)
             this._cmdRT = Set2DRTCMD.create(tex, true, Color.CLEAR, false);
         else this._cmdRT.renderTexture = tex;


### PR DESCRIPTION
fix(forum-55139): lock Light2D RenderTextures to prevent destroyUnusedResources from reclaiming them

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>