### PR TITLE
fix(forum-55249): fallback to canplay event when loadedmetadata not fired

### DIFF
--- a/src/layaAir/laya/media/HTMLVideoTexture.ts
+++ b/src/layaAir/laya/media/HTMLVideoTexture.ts
@@ -22,6 +22,9 @@ export class HTMLVideoTexture extends VideoTexture {
         ele.addEventListener("loadedmetadata", () =>
             this.setLoaded(this.element.videoWidth, this.element.videoHeight, Browser.onLayaRuntime));
         ele.addEventListener("canplay", () => {
+            //如果loadedmetadata未触发，在canplay时补充初始化
+            if (!this._loaded && this.element.videoWidth > 0 && this.element.videoHeight > 0)
+                this.setLoaded(this.element.videoWidth, this.element.videoHeight, Browser.onLayaRuntime);
             //让画面显示出来，而不是黑色
             this.event("canplay");
             if (!this._playing)


### PR DESCRIPTION
Forum: https://ask.layaair.com/d/55249

HTMLVideoTexture 的初始化完全依赖 `loadedmetadata` 事件来触发 `setLoaded()`，但某些浏览器/平台下这个事件可能不触发（缓存命中、资源加载极快、移动端浏览器策略等）。虽然后续 `canplay` 可能正常触发，但其处理器未检查 `_loaded`，导致纹理永远不会初始化。

在 `canplay` 事件中增加 fallback：若 `_loaded=false` 且 `videoWidth/videoHeight` 有效，补充调用 `setLoaded()`。