### PR TITLE
修复2D相机坐标转换和缩放后边界判断问题

### DIFF
--- a/src/layaAir/laya/display/Area2D.ts
+++ b/src/layaAir/laya/display/Area2D.ts
@@ -9,6 +9,7 @@ import { ShaderData } from "../RenderDriver/DriverDesign/RenderDevice/ShaderData
 import { SpriteConst } from "./SpriteConst";
 import { Matrix } from "../maths/Matrix";
 import { LayaEnv } from "../../LayaEnv";
+import { ILaya } from "../../ILaya";
 
 export class Area2D extends Sprite {
     private _mainCamera: Camera2D;
@@ -104,6 +105,8 @@ export class Area2D extends Sprite {
             // 如果没有主相机，屏幕坐标就是相对于Area2D的UI坐标
             return out;
         }
+        x *= ILaya.stage.scaleX;
+        y *= ILaya.stage.scaleY;
 
         let halfWidth = RenderState2D.width * 0.5;
         let halfHeight = RenderState2D.height * 0.5;

--- a/src/layaAir/laya/display/Scene2DSpecial/Camera2D.ts
+++ b/src/layaAir/laya/display/Scene2DSpecial/Camera2D.ts
@@ -42,6 +42,7 @@ export class Camera2D extends Sprite {
     private _drag_Bottom: number;
     private _positionSmooth: boolean;
     private _positionSpeed: number;//
+    private _currPos: Point;
 
     /**@internal TODO*/
     _renderTarget: RenderTexture;
@@ -323,6 +324,7 @@ export class Camera2D extends Sprite {
         this._positionSmooth = false;
         this._rect = new Vector4();
         this._zoom = new Vector2(1, 1);
+        this._currPos = new Point(0, 0);
     }
     /**
      * 获得viewPort大小
@@ -354,8 +356,9 @@ export class Camera2D extends Sprite {
     _getCameraTransform(): Matrix3x3 {
         //用来计算camera的矩阵
         let viewport = this._getScreenSize();
-        let curPosPoint = Point.TEMP;
+        let curPosPoint = this._currPos;
         this.globalTrans.getPos(curPosPoint);
+        // this.localToGlobal(curPosPoint.setTo(0, 0));
         let extendHorizental = viewport.x * 0.5 * this._zoom.x;
         let extendVertical = viewport.y * 0.5 * this._zoom.y;
 
@@ -375,9 +378,9 @@ export class Camera2D extends Sprite {
             }
 
             let sceneRect_left = this._cameraPos.x - extendHorizental;
-            let sceneRect_right = sceneRect_left + viewport.x;
+            let sceneRect_right = sceneRect_left + extendHorizental * 2;
             let sceneRect_top = this._cameraPos.y - extendVertical;
-            let sceneRect_bottom = sceneRect_top + viewport.y;
+            let sceneRect_bottom = sceneRect_top + extendVertical * 2;
 
             //limit
             if (sceneRect_left < this._limit_Left) {


### PR DESCRIPTION
问题在官方社区已提交，如图坐标转换接口在h5和小游戏版本正常
<img width="1160" height="637" alt="图片" src="https://github.com/user-attachments/assets/f5b214f3-f4df-4227-bf59-fd5825632c93" />

https://ask.layaair.com/d/55237-area2dshi-yong-2dxiang-ji-zai-wei-xin-ban-ben-area2dtransformpointjie-kou-fan-hui-zhi-cuo-wu