### PR TITLE
fix(forum-55211): Input native element position offset incorrect when scaled

### DIFF
--- a/src/layaAir/laya/utils/SpriteUtils.ts
+++ b/src/layaAir/laya/utils/SpriteUtils.ts
@@ -80,9 +80,9 @@ export class SpriteUtils {
         var tx: number, ty: number;
 
         if (perpendicular) {
-            // 在舞台上的坐标
-            tx = y + globalTransform.y;
-            ty = x + globalTransform.x;
+            // 在舞台上的坐标（局部偏移需乘以全局缩放）
+            tx = globalTransform.y + y * globalTransform.scaleY;
+            ty = globalTransform.x + x * globalTransform.scaleX;
 
             // 在画布上的坐标
             tx *= canvasMatrix.d;
@@ -105,9 +105,9 @@ export class SpriteUtils {
         }
         // 没有canvas旋转
         else {
-            // 在舞台上的坐标
-            tx = x + globalTransform.x;
-            ty = y + globalTransform.y;
+            // 在舞台上的坐标（局部偏移需乘以全局缩放）
+            tx = globalTransform.x + x * globalTransform.scaleX;
+            ty = globalTransform.y + y * globalTransform.scaleY;
 
             // 在画布上的坐标
             tx *= canvasMatrix.a;


### PR DESCRIPTION
Forum: https://ask.layaair.com/d/55211

SpriteUtils.getTransformRelativeToWindow 计算原生输入框窗口坐标时，Input 的局部偏移（如 padding）直接与全局坐标相加，未乘全局缩放系数。Input/父节点存在缩放时偏移未被正确缩放，导致原生 input 元素和 Input 组件显示位置不一致。