### PR TITLE
fix: skip URL encoding for chinese filenames on TT mini-game（修复抖音小游戏中…

### DIFF
--- a/src/layaAir/platforms/minigame/MgDownloader.ts
+++ b/src/layaAir/platforms/minigame/MgDownloader.ts
@@ -38,7 +38,7 @@ export class MgDownloader extends Downloader {
         if (Browser.onVVMiniGame || Browser.onQGMiniGame) //vivo&oppo
             this.supportSubPackageMultiLevelFolders = false;
 
-        if (Browser.onWXMiniGame || Browser.onHWMiniGame) //微信小游戏、华为小游戏不需要这个
+        if (Browser.onWXMiniGame || Browser.onHWMiniGame || Browser.onTTMiniGame) //微信小游戏、华为小游戏、抖音小游戏不需要这个
             this.escapeZhCharsInURL = false;
 
         if (enableCache) {


### PR DESCRIPTION
…文文件名加载失败，跳过 URL 编码）