### PR TITLE
fix(2d): 修复2D renderTime使用绝对时间戳导致微信小游戏float32精度丢失

### DIFF
--- a/src/layaAir/Config.ts
+++ b/src/layaAir/Config.ts
@@ -172,8 +172,8 @@ export class Config {
     /**
      * @en Whether to use TextureArray
      * @zh 是否使用TextureArray: 文字和自动图集使用TextureArray来优化
-     */ 
-    static useTextureArray=false;
+     */
+    static useTextureArray = false;
 }
 
 export const PlayerConfig: {

--- a/src/layaAir/laya/display/Scene2DSpecial/SequenceFrame2D/SequenceFrame2DRender.ts
+++ b/src/layaAir/laya/display/Scene2DSpecial/SequenceFrame2D/SequenceFrame2DRender.ts
@@ -23,6 +23,7 @@ import { Material } from "../../../resource/Material";
 import { Texture } from "../../../resource/Texture";
 import { Texture2D } from "../../../resource/Texture2D";
 import { ShaderDefines2D } from "../../../webgl/shader/d2/ShaderDefines2D";
+import { Render2DProcessor } from "../../Render2DProcessor";
 import { SequenceFrame2DInstanceBatch } from "./SequenceFrame2DInstanceBatch";
 import { SequenceFrame2DShader } from "./SequenceFrame2DShader";
 
@@ -554,7 +555,7 @@ export class SequenceFrame2DRender extends BaseRenderNode2D {
     }
 
     private _getCurrentTime(): number {
-        return (ILaya.timer?.currTimer || 0) * 0.001;
+        return Render2DProcessor.renderTime;
     }
 
     private _getPlaybackAge(now: number = this._getCurrentTime()): number {

--- a/src/layaAir/laya/display/Stage.ts
+++ b/src/layaAir/laya/display/Stage.ts
@@ -741,7 +741,7 @@ export class Stage extends Sprite {
 
         Timer.callLaters._update(timestamp);
         Stat.loopCount++;
-        Render2DProcessor.renderTime = (ILaya.timer?.currTimer || 0) * 0.001;
+        Render2DProcessor.renderTime += (ILaya.timer?.delta || 0) * 0.001;
         LayaGL.renderEngine.startFrame();
 
         if (this.renderingEnabled) {


### PR DESCRIPTION
将 Render2DProcessor.renderTime 从直接使用 currTimer 改为累加 delta，避免微信小游戏中大时间戳导致的float32精度问题。SequenceFrame2DRender 现在直接读取 Render2DProcessor.renderTime 而非重复计算。同时格式化 Config.ts 代码。