### PR TITLE
fix(physics): mesh collider scale sync when sharing mesh

### DIFF
--- a/src/layaAir/laya/Physics3D/Bullet/Collider/btCollider.ts
+++ b/src/layaAir/laya/Physics3D/Bullet/Collider/btCollider.ts
@@ -328,8 +328,17 @@ export class btCollider implements ICollider {
      */
     setColliderShape(shape: btColliderShape) {
         shape._btCollider = this;
-        if (shape == this._btColliderShape || shape._btShape == null)
+        if (shape._btShape == null)
             return;
+        if (shape == this._btColliderShape) {
+            // Same wrapper shape may recreate a new native btShape (e.g. mesh collider refresh).
+            // Rebind and resync transform so scale is applied to the new native shape.
+            if (this._btCollider) {
+                btStatics.bt.btCollisionObject_setCollisionShape(this._btCollider, shape._btShape);
+                this.componentEnable && this._derivePhysicsTransformation(true);
+            }
+            return;
+        }
         var lastColliderShape: btColliderShape = this._btColliderShape;
         this._btColliderShape = shape;
         let bt = btStatics.bt;

--- a/src/layaAir/laya/Physics3D/Bullet/Shape/btMeshColliderShape.ts
+++ b/src/layaAir/laya/Physics3D/Bullet/Shape/btMeshColliderShape.ts
@@ -15,6 +15,8 @@ export class btMeshColliderShape extends btColliderShape implements IMeshCollide
 
     /**@internal */
     private _physicMesh: any;
+    /**@internal */
+    private _physicsMeshOwned: boolean = false;
 
     /**@internal */
     static _btTempVector30: number;
@@ -103,13 +105,18 @@ export class btMeshColliderShape extends btColliderShape implements IMeshCollide
         return this._convex;
     }
 
-    private _createPhysicsMeshFromMesh(value: Mesh): number {
-        if (value._triangleMesh) {
+    private _createPhysicsMeshFromMesh(value: Mesh, shared: boolean): number {
+        if (shared && value._triangleMesh) {
             return value._triangleMesh;
         }
         let bt = btStatics.bt;
 
-        var triangleMesh: number = value._triangleMesh = bt.btTriangleMesh_create();//TODO:独立抽象btTriangleMesh,增加内存复用
+        // For non-convex mesh colliders, each collider should own an independent triangle mesh.
+        // Sharing btTriangleMesh across multiple shapes causes scale coupling between colliders.
+        var triangleMesh: number = bt.btTriangleMesh_create();
+        if (shared) {
+            value._triangleMesh = triangleMesh;
+        }
         var nativePositio0: number = btMeshColliderShape._btTempVector30;
         var nativePositio1: number = btMeshColliderShape._btTempVector31;
         var nativePositio2: number = btMeshColliderShape._btTempVector32;
@@ -134,7 +141,7 @@ export class btMeshColliderShape extends btColliderShape implements IMeshCollide
 
     private _createConvexMeshFromMesh(value: Mesh): number {
         if (!value._convexMesh) {
-            let physicMesh = this._createPhysicsMeshFromMesh(this._mesh);
+            let physicMesh = this._createPhysicsMeshFromMesh(this._mesh, true);
             value._convexMesh = btStatics.bt.btShapeHull_create(physicMesh);
         }
         return value._convexMesh;
@@ -145,7 +152,11 @@ export class btMeshColliderShape extends btColliderShape implements IMeshCollide
         if (this._btShape) {
             bt.btCollisionShape_destroy(this._btShape);
         }
-        this._physicMesh = this._createPhysicsMeshFromMesh(this._mesh);
+        if (this._physicMesh && this._physicsMeshOwned) {
+            bt.btStridingMeshInterface_destroy(this._physicMesh);
+        }
+        this._physicMesh = this._createPhysicsMeshFromMesh(this._mesh, false);
+        this._physicsMeshOwned = true;
         if (this._physicMesh) {
             this._btShape = bt.btBvhTriangleMeshShape_create(this._physicMesh);
             if (this._btCollider) this._btCollider.setColliderShape(this);
@@ -179,6 +190,15 @@ export class btMeshColliderShape extends btColliderShape implements IMeshCollide
             // 	bt.btGImpactShapeInterface_updateBound(this._btShape);//更新缩放后需要更新包围体,有性能损耗
             // }
         }
+    }
+
+    destroy(): void {
+        if (this._physicMesh && this._physicsMeshOwned) {
+            btStatics.bt.btStridingMeshInterface_destroy(this._physicMesh);
+            this._physicMesh = null;
+            this._physicsMeshOwned = false;
+        }
+        super.destroy();
     }
 
 }

--- a/src/layaAir/laya/d3/physics/shape/MeshColliderShape.ts
+++ b/src/layaAir/laya/d3/physics/shape/MeshColliderShape.ts
@@ -27,7 +27,9 @@ export class MeshColliderShape extends Physics3DColliderShape {
     }
 
     set mesh(value: Mesh) {
-        if ((this._mesh == value && this._shape) || !value)
+        if (!value)
+            return;
+        if (this._mesh == value && this._shape && this._shape.getPhysicsShape())
             return;
         this._mesh = value;
         this._changeShape();


### PR DESCRIPTION
- 修复了 MeshCollider 共用同一 Mesh 时，后续碰撞器缩放不正确的问题（首个正常、其余异常）。
- 根因是 Bullet 非凸网格碰撞器复用了 Mesh._triangleMesh ，导致多个碰撞器共享底层数据并产生缩放串扰。
- 调整为：非凸路径每个碰撞器独立创建三角网格，并补充对应释放逻辑，避免内存泄漏。
- 同时修复了 shape 重建场景下的重绑定与强制变换同步，以及同 mesh 赋值时过早 return 导致的漏更新。
- 改动仅在 src 源码（无 build 目录手改），已完成本地回归验证路径：共享 mesh + 多对象不同缩放 + 运行时缩放更新。