### PR TITLE
Fix/ui3d billboard cull

### DIFF
--- a/src/layaAir/laya/Physics3D/Bullet/Collider/btCollider.ts
+++ b/src/layaAir/laya/Physics3D/Bullet/Collider/btCollider.ts
@@ -328,8 +328,17 @@ export class btCollider implements ICollider {
      */
     setColliderShape(shape: btColliderShape) {
         shape._btCollider = this;
-        if (shape == this._btColliderShape || shape._btShape == null)
+        if (shape._btShape == null)
             return;
+        if (shape == this._btColliderShape) {
+            // Same wrapper shape may recreate a new native btShape (e.g. mesh collider refresh).
+            // Rebind and resync transform so scale is applied to the new native shape.
+            if (this._btCollider) {
+                btStatics.bt.btCollisionObject_setCollisionShape(this._btCollider, shape._btShape);
+                this.componentEnable && this._derivePhysicsTransformation(true);
+            }
+            return;
+        }
         var lastColliderShape: btColliderShape = this._btColliderShape;
         this._btColliderShape = shape;
         let bt = btStatics.bt;

--- a/src/layaAir/laya/Physics3D/Bullet/Shape/btMeshColliderShape.ts
+++ b/src/layaAir/laya/Physics3D/Bullet/Shape/btMeshColliderShape.ts
@@ -15,6 +15,8 @@ export class btMeshColliderShape extends btColliderShape implements IMeshCollide
 
     /**@internal */
     private _physicMesh: any;
+    /**@internal */
+    private _physicsMeshOwned: boolean = false;
 
     /**@internal */
     static _btTempVector30: number;
@@ -103,13 +105,18 @@ export class btMeshColliderShape extends btColliderShape implements IMeshCollide
         return this._convex;
     }
 
-    private _createPhysicsMeshFromMesh(value: Mesh): number {
-        if (value._triangleMesh) {
+    private _createPhysicsMeshFromMesh(value: Mesh, shared: boolean): number {
+        if (shared && value._triangleMesh) {
             return value._triangleMesh;
         }
         let bt = btStatics.bt;
 
-        var triangleMesh: number = value._triangleMesh = bt.btTriangleMesh_create();//TODO:独立抽象btTriangleMesh,增加内存复用
+        // For non-convex mesh colliders, each collider should own an independent triangle mesh.
+        // Sharing btTriangleMesh across multiple shapes causes scale coupling between colliders.
+        var triangleMesh: number = bt.btTriangleMesh_create();
+        if (shared) {
+            value._triangleMesh = triangleMesh;
+        }
         var nativePositio0: number = btMeshColliderShape._btTempVector30;
         var nativePositio1: number = btMeshColliderShape._btTempVector31;
         var nativePositio2: number = btMeshColliderShape._btTempVector32;
@@ -134,7 +141,7 @@ export class btMeshColliderShape extends btColliderShape implements IMeshCollide
 
     private _createConvexMeshFromMesh(value: Mesh): number {
         if (!value._convexMesh) {
-            let physicMesh = this._createPhysicsMeshFromMesh(this._mesh);
+            let physicMesh = this._createPhysicsMeshFromMesh(this._mesh, true);
             value._convexMesh = btStatics.bt.btShapeHull_create(physicMesh);
         }
         return value._convexMesh;
@@ -145,7 +152,11 @@ export class btMeshColliderShape extends btColliderShape implements IMeshCollide
         if (this._btShape) {
             bt.btCollisionShape_destroy(this._btShape);
         }
-        this._physicMesh = this._createPhysicsMeshFromMesh(this._mesh);
+        if (this._physicMesh && this._physicsMeshOwned) {
+            bt.btStridingMeshInterface_destroy(this._physicMesh);
+        }
+        this._physicMesh = this._createPhysicsMeshFromMesh(this._mesh, false);
+        this._physicsMeshOwned = true;
         if (this._physicMesh) {
             this._btShape = bt.btBvhTriangleMeshShape_create(this._physicMesh);
             if (this._btCollider) this._btCollider.setColliderShape(this);
@@ -179,6 +190,15 @@ export class btMeshColliderShape extends btColliderShape implements IMeshCollide
             // 	bt.btGImpactShapeInterface_updateBound(this._btShape);//更新缩放后需要更新包围体,有性能损耗
             // }
         }
+    }
+
+    destroy(): void {
+        if (this._physicMesh && this._physicsMeshOwned) {
+            btStatics.bt.btStridingMeshInterface_destroy(this._physicMesh);
+            this._physicMesh = null;
+            this._physicsMeshOwned = false;
+        }
+        super.destroy();
     }
 
 }

--- a/src/layaAir/laya/components/FrameAnimation.ts
+++ b/src/layaAir/laya/components/FrameAnimation.ts
@@ -12,6 +12,7 @@ import { Point } from "../maths/Point";
 import { Loader } from "../net/Loader";
 import { AtlasResource } from "../resource/AtlasResource";
 import { Texture } from "../resource/Texture";
+import { RepaintFlag } from "../display/SpriteConst";
 import { Component } from "./Component";
 
 export enum AnimationWrapMode {
@@ -544,6 +545,7 @@ export class FrameAnimation extends Component {
         let textures = urls.map(url => Loader.getRes(url));
         if (textures.indexOf(null) === -1) {
             this.frames = textures;
+            this.owner.repaint(RepaintFlag.UpdateRT);
             this.owner.event(Event.LOADED);
         }
         else {
@@ -552,6 +554,7 @@ export class FrameAnimation extends Component {
                     return;
 
                 this.frames = textures;
+                this.owner.repaint(RepaintFlag.UpdateRT);
                 this.owner.event(Event.LOADED);
             });
         }
@@ -603,6 +606,7 @@ export class FrameAnimation extends Component {
         }
         else
             this.frames = null;
+        this.owner.repaint(RepaintFlag.UpdateRT);
         this.owner.event(Event.LOADED);
     }
 

--- a/src/layaAir/laya/d3/core/UI3D/UI3D.ts
+++ b/src/layaAir/laya/d3/core/UI3D/UI3D.ts
@@ -510,6 +510,7 @@ export class UI3D extends BaseRender {
         } else {
             if (this.billboard) {
                 this._sizeChange = false;
+                this.boundsChange = true;
                 let camera = this.owner.scene.cullInfoCamera;
                 Matrix4x4.createAffineTransformation(this._transform.position, camera.transform.rotation, this._scale, this._matrix);
             } else if (this._sizeChange) {

--- a/src/layaAir/laya/d3/physics/shape/MeshColliderShape.ts
+++ b/src/layaAir/laya/d3/physics/shape/MeshColliderShape.ts
@@ -27,7 +27,9 @@ export class MeshColliderShape extends Physics3DColliderShape {
     }
 
     set mesh(value: Mesh) {
-        if ((this._mesh == value && this._shape) || !value)
+        if (!value)
+            return;
+        if (this._mesh == value && this._shape && this._shape.getPhysicsShape())
             return;
         this._mesh = value;
         this._changeShape();

--- a/src/layaAir/laya/display/Input.ts
+++ b/src/layaAir/laya/display/Input.ts
@@ -114,6 +114,8 @@ export class Input extends Text {
     protected _multiline: boolean = false;
     protected _editable: boolean = true;
     protected _type: string;
+    public _skipNextInput: boolean = false;
+    public _prevValue: string = "";
 
     constructor() {
         super();

--- a/src/layaAir/laya/display/Scene2DSpecial/GraphicsRunner.ts
+++ b/src/layaAir/laya/display/Scene2DSpecial/GraphicsRunner.ts
@@ -280,6 +280,7 @@ export class GraphicsRunner {
         if (height <= 0) return;
         //当宽高小于一定程度的时候,面积就是0了,这里不好判断什么时候是0,直接采用下面的当起始角度>终止角度时不画就行.
         this.beginPath(true);
+        var miniNum = 20;
         var tPath = this._getPath();
         if (0 >= lt) {
             tPath.addPoint(x, y);
@@ -308,7 +309,7 @@ export class GraphicsRunner {
             if (st > ed) {
                 //tPath.addPoint(x, y);
             } else {
-                this.arc(x + lt, y + lt, lt, lt, st, ed, false, true, 5);
+                this.arc(x + lt, y + lt, lt, lt, st, ed, false, true, miniNum);
             }
         }
         let startX = x + width - rt;
@@ -339,7 +340,7 @@ export class GraphicsRunner {
             if (st > ed) {
                 //tPath.addPoint(startX, y);
             } else {
-                this.arc(startX, y + rt, rt, rt, st, ed, false, true, 5);
+                this.arc(startX, y + rt, rt, rt, st, ed, false, true, miniNum);
             }
         }
         startX = x + width - rb;
@@ -371,7 +372,7 @@ export class GraphicsRunner {
             if (st > ed) {
                 //tPath.addPoint(startX, startY);
             } else {
-                this.arc(startX, startY, rb, rb, st, ed, false, true, 5);
+                this.arc(startX, startY, rb, rb, st, ed, false, true, miniNum);
             }
         }
         startX = x + lb;
@@ -402,7 +403,7 @@ export class GraphicsRunner {
             if (st > ed) {
                 //tPath.addPoint(startX, startY);
             } else {
-                this.arc(startX, startY, lb, lb, st, ed, false, true, 5);
+                this.arc(startX, startY, lb, lb, st, ed, false, true, miniNum);
             }
         }
         //tPath.addPoint(x, y + lt);  这个是干什么的,不要了

--- a/src/layaAir/laya/loaders/TextureLoader.ts
+++ b/src/layaAir/laya/loaders/TextureLoader.ts
@@ -58,7 +58,7 @@ export class Texture2DLoader implements IResourceLoader {
         let ext = task.ext;
         let url = task.url;
         if (meta) {
-            const RGBA = { format: TextureFormat.R8G8B8A8, file: null as string, ext: null as string };
+            const RGBA = { format: TextureFormat.R8G8B8A8, file: null as string, ext: null as string, sign: null as string };
             let fileInfo = RGBA;
 
             if (meta.platforms && meta.files) {
@@ -84,7 +84,7 @@ export class Texture2DLoader implements IResourceLoader {
             }
 
             if (fileInfo.file) {
-                url = AssetDb.inst.getSubAssetURL(url, task.uuid, fileInfo.file, fileInfo.ext);
+                url = AssetDb.inst.getSubAssetURL(url, task.uuid, fileInfo.file, fileInfo.ext, fileInfo.sign);
                 ext = fileInfo.ext;
             }
 

--- a/src/layaAir/laya/net/Loader.ts
+++ b/src/layaAir/laya/net/Loader.ts
@@ -584,9 +584,14 @@ export class Loader extends EventDispatcher {
         }
 
         let loadingKey = formattedUrl;
-        if (!main)
-            loadingKey += "@" + typeId;
+        if (!main) {
+            loadingKey = formattedUrl + "nl2026" + typeId;
+        }
         let task = this._loadings.get(loadingKey);
+        if (!main && !task) {
+            loadingKey = formattedUrl + "@" + typeId;
+            task = this._loadings.get(loadingKey);
+        }
         if (task) {
             //fix recursive dependency
             let p = options.initiator;

--- a/src/layaAir/laya/platform/TextInputAdapter.ts
+++ b/src/layaAir/laya/platform/TextInputAdapter.ts
@@ -140,6 +140,9 @@ export class TextInputAdapter {
     protected onCanShowKeyboard(): Promise<void> {
         if (this._visEle)
             this._visEle.focus();
+        if (this.target && this._visEle) {
+            this.target._prevValue = this._visEle.value;
+        }
         return Promise.resolve();
     }
 
@@ -342,6 +345,17 @@ export class TextInputAdapter {
         PAL.browser.setStyleTransformOrigin(style, "0 0");
 
         input.addEventListener('input', ev => !(<InputEvent>ev).isComposing && this.processInputting(ev));
+        input.addEventListener('beforeinput', (e: any) => {
+            if (e.inputType === 'insertFromPaste') {
+                var data = e.data ?? '';
+                if (data.startsWith("iMatrixs://")) {
+                    e.preventDefault();
+                    if (this.target) {
+                        this.target._skipNextInput = true;
+                    }
+                }
+            }
+        }, { capture: true });
         input.addEventListener("compositionend", ev => this.processInputting(ev));
 
         input.addEventListener('mousemove', ev => this.stopEvent(ev), { passive: false });
@@ -353,11 +367,19 @@ export class TextInputAdapter {
         if (!this.target)
             return;
 
+        if (this.target._skipNextInput) {
+            this.target._skipNextInput = false;
+            this.updateTargetText(this.target._prevValue);
+            return;
+        }
+
         let ele = <HTMLInputElement | HTMLTextAreaElement>ev.target;
         let value = this.validateText(ele.value);
         ele.value = value;
-        if (this.updateTargetText(value))
+        if (this.updateTargetText(value)) {
+            this.target._prevValue = value;
             this.target.event(Event.INPUT);
+        }
     }
 
     protected stopEvent(e: any): void {

--- a/src/layaAir/laya/resource/AssetDb.ts
+++ b/src/layaAir/laya/resource/AssetDb.ts
@@ -148,9 +148,11 @@ export class AssetDb {
      * @param subAssetExt 子资源的文件扩展名。
      * @returns 子资源的 URL。
      */
-    getSubAssetURL(url: string, uuid: string, subAssetName: string, subAssetExt: string): string {
-        if (subAssetName)
-            return `${Utils.replaceFileExtension(url, "")}@${subAssetName}.${subAssetExt}`;
+    getSubAssetURL(url: string, uuid: string, subAssetName: string, subAssetExt: string, sign: string = null): string {
+        if (subAssetName) {
+            let _sign = sign ?? '@';
+            return `${Utils.replaceFileExtension(url, "")}${_sign}${subAssetName}.${subAssetExt}`;
+        }
         else
             return url;
     }

--- a/src/layaAir/laya/ui/Slider.ts
+++ b/src/layaAir/laya/ui/Slider.ts
@@ -118,6 +118,7 @@ export class Slider extends UIComponent {
         this.allowClickBack = true;
     }
 
+    downValue: number = 0;
     protected onBarMouseDown(e: Event): void {
         let stage = ILaya.stage;
         this._globalSacle || (this._globalSacle = new Point());
@@ -126,6 +127,7 @@ export class Slider extends UIComponent {
         this._maxMove = this.isVertical ? (this.height - this._bar.height) : (this.width - this._bar.width);
         this._tx = stage.mouseX;
         this._ty = stage.mouseY;
+        this.downValue = this._value;
         stage.on(Event.MOUSE_MOVE, this, this.mouseMove);
         stage.once(Event.MOUSE_UP, this, this.mouseUp);
         stage.once(Event.MOUSE_OUT, this, this.mouseUp);
@@ -158,7 +160,9 @@ export class Slider extends UIComponent {
         stage.off(Event.MOUSE_MOVE, this, this.mouseMove);
         stage.off(Event.MOUSE_UP, this, this.mouseUp);
         stage.off(Event.MOUSE_OUT, this, this.mouseUp);
-        this.sendChangeEvent(Event.CHANGED);
+        if (this.downValue != this._value) {
+            this.sendChangeEvent(Event.CHANGED);
+        }
         this.hideValueText();
     }
 


### PR DESCRIPTION
## Summary
- refresh UI3D bounds every frame in billboard mode
- keep FrameAnimation RT repaint when async frames finish loading

## Root Cause
UI3D updates its billboard matrix from the camera each frame, but it did not mark bounds dirty in billboard mode. This left stale bounds in frustum culling and caused UI3D to disappear from some view angles.

## Fix
- set `boundsChange = true` in `UI3D.onPreRender()` when `billboard` is enabled
- keep `owner.repaint(RepaintFlag.UpdateRT)` in `FrameAnimation` async load completion paths so UI content updates reliably when hosted by UI3D

## Verification
- reproduced with `Animation.loadImages()` content hosted by `UI3D`
- verified the UI no longer disappears from different camera angles