### PR TITLE
fix(BaseRenderNode2D): clear renderElements on destroy to prevent mem…

### DIFF
--- a/src/layaAir/laya/NodeRender2D/BaseRenderNode2D.ts
+++ b/src/layaAir/laya/NodeRender2D/BaseRenderNode2D.ts
@@ -342,6 +342,7 @@ export class BaseRenderNode2D extends Component {
                 BaseRenderNode2D._removeRenderElement2DMaterial(element, this._getElementMaterial(i));
             }
         }
+        this._struct.renderElements = [];
         for (var i = 0, n = this._materials.length; i < n; i++) {
             let m = this._materials[i];
             m && !m.destroyed && m._removeReference();


### PR DESCRIPTION
…ory leak

Clear _struct.renderElements array during component destruction to ensure all render element references are properly cleaned up.