### PR TITLE
fix(forum-55189): disable MSAA for mask parent RT to fix white line artifact

### DIFF
--- a/src/layaAir/laya/display/Sprite.ts
+++ b/src/layaAir/laya/display/Sprite.ts
@@ -2123,6 +2123,7 @@ export class Sprite extends Node {
             if (this._renderType & SpriteConst.DRAW2RT) {
                 if (
                     !this._drawOriRT
+                    || this._drawOriRT === RenderTexture2D._empty
                     || this._subpassUpdateFlag
                     || flag & RepaintFlag.UpdateRT
                     || (this.transform && this._maskParent)
@@ -2462,7 +2463,7 @@ export class Sprite extends Node {
         if (rect.width === 0 || rect.height === 0) {
             this._drawOriRT = RenderTexture2D._empty;
         } else {
-            let multiSamples = LayaGL.renderEngine.getCapable(RenderCapable.MSAA) ? 4 : 1;
+            let multiSamples = !this._mask && LayaGL.renderEngine.getCapable(RenderCapable.MSAA) ? 4 : 1;
             let renderTexture = RenderTexture2D.createFromPool(rect.width, rect.height, RenderTargetFormat.R8G8B8A8, RenderTargetFormat.DEPTHSTENCIL_24_8, multiSamples);
             renderTexture._invertY = LayaGL.renderEngine._screenInvertY;
             this._drawOriRT = renderTexture;


### PR DESCRIPTION
Forum: https://ask.layaair.com/d/55189

When a sprite has a mask, its sub-render pass RT should not use MSAA.
MSAA on the parent RT causes the mask quad's edges to be anti-aliased
during resolve, leaking content at the mask boundary as visible white lines.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>