### PR TITLE
fix(forum-55090): ViewStack.set_dataSource use _setIndexHandler instead of direct selectedIndex assignment

### DIFF
--- a/src/layaAir/laya/ui/ViewStack.ts
+++ b/src/layaAir/laya/ui/ViewStack.ts
@@ -162,7 +162,7 @@ export class ViewStack extends Box {
     set_dataSource(value: any) {
         this._dataSource = value;
         if (typeof (value) == 'number' || typeof (value) == 'string') {
-            this.selectedIndex = parseInt(value as string);
+            this._setIndexHandler.runWith(parseInt(value as string));
         } else {
             for (var prop in this._dataSource) {
                 if (prop in this) {


### PR DESCRIPTION
fix(forum-55090): ViewStack.set_dataSource use _setIndexHandler instead of direct selectedIndex assignment