### PR TITLE
fix(forum-55187): prevent destroyUnusedResources from destroying Light2D internal meshes

### DIFF
--- a/src/layaAir/laya/Light2D/Light2DManager.ts
+++ b/src/layaAir/laya/Light2D/Light2DManager.ts
@@ -1232,7 +1232,7 @@ export class Light2DManager implements IElementComponentManager, ILight2DManager
      * @returns 生成或更新后的网格对象。
     */
     private _makeOrUpdateMesh(vertices: Float32Array, indices: Uint16Array, mesh?: Mesh2D) {
-        if (mesh) {
+        if (mesh && !mesh.destroyed) {
             const idx = mesh.getIndices();
             const ver = mesh.getVertices()[0];
             if (Light2DManager.REUSE_MESH
@@ -1246,7 +1246,9 @@ export class Light2DManager implements IElementComponentManager, ILight2DManager
             } else this._needToRecover.push(mesh); //mesh不可以复用，回收
         }
         const declaration = VertexMesh2D.getVertexDeclaration(['POSITION,UV'], false)[0];
-        return Mesh2D.createMesh2DByPrimitive([vertices], [declaration], indices, IndexFormat.UInt16, [{ length: indices.length, start: 0 }], true);
+        const newMesh = Mesh2D.createMesh2DByPrimitive([vertices], [declaration], indices, IndexFormat.UInt16, [{ length: indices.length, start: 0 }], true);
+        newMesh._addReference();
+        return newMesh;
     }
 
     /**


### PR DESCRIPTION
Forum: https://ask.layaair.com/d/55187

Light2DManager creates Mesh2D objects for light rendering but never adds
references, so destroyUnusedResources() treats them as unused and destroys
them. After destruction _indexBuffer becomes null, causing TypeError on
next frame when the manager tries to reuse the mesh.

Fix: add _addReference() on newly created meshes and check mesh.destroyed
before attempting reuse.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>