### PR TITLE
fix: guard WebAssembly stub assignment for TT iOS readonly slot（修复抖音i…

### DIFF
--- a/src/layaAir/platforms/minigame/MgBrowserAdapter.ts
+++ b/src/layaAir/platforms/minigame/MgBrowserAdapter.ts
@@ -154,8 +154,13 @@ export class MgBrowserAdapter extends BrowserAdapter {
             wasmGlobal = (window as any).qg;
 
         if (wasmGlobal) {
-            if (!window.WebAssembly) //让WASM库以为支持WASM
-                (window as any).WebAssembly = { Memory : wasmGlobal.Memory };
+            if (!window.WebAssembly) { //让WASM库以为支持WASM
+                try {
+                    (window as any).WebAssembly = { Memory: wasmGlobal.Memory };
+                } catch (e) {
+                    //抖音iOS等平台window.WebAssembly虽undefined但slot只读，赋值会抛错；wasm库走WasmAdapter钩子不依赖此stub，忽略
+                }
+            }
             WasmAdapter.Memory = wasmGlobal.Memory;
 
             WasmAdapter.instantiateWasm = (wasmFile: string, imports: any) => {


### PR DESCRIPTION
…OS真机因window.WebAssembly只读导致引擎初始化失败）