### PR TITLE
修复微信版本播放音乐指定开始时间时死循环

### DIFF
--- a/src/layaAir/platforms/minigame/MgInnerAudioChannel.ts
+++ b/src/layaAir/platforms/minigame/MgInnerAudioChannel.ts
@@ -36,12 +36,12 @@ export class MgInnerAudioChannel extends SoundChannel {
         });
         ctx.onEnded(() => this.onPlayEnd());
         let playSound = () => {
+            ctx.offCanplay(playSound);
             if (this._ctx && !this._paused) {
                 if (this.startTime != 0)
                     ctx.seek(this.startTime);
                 ctx.play();
             }
-            ctx.offCanplay(playSound);
         };
         ctx.onCanplay(playSound);
 


### PR DESCRIPTION
ctx.seek(this.startTime);会触发playSound导致死循环，不明原因