### PR TITLE
fix(tt-minigame): also probe readdir to gate MgDownloader cache（抖音试玩广…

### DIFF
--- a/src/layaAir/platforms/minigame/MgBrowserAdapter.ts
+++ b/src/layaAir/platforms/minigame/MgBrowserAdapter.ts
@@ -102,7 +102,7 @@ export class MgBrowserAdapter extends BrowserAdapter {
 
     start(): Promise<void> {
         let downloader = Loader.downloader = new MgDownloader(
-            PAL.hasAPI("getFileSystemManager") && PAL.hasAPI(PAL.g.getFileSystemManager(), "writeFile")
+            PAL.hasAPI("getFileSystemManager") && PAL.hasAPI(PAL.g.getFileSystemManager(), "writeFile") && PAL.hasAPI(PAL.g.getFileSystemManager(), "readdir")
         );
         this.setupWasmSupport();
 


### PR DESCRIPTION
…告环境缺 readdir API，需在选择带缓存的 MgDownloader 前一并探测，避免后续读目录失败）