### PR TITLE
fix: refresh UI3D bounds for billboard animation

### DIFF
--- a/src/layaAir/laya/components/FrameAnimation.ts
+++ b/src/layaAir/laya/components/FrameAnimation.ts
@@ -12,6 +12,7 @@ import { Point } from "../maths/Point";
 import { Loader } from "../net/Loader";
 import { AtlasResource } from "../resource/AtlasResource";
 import { Texture } from "../resource/Texture";
+import { RepaintFlag } from "../display/SpriteConst";
 import { Component } from "./Component";
 
 export enum AnimationWrapMode {
@@ -544,6 +545,7 @@ export class FrameAnimation extends Component {
         let textures = urls.map(url => Loader.getRes(url));
         if (textures.indexOf(null) === -1) {
             this.frames = textures;
+            this.owner.repaint(RepaintFlag.UpdateRT);
             this.owner.event(Event.LOADED);
         }
         else {
@@ -552,6 +554,7 @@ export class FrameAnimation extends Component {
                     return;
 
                 this.frames = textures;
+                this.owner.repaint(RepaintFlag.UpdateRT);
                 this.owner.event(Event.LOADED);
             });
         }
@@ -603,6 +606,7 @@ export class FrameAnimation extends Component {
         }
         else
             this.frames = null;
+        this.owner.repaint(RepaintFlag.UpdateRT);
         this.owner.event(Event.LOADED);
     }
 

--- a/src/layaAir/laya/d3/core/UI3D/UI3D.ts
+++ b/src/layaAir/laya/d3/core/UI3D/UI3D.ts
@@ -510,6 +510,7 @@ export class UI3D extends BaseRender {
         } else {
             if (this.billboard) {
                 this._sizeChange = false;
+                this.boundsChange = true;
                 let camera = this.owner.scene.cullInfoCamera;
                 Matrix4x4.createAffineTransformation(this._transform.position, camera.transform.rotation, this._scale, this._matrix);
             } else if (this._sizeChange) {


### PR DESCRIPTION
## Summary
- refresh UI3D bounds every frame in billboard mode
- keep FrameAnimation RT repaint when async frames finish loading

## Root Cause
UI3D updates its billboard matrix from the camera each frame, but it did not mark bounds dirty in billboard mode. This left stale bounds in frustum culling and caused UI3D to disappear from some view angles.

## Fix
- set `boundsChange = true` in `UI3D.onPreRender()` when `billboard` is enabled
- keep `owner.repaint(RepaintFlag.UpdateRT)` in `FrameAnimation` async load completion paths so UI content updates reliably when hosted by UI3D

## Verification
- reproduced with `Animation.loadImages()` content hosted by `UI3D`
- verified the UI no longer disappears from different camera angles