### PR TITLE
VFX: UNI VFX visual alignment (SG per-particle path + composite transform + SingleBurst sleeping + Triangle primitive)

### DIFF
--- a/src/layaAir/laya/d3/resource/models/PrimitiveMesh.ts
+++ b/src/layaAir/laya/d3/resource/models/PrimitiveMesh.ts
@@ -676,13 +676,40 @@ export class PrimitiveMesh {
 	 * @return 创建的网格实例。
 	 */
 	static createQuad(long: number = 1, width: number = 1): Mesh {
-		//定义顶点数据结构
-		var vertexDeclaration: VertexDeclaration = VertexMesh.getVertexDeclaration("POSITION,NORMAL,UV");
+		// POSITION,NORMAL,UV,TANGENT — 加 TANGENT 让 ShaderGraph shader (e.g. UNI-Masked) 走 mask distortion 路径
+		// 之前只 POSITION,NORMAL,UV; VFX outputShaderGraphQuad 用 builtin:Quad 时 shader 拿不到 a_Tangent0 让 mask 算空
+		var vertexDeclaration: VertexDeclaration = VertexMesh.getVertexDeclaration("POSITION,NORMAL,UV,TANGENT");
 		var halfLong: number = long / 2;
 		var halfWidth: number = width / 2;
-
-		var vertices: Float32Array = new Float32Array([-halfLong, halfWidth, 0, 0, 0, 1, 0, 0, halfLong, halfWidth, 0, 0, 0, 1, 1, 0, -halfLong, -halfWidth, 0, 0, 0, 1, 0, 1, halfLong, -halfWidth, 0, 0, 0, 1, 1, 1]);
+		// per vertex: pos(3) + normal(3) + uv(2) + tangent(4) = 12 floats
+		// tangent = (1, 0, 0, 1) — UV.x dir, w=1 right-handed bitangent (跟 fbx 标准 quad 一致)
+		var vertices: Float32Array = new Float32Array([
+			-halfLong,  halfWidth, 0,   0, 0, 1,   0, 0,   1, 0, 0, 1,
+			 halfLong,  halfWidth, 0,   0, 0, 1,   1, 0,   1, 0, 0, 1,
+			-halfLong, -halfWidth, 0,   0, 0, 1,   0, 1,   1, 0, 0, 1,
+			 halfLong, -halfWidth, 0,   0, 0, 1,   1, 1,   1, 0, 0, 1,
+		]);
 		var indices: Uint16Array = new Uint16Array([0, 1, 2, 3, 2, 1]);
+
+		return PrimitiveMesh._createMesh(vertexDeclaration, vertices, indices);
+	}
+
+	static createTriangle(long: number = 1, width: number = 1): Mesh {
+		// Unity VFX Graph VFXPlanarPrimitive Triangle: 顶点 circumscribe unit square (顶点在 quad 外, 让 inside triangle 完全覆盖 [0,1]² UV)
+		// 这样 mask 纹理 sample 完整 wisp shape, mask alpha cut 让 triangle 边透明 → 可见 wisp turbulence 细节
+		// UV 跟 vertex pos affine 一致: pos (x, y) in mesh space ↔ UV (x/long + 0.5, -y/width + 0.5)
+		// 即 quad corner pos (-halfLong, halfWidth) → UV (0, 0) (top-left)
+		// 验证: 单位 quad 4 corner UV 精准 (0,0)/(1,0)/(0,1)/(1,1)，triangle 顶点 UV 在 [-0.5, 1.5]
+		// inscribed Triangle (vertex 跟 quad 同 size) 让 mask 只 sample partial wisp UV, wisp 看着细窄 — circumscribe 更接近 Unity wisp 形态
+		var vertexDeclaration: VertexDeclaration = VertexMesh.getVertexDeclaration("POSITION,NORMAL,UV,TANGENT");
+		var halfLong: number = long / 2;
+		var halfWidth: number = width / 2;
+		var vertices: Float32Array = new Float32Array([
+			0,             halfWidth * 3, 0,   0, 0, 1,    0.5, -1,   1, 0, 0, 1,
+			-halfLong * 2, -halfWidth,    0,   0, 0, 1,   -0.5,  1,   1, 0, 0, 1,
+			 halfLong * 2, -halfWidth,    0,   0, 0, 1,    1.5,  1,   1, 0, 0, 1,
+		]);
+		var indices: Uint16Array = new Uint16Array([0, 1, 2]);
 
 		return PrimitiveMesh._createMesh(vertexDeclaration, vertices, indices);
 	}

--- a/src/layaAir/laya/vfx/ShaderExpressionEvaluator.ts
+++ b/src/layaAir/laya/vfx/ShaderExpressionEvaluator.ts
@@ -1,0 +1,334 @@
+import { Vector4 } from "../maths/Vector4";
+
+/**
+ * VFX → ShaderGraph 之间 operator chain 的 runtime evaluator。
+ *
+ * Unity VFX Graph 中 OutputContext 的 shader uniform（如 _MainTextureColor）可以接到
+ * operator chain（SampleGradient/SampleCurve/Math 等），每帧求值后写到 material。
+ * 转换器把这些 chain 序列化到 .lvfx 的 shaderPropertyExpressions，runtime 这里 evaluate。
+ *
+ * 不支持 per-particle attribute (AgeOverLifetime 等) — 用 GlobalTimeRatio 近似 (mod(time,1))。
+ */
+
+export interface ExprNode {
+    kind: string;          // Constant / VFXParameter / SampleGradient / VFXTotalTime / Add / ...
+    outputType: string;    // float / vec2 / vec3 / vec4 / Gradient / Curve / int / bool
+    value?: any;           // Constant / VFXParameter default
+    exposedName?: string;  // VFXParameter
+    defaultValue?: any;
+    inputs?: string[];     // 下游节点 id 列表
+}
+
+export interface ExprGraph {
+    rootNodeId: string;
+    outputType: string;
+    nodes: { [id: string]: ExprNode };
+}
+
+export interface GradientData {
+    colorKeys: Array<{ color: { r: number; g: number; b: number; a: number }; time: number }>;
+    alphaKeys: Array<{ alpha: number; time: number }>;
+    mode?: number;  // 0 = Blend, 1 = Fixed
+}
+
+export interface CurveData {
+    frames: Array<{ time: number; value: number; inTangent: number; outTangent: number }>;
+    preWrapMode?: number;
+    postWrapMode?: number;
+}
+
+export interface ExprEvalContext {
+    totalTime: number;
+    deltaTime: number;
+    /** runtime VFXParameter 实际值 map: exposedName → cached value (含 Prefab/Inspector override 后的 Gradient/Curve/Vector 等) */
+    propertyValues?: Map<string, { cached: any, value?: number[] }>;
+    /** 当前 effect 是否含 ConstantRate/PeriodicBurst/VariableRate 持续 spawn (区别于纯 SingleBurst).
+     *  决定 GlobalTimeRatio 行为: SingleBurst-only 用 cap min(t,1) 跟首批粒子 age 偶然同步,
+     *  持续 spawn 用 mod 1 让 cycle 持续 (避免 t>1 后 Disappear=1 让所有粒子永远不可见). */
+    hasContinuousSpawn?: boolean;
+}
+
+export class ShaderExpressionEvaluator {
+    /** evaluate 单个 expression graph，返回 root 节点的求值结果 */
+    static evaluate(graph: ExprGraph, ctx: ExprEvalContext): any {
+        if (!graph || !graph.nodes || !graph.rootNodeId) return null;
+        const cache: { [id: string]: any } = {};
+        return this._evalNode(graph.rootNodeId, graph.nodes, cache, ctx);
+    }
+
+    private static _evalNode(id: string, nodes: { [id: string]: ExprNode }, cache: any, ctx: any): any {
+        if (cache[id] !== undefined) return cache[id];
+        const n = nodes[id];
+        if (!n) return null;
+        let result: any = null;
+        switch (n.kind) {
+            case "Constant":
+                result = n.value;
+                break;
+            case "VFXParameter": {
+                // 优先从 runtime _propertyValues 取（含 Prefab/Inspector override 的最终值）
+                // 关键: 拿不到 override 时 return undefined → caller (caller 在 outer eval / setUniform 调用方) 跳过
+                // setUniform 让 ShaderGraph 编译期 default 生效 (e.g. 金色 SecondaryGradient).
+                // 之前 fallback 到 n.defaultValue (.vfx VFXParameter 端的内置 default 通常是灰白占位) →
+                // 覆盖 ShaderGraph default 让 UNI VFX1 wisps 颜色丢失 (原本金色变灰白).
+                const pv: any = ctx.propertyValues && n.exposedName ? ctx.propertyValues.get(n.exposedName) : null;
+                if (pv) {
+                    if (pv.rawGradientStops && pv.rawGradientStops.length > 0) {
+                        result = { __layaGradientStops: pv.rawGradientStops };
+                    } else if (pv.rawCurveFrames && pv.rawCurveFrames.length > 0) {
+                        result = { __layaCurveFrames: pv.rawCurveFrames };
+                    } else if (pv.value && pv.value.length > 0) {
+                        const v = pv.value;
+                        result = pv.value.length === 1 ? Number(v[0]) || 0 : { r: v[0] ?? 0, g: v[1] ?? 0, b: v[2] ?? 0, a: v[3] ?? 0 };
+                    } else if (pv.cached != null) {
+                        result = pv.cached;
+                    } else {
+                        result = undefined;   // 没真值 — 让上游 SampleGradient/CombineVec 等返回 undefined → 整个 expression 跳过
+                    }
+                } else {
+                    result = undefined;   // 同上
+                }
+                break;
+            }
+            case "VFXTotalTime":
+            case "VFXTime":
+                result = ctx.totalTime;
+                break;
+            case "VFXDeltaTime":
+                result = ctx.deltaTime;
+                break;
+            case "VFXFrameIndex":
+                result = Math.floor(ctx.totalTime * 60);   // assume 60fps frame index
+                break;
+            case "GlobalTimeRatio":
+                // AgeOverLifetime 的近似 — material uniform 不能 per-particle，用 system 全局时间
+                // 行为依赖 spawner 类型 (ctx.hasContinuousSpawn 由 VisualEffect 注入):
+                //   SingleBurst-only: cap min(totalTime, 1) — 跟 per-particle ageOverLifetime 偶然吻合 (system 跟首批粒子同步)
+                //     避免 lifetime>1s 的 sample (UNI VFX2 1.4s) 让 curve fade 循环 ("ring 2 圈")
+                //   ConstantRate/PeriodicBurst: mod(totalTime, 1) — 让 cycle 持续循环
+                //     避免 cap 后 totalTime>1 让 Disappear=curve(1)=1 让所有粒子永远不可见 (UNI VFX6 不显示)
+                result = ctx.hasContinuousSpawn
+                    ? (ctx.totalTime - Math.floor(ctx.totalTime))
+                    : Math.min(ctx.totalTime, 1);
+                break;
+            case "Random": {
+                // Unity 端 Random(min, max, seed) 是 per-particle random, Laya material uniform 是 per-system 一份不能 per-particle.
+                // 之前写死 result=0.5 完全 ignore inputs 让 _MaskFlipbookIndex Random(0,3) 永远 0.5 而不是 0~3 范围
+                // 改成读 min/max input + 用 totalTime+seed-based deterministic random 让每帧动画 (frame 切换 mask flipbook)
+                const min = Number(this._evalNode(n.inputs![0], nodes, cache, ctx)) || 0;
+                const max = Number(this._evalNode(n.inputs![1], nodes, cache, ctx)) || 1;
+                const seed = n.inputs!.length > 2 ? Number(this._evalNode(n.inputs![2], nodes, cache, ctx)) || 0 : 0;
+                // 用 totalTime + seed 做伪随机 (deterministic per-frame, 让 mask flipbook frame 切换)
+                const t = ctx.totalTime + seed * 13.7;
+                const r = Math.abs(Math.sin(t * 12.9898) * 43758.5453) % 1;
+                result = min + (max - min) * r;
+                break;
+            }
+            case "SampleGradient": {
+                const grad = this._evalNode(n.inputs![0], nodes, cache, ctx) as GradientData;
+                const t = Number(this._evalNode(n.inputs![1], nodes, cache, ctx)) || 0;
+                result = this._sampleGradient(grad, t);
+                break;
+            }
+            case "SampleCurve": {
+                const curve = this._evalNode(n.inputs![0], nodes, cache, ctx) as CurveData;
+                const t = Number(this._evalNode(n.inputs![1], nodes, cache, ctx)) || 0;
+                result = this._sampleCurve(curve, t);
+                break;
+            }
+            case "Add":
+            case "Sub":
+            case "Mul":
+            case "Div":
+            case "Mod": {
+                const a = this._evalNode(n.inputs![0], nodes, cache, ctx);
+                const b = this._evalNode(n.inputs![1], nodes, cache, ctx);
+                result = this._binOp(n.kind, a, b);
+                break;
+            }
+            case "Lerp": {
+                const x = this._evalNode(n.inputs![0], nodes, cache, ctx);
+                const y = this._evalNode(n.inputs![1], nodes, cache, ctx);
+                const s = Number(this._evalNode(n.inputs![2], nodes, cache, ctx)) || 0;
+                result = this._lerp(x, y, s);
+                break;
+            }
+            case "Sin": result = Math.sin(Number(this._evalNode(n.inputs![0], nodes, cache, ctx)) || 0); break;
+            case "Cos": result = Math.cos(Number(this._evalNode(n.inputs![0], nodes, cache, ctx)) || 0); break;
+            case "Frac": {
+                const x = Number(this._evalNode(n.inputs![0], nodes, cache, ctx)) || 0;
+                result = x - Math.floor(x);
+                break;
+            }
+            case "Abs": result = Math.abs(Number(this._evalNode(n.inputs![0], nodes, cache, ctx)) || 0); break;
+            case "Neg": result = -(Number(this._evalNode(n.inputs![0], nodes, cache, ctx)) || 0); break;
+            case "Saturate": {
+                const x = Number(this._evalNode(n.inputs![0], nodes, cache, ctx)) || 0;
+                result = Math.max(0, Math.min(1, x));
+                break;
+            }
+            // 子分量 combine: 转换器 walkSlotTree 检测 vec2/3/4 master slot 的子 slot link 时 emit
+            // (e.g. _MainTextureOffset.y 接 Random output → CombineVec2(0, Random))
+            case "CombineVec2": {
+                const x = Number(this._evalNode(n.inputs![0], nodes, cache, ctx)) || 0;
+                const y = Number(this._evalNode(n.inputs![1], nodes, cache, ctx)) || 0;
+                result = { x, y };
+                break;
+            }
+            case "CombineVec3": {
+                const x = Number(this._evalNode(n.inputs![0], nodes, cache, ctx)) || 0;
+                const y = Number(this._evalNode(n.inputs![1], nodes, cache, ctx)) || 0;
+                const z = Number(this._evalNode(n.inputs![2], nodes, cache, ctx)) || 0;
+                result = { x, y, z };
+                break;
+            }
+            case "CombineVec4": {
+                const x = Number(this._evalNode(n.inputs![0], nodes, cache, ctx)) || 0;
+                const y = Number(this._evalNode(n.inputs![1], nodes, cache, ctx)) || 0;
+                const z = Number(this._evalNode(n.inputs![2], nodes, cache, ctx)) || 0;
+                const w = Number(this._evalNode(n.inputs![3], nodes, cache, ctx)) || 0;
+                result = { x, y, z, w };
+                break;
+            }
+            default:
+                result = null;
+        }
+        cache[id] = result;
+        return result;
+    }
+
+    /** Gradient sample lerp — 支持两种格式：
+     *  Unity {colorKeys:[{color,time}], alphaKeys:[{alpha,time}]}
+     *  Laya  {__layaGradientStops:[{time,r,g,b,a}]} (color+alpha 同 stop)
+     */
+    private static _sampleGradient(g: any, t: number): { r: number; g: number; b: number; a: number } | null {
+        // grad 未提供 (VFXParameter 无 propertyValues override) → return null 让 caller skip setUniform
+        // 让 ShaderGraph 编译期 default 生效 (e.g. UNI VFX1 金色 SecondaryGradient)
+        if (!g) return null as any;
+        const clamp = Math.max(0, Math.min(1, t));
+        // Laya VFXGradientStop 格式：[{t, color:[r,g,b,a]}]
+        if (g.__layaGradientStops && Array.isArray(g.__layaGradientStops) && g.__layaGradientStops.length > 0) {
+            const stops = g.__layaGradientStops;
+            let s0 = stops[0], s1 = stops[stops.length - 1];
+            for (let i = 0; i < stops.length - 1; i++) {
+                if (clamp >= stops[i].t && clamp <= stops[i + 1].t) {
+                    s0 = stops[i]; s1 = stops[i + 1]; break;
+                }
+            }
+            const denom = (s1.t - s0.t) || 1;
+            const u = Math.max(0, Math.min(1, (clamp - s0.t) / denom));
+            const c0 = s0.color || [1, 1, 1, 1];
+            const c1 = s1.color || [1, 1, 1, 1];
+            return {
+                r: c0[0] + (c1[0] - c0[0]) * u,
+                g: c0[1] + (c1[1] - c0[1]) * u,
+                b: c0[2] + (c1[2] - c0[2]) * u,
+                a: c0[3] + (c1[3] - c0[3]) * u,
+            };
+        }
+        // Unity 格式
+        if (!g.colorKeys || g.colorKeys.length === 0) return { r: 1, g: 1, b: 1, a: 1 };
+        const keys = g.colorKeys;
+        const aKeys = g.alphaKeys || [{ alpha: 1, time: 0 }];
+        const mode = g.mode || 0;
+        let c0 = keys[0], c1 = keys[keys.length - 1];
+        for (let i = 0; i < keys.length - 1; i++) {
+            if (clamp >= keys[i].time && clamp <= keys[i + 1].time) {
+                c0 = keys[i]; c1 = keys[i + 1]; break;
+            }
+        }
+        const denom = (c1.time - c0.time) || 1;
+        const u = mode === 1 ? 0 : Math.max(0, Math.min(1, (clamp - c0.time) / denom));
+        const r = c0.color.r + (c1.color.r - c0.color.r) * u;
+        const g_ = c0.color.g + (c1.color.g - c0.color.g) * u;
+        const b = c0.color.b + (c1.color.b - c0.color.b) * u;
+        let a0 = aKeys[0], a1 = aKeys[aKeys.length - 1];
+        for (let i = 0; i < aKeys.length - 1; i++) {
+            if (clamp >= aKeys[i].time && clamp <= aKeys[i + 1].time) {
+                a0 = aKeys[i]; a1 = aKeys[i + 1]; break;
+            }
+        }
+        const aDenom = (a1.time - a0.time) || 1;
+        const au = mode === 1 ? 0 : Math.max(0, Math.min(1, (clamp - a0.time) / aDenom));
+        const a = a0.alpha + (a1.alpha - a0.alpha) * au;
+        return { r, g: g_, b, a };
+    }
+
+    /** Unity AnimationCurve sample — 简化 linear lerp（不算 Hermite tangent，足够多数 material uniform 用例） */
+    private static _sampleCurve(c: CurveData, t: number): number {
+        // curve 未提供 → return null 让 caller skip setUniform 让 ShaderGraph default 生效
+        if (!c) return null as any;
+        if (!c.frames || c.frames.length === 0) return 0;
+        if (c.frames.length === 1) return c.frames[0].value;
+        const clamp = Math.max(c.frames[0].time, Math.min(c.frames[c.frames.length - 1].time, t));
+        let f0 = c.frames[0], f1 = c.frames[c.frames.length - 1];
+        for (let i = 0; i < c.frames.length - 1; i++) {
+            if (clamp >= c.frames[i].time && clamp <= c.frames[i + 1].time) {
+                f0 = c.frames[i]; f1 = c.frames[i + 1]; break;
+            }
+        }
+        const denom = (f1.time - f0.time) || 1;
+        const u = (clamp - f0.time) / denom;
+        return f0.value + (f1.value - f0.value) * u;
+    }
+
+    private static _binOp(kind: string, a: any, b: any): any {
+        const isVec = (v: any) => v && typeof v === "object" && ("r" in v || "x" in v);
+        if (isVec(a) || isVec(b)) {
+            // vec op vec / vec op float 都 broadcast
+            const getC = (v: any, k: string) => {
+                if (typeof v === "number") return v;
+                if (k === "r" || k === "x") return v.r !== undefined ? v.r : v.x;
+                if (k === "g" || k === "y") return v.g !== undefined ? v.g : v.y;
+                if (k === "b" || k === "z") return v.b !== undefined ? v.b : v.z;
+                if (k === "a" || k === "w") return v.a !== undefined ? v.a : v.w;
+                return 0;
+            };
+            const op = (x: number, y: number) => kind === "Add" ? x + y : kind === "Sub" ? x - y : kind === "Mul" ? x * y : kind === "Div" ? (y !== 0 ? x / y : 0) : kind === "Mod" ? x - y * Math.floor(x / (y || 1)) : 0;
+            return {
+                r: op(getC(a, "r"), getC(b, "r")),
+                g: op(getC(a, "g"), getC(b, "g")),
+                b: op(getC(a, "b"), getC(b, "b")),
+                a: op(getC(a, "a"), getC(b, "a")),
+            };
+        }
+        const x = Number(a) || 0, y = Number(b) || 0;
+        switch (kind) {
+            case "Add": return x + y;
+            case "Sub": return x - y;
+            case "Mul": return x * y;
+            case "Div": return y !== 0 ? x / y : 0;
+            case "Mod": return x - y * Math.floor(x / (y || 1));
+        }
+        return 0;
+    }
+
+    private static _lerp(x: any, y: any, s: number): any {
+        const isVec = (v: any) => v && typeof v === "object";
+        if (isVec(x)) {
+            return {
+                r: (x.r ?? x.x ?? 0) * (1 - s) + (y.r ?? y.x ?? 0) * s,
+                g: (x.g ?? x.y ?? 0) * (1 - s) + (y.g ?? y.y ?? 0) * s,
+                b: (x.b ?? x.z ?? 0) * (1 - s) + (y.b ?? y.z ?? 0) * s,
+                a: (x.a ?? x.w ?? 0) * (1 - s) + (y.a ?? y.w ?? 0) * s,
+            };
+        }
+        return (Number(x) || 0) * (1 - s) + (Number(y) || 0) * s;
+    }
+
+    /** 把求值结果转 Vector4（用于 setVector 到 ShaderData） */
+    static toVector4(v: any, out?: Vector4): Vector4 {
+        if (!out) out = new Vector4();
+        if (typeof v === "number") {
+            out.setValue(v, v, v, v);
+        } else if (v && typeof v === "object") {
+            out.setValue(
+                v.r !== undefined ? v.r : (v.x !== undefined ? v.x : 0),
+                v.g !== undefined ? v.g : (v.y !== undefined ? v.y : 0),
+                v.b !== undefined ? v.b : (v.z !== undefined ? v.z : 0),
+                v.a !== undefined ? v.a : (v.w !== undefined ? v.w : 0),
+            );
+        }
+        return out;
+    }
+}

--- a/src/layaAir/laya/vfx/VFXAsset.ts
+++ b/src/layaAir/laya/vfx/VFXAsset.ts
@@ -294,6 +294,8 @@ export enum VFXPropertyType {
     Vec4 = "vec4",
     Color = "color",
     Gradient = "gradient",
+    Texture2D = "texture2D",
+    Curve = "curve",
 }
 
 export interface VFXGradientStop {
@@ -305,8 +307,14 @@ export class VFXPropertyDesc {
     name: string;           // 面向用户的属性名
     uniform: string;        // shader uniform 名
     type: VFXPropertyType;
-    default: number[];      // 标量 / 向量默认值（非 Gradient 用）
+    default: number[] | string[];      // 标量/向量数字数组 (Float/Vec2/3/4/Color) 或资源 res:// 字符串数组 (Texture2D)
     gradientStops?: VFXGradientStop[];  // Gradient 类型：关键帧列表
+    /** Texture2D 类型异步加载后存放的纹理实例 */
+    texture?: any;
+    /** 分组名，用于 Inspector 把同组属性折叠在一起展示；空/未设视为 "Default" 组 */
+    group?: string;
+    /** Inspector 显示的友好名称；未设回退到 name */
+    displayName?: string;
 }
 
 export class VFXCurveUniformDesc {

--- a/src/layaAir/laya/vfx/VFXAssetParser.ts
+++ b/src/layaAir/laya/vfx/VFXAssetParser.ts
@@ -192,6 +192,36 @@ export class VFXAssetParser {
                             )
                         );
                     }
+                    // ShaderGraph property binding (VFX exposed prop name → shader uniform name) — runtime setTexture 时按 binding 把 exposed name 转 shader uniform name
+                    if (sys.shaderPropertyBindings && typeof sys.shaderPropertyBindings === "object") {
+                        (desc as any).shaderPropertyBindings = sys.shaderPropertyBindings;
+                    }
+                    // ShaderGraph property inline defaults (shader uniform name → res://uuid) — wall mesh 等 outputCtx 给 shader 属性写的 inline 资源 default
+                    // .bps 编译时丢了这种 inline default，runtime 必须显式 setTexture 让 wall mesh 等用 uni_ring_warped 而非 .bps 内 white texture
+                    if (sys.shaderPropertyDefaults && typeof sys.shaderPropertyDefaults === "object") {
+                        const entries: { [uniformName: string]: { url: string, texture: any } } = {};
+                        for (const uniformName in sys.shaderPropertyDefaults) {
+                            const url: string = sys.shaderPropertyDefaults[uniformName];
+                            if (typeof url !== "string" || !url) continue;
+                            const entry = { url, texture: null as any };
+                            entries[uniformName] = entry;
+                            loadPromises.push(
+                                (Laya.loader.load(url) as Promise<any>).then(
+                                    // Laya.loader.load 返回 Texture / Texture2D / BaseTexture, setTexture 期望 Laya Texture 不是 unwrap .bitmap (ImageBitmap).
+                                    // 之前 .bitmap unwrap 让 setTexture 拿 ImageBitmap 实例 binding fail, MaskTexture sample 拿 default white.
+                                    (tex: any) => { if (tex) entry.texture = tex; },
+                                    (err: any) => { console.warn(`[VFX] shaderPropertyDefault '${uniformName}' load failed: ${url}`, err); }
+                                )
+                            );
+                        }
+                        (desc as any).shaderPropertyDefaults = entries;
+                    }
+                    // ShaderGraph property expression chain（VFX operator chain → shader uniform 每帧求值）
+                    // 转换器把上游不是 VFXParameter 的 operator chain 序列化到 shaderPropertyExpressions，
+                    // 让 ShaderExpressionEvaluator 每帧 evaluate → setVector/setNumber 到 material
+                    if (sys.shaderPropertyExpressions && typeof sys.shaderPropertyExpressions === "object") {
+                        (desc as any).shaderPropertyExpressions = sys.shaderPropertyExpressions;
+                    }
 
                     // Strip 专属字段（对齐 Unity Output Trail）
                     if (typeof sys.colorMapping === "string") desc.stripColorMapping = sys.colorMapping;
@@ -306,6 +336,7 @@ export class VFXAssetParser {
                             case "Capsule":  return PrimitiveMesh.createCapsule(0.5, 2, 12, 12);
                             case "Plane":    return PrimitiveMesh.createPlane(10, 10, 1, 1);
                             case "Quad":     return PrimitiveMesh.createQuad(1, 1);
+                            case "Triangle": return PrimitiveMesh.createTriangle(1, 1);
                             default: return null;
                         }
                     };
@@ -541,6 +572,7 @@ export class VFXAssetParser {
                             case "Capsule":  return PrimitiveMesh.createCapsule(0.5, 2, 12, 12);
                             case "Plane":    return PrimitiveMesh.createPlane(10, 10, 1, 1);
                             case "Quad":     return PrimitiveMesh.createQuad(1, 1);
+                            case "Triangle": return PrimitiveMesh.createTriangle(1, 1);
                             default: return null;
                         }
                     };
@@ -619,6 +651,30 @@ export class VFXAssetParser {
                             ];
                         }
                         desc.default = [];
+                        break;
+                    }
+                    case VFXPropertyType.Texture2D: {
+                        // Texture2D property: d 是 string "res://uuid" 或 array ["res://uuid"] (转换器统一输出后者)
+                        // Unity VFX exposed prop 跟 ShaderGraph 内 shader uniform 是双命名空间，OutputContext 含 binding；
+                        // 这里只 load 资源存到 desc.texture，setTexture 绑定 shader uniform 在 VisualEffect.onStart 用 binding 名做
+                        let url: string | null = null;
+                        if (Array.isArray(d) && typeof d[0] === "string") url = d[0];
+                        else if (typeof d === "string") url = d;
+                        desc.default = url ? [url] : [];
+                        desc.texture = null;
+                        if (url) {
+                            const loadTex = Laya.loader.load(url).then((tex: any) => {
+                                if (tex) {
+                                    // loader 对 PNG 返回 Texture wrapper，取其 bitmap (Texture2D) 用来 bind shader sampler
+                                    desc.texture = tex.bitmap || tex._image || tex._source || tex;
+                                } else {
+                                    console.warn(`[VFX] Texture2D property '${prop.name}' load returned null: ${url}`);
+                                }
+                            }, (err: any) => {
+                                console.warn(`[VFX] Texture2D property '${prop.name}' load failed: ${url}`, err);
+                            });
+                            loadPromises.push(loadTex);
+                        }
                         break;
                     }
                 }
@@ -1160,6 +1216,7 @@ function normalizePropertyType(raw: string): VFXPropertyType {
     if (s === "vec4" || s === "vector4") return VFXPropertyType.Vec4;
     if (s === "color") return VFXPropertyType.Color;
     if (s === "gradient") return VFXPropertyType.Gradient;
+    if (s === "texture2d") return VFXPropertyType.Texture2D;
     return VFXPropertyType.Float;
 }
 

--- a/src/layaAir/laya/vfx/VFXRenderer.ts
+++ b/src/layaAir/laya/vfx/VFXRenderer.ts
@@ -1,3 +1,4 @@
+import { Loader } from "../net/Loader";
 import { VFXGeometry } from "./VFXGeometry";
 import { VFXStripGeometry } from "./VFXStripGeometry";
 import { VisualEffect } from "./VisualEffect";
@@ -229,6 +230,10 @@ export class VFXRenderer extends BaseRender {
             const colors: Color[] = [];
             mesh.getColors(colors);
             if (!colors.length) return;
+            // Laya Mesh.getColors 先扩 length=vertexCount 再 if(element) 填，mesh 缺 color
+            // 顶点元素时 colors.length>0 但 colors[i] 全 undefined，直接 .r 访问会崩。
+            // 检查首个元素确认真有 color 数据；UNI VFX 的 mesh 多数没 vertex color
+            if (colors[0] == null) return;
 
             // mesh 的 vertex 通常 split for UV/normal seams: 同物理位置不同 index 不互连
             // 直接 indices 算 adj 在 per-triangle independent vertices mesh 上 smooth 永不 propagate.
@@ -350,18 +355,21 @@ export class VFXRenderer extends BaseRender {
         VFXRenderer._patchedTextureUrls.add(url);
         console.log("[VFX alpha] start url=", url);
         try {
-            const realUrl = (Laya as any).URL?.formatURL ? (Laya as any).URL.formatURL(url) : url;
-            console.log("[VFX alpha] realUrl=", realUrl);
-            const resp = await fetch(realUrl);
-            console.log("[VFX alpha] fetch ok=", resp.ok, "type=", resp.headers.get("content-type"));
-            if (!resp.ok) return;
-            const blob = await resp.blob();
+            // 不能直接 fetch(res://...)，浏览器不认 res: scheme。
+            // 改走 Laya.loader.load(url, BUFFER) 拿 ArrayBuffer：
+            //   - Loader 内部把 res:// 解析成实际 IDE preview server URL (http://localhost:xxx/library/...)
+            //   - 同一 url 加载有 cache，不会触发二次实际下载
+            const buffer = await Laya.loader.load(url, Loader.BUFFER);
+            if (!buffer || !(buffer instanceof ArrayBuffer)) {
+                console.warn("[VFX alpha] loader returned non-ArrayBuffer:", typeof buffer);
+                return;
+            }
             // 只处理 PNG (其它格式如 KTX/DDS 通常带正确 alpha)
-            console.log("[VFX alpha] blob.type=", blob.type, "blob.size=", blob.size);
-            if (!blob.type.includes("png") && !url.toLowerCase().endsWith(".png") && !blob.type.includes("image")) {
+            if (!url.toLowerCase().endsWith(".png")) {
                 console.log("[VFX alpha] skip - not png");
                 return;
             }
+            const blob = new Blob([buffer], { type: "image/png" });
             const imgBitmap = await createImageBitmap(blob);
             const canvas = document.createElement("canvas");
             canvas.width = imgBitmap.width;

--- a/src/layaAir/laya/vfx/VisualEffect.ts
+++ b/src/layaAir/laya/vfx/VisualEffect.ts
@@ -9,10 +9,11 @@ import { VFXAsset, VFXUpdateMode, VFXSystemType, VFXSpawnerSystemDesc, VFXPartic
 import { VFXEventAttribute } from "./VFXEventAttribute";
 import { bakeSkinnedMeshVertexTexture, bakeSkinnedMeshBonesTexture } from "./VFXAssetParser";
 import { VFXFrameTime } from "./VFXFrameTime";
+import { ShaderExpressionEvaluator, ExprGraph } from "./ShaderExpressionEvaluator";
+import { VFXRenderer } from "./VFXRenderer";
 import { VFXGeometry, VFXGeometryParams } from "./VFXGeometry";
 import { VFXBillboardGeometry, VFXBillboardGeometryParams } from "./VFXBillboardGeometry";
 import { VFXStripGeometry, VFXStripGeometryParams } from "./VFXStripGeometry";
-import { VFXRenderer } from "./VFXRenderer";
 import { VFXState } from "./VFXState";
 import { Script } from "../components/Script";
 import { Camera } from "../d3/core/Camera";
@@ -74,6 +75,16 @@ export class VisualEffect extends Script {
     }
 
     randomSeed: number = 0;
+
+    /**
+     * @en Property override values from Inspector. Stored as JSON string (LayaPro 序列化层不识别 plain object dynamic key map，必须 string 序列化).
+     *     Decoded shape: { [name: string]: number[] } per type Float [v] / Vec2 [x,y] / Vec3 [x,y,z] / Vec4 / Color [x,y,z,w].
+     *     Gradient override not supported in MVP. Applied after initAssetData when _propertyValues is ready.
+     * @zh Inspector 设置的 property override 值，存为 JSON string（LayaPro 序列化层 type=object 不识别会 fallback null，必须用 string 类型字段）。
+     *     解码后 shape：{ name: number[] }，对应 Float/Vec2/Vec3/Vec4/Color 类型。
+     *     Gradient override 暂不支持。在 initAssetData 完成后由 _applyPropertyOverrides 解码应用。
+     */
+    propertyOverrides: string = "{}";
 
     private currentSeed: number = 0;
 
@@ -326,6 +337,12 @@ export class VisualEffect extends Script {
                     particleSystem.mainTexture = (particleDesc as any).mainTexture || "";
                     particleSystem.subpixelAA = particleDesc.subpixelAA;
                     particleSystem.customShaderName = particleDesc.customShaderName;
+                    // ShaderGraph property binding/defaults — VFX exposed name → shader uniform name 映射 + shader uniform inline default texture
+                    // instance 不含 .desc 字段，必须显式 copy 让 onStart 时能拿到（同 customShaderName 这种 pattern）
+                    (particleSystem as any).shaderPropertyBindings = (particleDesc as any).shaderPropertyBindings || null;
+                    (particleSystem as any).shaderPropertyDefaults = (particleDesc as any).shaderPropertyDefaults || null;
+                    // ShaderGraph property expression chains（每帧 evaluate 写 shader uniform，参 ShaderExpressionEvaluator）
+                    (particleSystem as any).shaderPropertyExpressions = (particleDesc as any).shaderPropertyExpressions || null;
                     // Billboard procedural 配置（对齐 Unity VFXPlanarPrimitiveOutput）
                     particleSystem.billboardPrimitive = particleDesc.billboardPrimitive;
                     particleSystem.billboardVertexCount = particleDesc.billboardVertexCount;
@@ -438,13 +455,15 @@ export class VisualEffect extends Script {
         this.globalEventAttribute = this.createEmptyEventAttribute();
         this.globalEventAttribute.setFloat("spawnCount", 1);
         this.globalEventAttribute.setVector4("color", 1, 1, 1, 1);
-        this.globalEventAttribute.setVector3("velocity", 1.5, 0, 0);
+        // velocity 默认 (0,0,0): 事件触发没显式 attribute 时粒子初始速度为零, 由 init blocks 显式 setAttribute 覆盖.
+        // 之前 (1.5, 0, 0) 像测试残留, 让没初始化 velocity 的 sample 粒子默认朝 +X 飞.
+        this.globalEventAttribute.setVector3("velocity", 0, 0, 0);
 
         // 初始化 property 默认值并创建缓存对象
         this._propertyValues.clear();
         for (const prop of this.asset.properties) {
             const id = Shader3D.propertyNameToID(prop.uniform);
-            const v = prop.default;
+            const v = prop.default as any;
             let cached: any = null;
             switch (prop.type) {
                 case VFXPropertyType.Vec2:
@@ -463,27 +482,105 @@ export class VisualEffect extends Script {
                     // 烘焙 256×1 Texture2D；sampleGradient 走 textureLod(uniform, vec2(t, 0.5), 0)
                     cached = bakeGradientTexture(prop.gradientStops || []);
                     break;
+                case VFXPropertyType.Texture2D:
+                    // 已在 VFXAssetParser 异步加载到 desc.texture（await loadPromises 完才进 onStart）
+                    cached = (prop as any).texture;
+                    break;
             }
             this._propertyValues.set(prop.name, {
                 id,
                 type: prop.type,
-                value: [...v],
-                cached
-            });
-            // Gradient 属性直接绑到所有粒子系统的 shaderData（texture uniform）
-            if (prop.type === VFXPropertyType.Gradient && cached) {
+                value: Array.isArray(v) ? [...v] : [],
+                cached,
+                // raw 字段：Gradient 的 baked Texture 不可 CPU sample，evaluator 用这里的 stops/curve 数据
+                // gradientStops 格式：[{ time, r, g, b, a }]（已 normalize 到 0-1 time）
+                // 期望：随后 _applyPropertyOverrides / setPropertyXxx 时若 override 也更新这里
+                rawGradientStops: prop.type === VFXPropertyType.Gradient ? (prop.gradientStops || []) : undefined,
+                rawCurveFrames: prop.type === VFXPropertyType.Curve ? ((prop as any).curveFrames || []) : undefined,
+            } as any);
+            // Gradient / Texture2D 属性直接绑到所有粒子系统的 shaderData（texture uniform）
+            // Texture2D: VFX exposed name 跟 ShaderGraph 内 shader uniform name 常不一致 (e.g. RingMaskTexture → _MaskTexture)，
+            // 每个 system 实例的 shaderPropertyBindings 含正向 binding，按 binding 拿 shader uniform name 再 setTexture
+            if ((prop.type === VFXPropertyType.Gradient || prop.type === VFXPropertyType.Texture2D) && cached) {
                 for (const sys of this.systems) {
                     if (sys instanceof VFXParticleSystem) {
+                        const bindings = (sys as any).shaderPropertyBindings;
+                        const shaderUniformName = bindings ? bindings[prop.name] : null;
+                        const aliasIds = shaderUniformName
+                            ? [id, Shader3D.propertyNameToID(shaderUniformName)]
+                            : [id];
                         for (const sd of sys.getAllShaderDatas()) {
-                            sd.setTexture(id, cached);
+                            for (const aid of aliasIds) sd.setTexture(aid, cached);
                         }
                     }
                 }
             }
         }
 
+        // ── apply shaderPropertyDefaults per system ──
+        // wall mesh 等 outputShaderGraph ctx 的 inline default texture (e.g. _MaskTexture=uni_ring_warped)
+        // .bps 编译时丢了，runtime 必须显式 setTexture 让 wall mesh 用 uni_ring_warped 而非 .bps 内 white
+        // ⚠ 必须 include material shaderData (fragment shader sample 用) — getAllShaderDatas() 只返回 compute shader ShaderDatas
+        // 不含 material.shaderData，导致 mask 纹理只 set 到 compute shader uniform 不影响 fragment sample → mask 不生效
+        for (const sys of this.systems) {
+            if (!(sys instanceof VFXParticleSystem)) continue;
+            const defaults = (sys as any).shaderPropertyDefaults;
+            if (!defaults) continue;
+            const allDatas = sys.getAllShaderDatas().slice();
+            const customShaderName = (sys as any).customShaderName as string;
+            const blendMode = (sys as any).blendMode as string || "Alpha";
+            if (customShaderName) {
+                const mat = VFXRenderer.getCustomShaderMaterial(customShaderName, blendMode);
+                if (mat && mat.shaderData && allDatas.indexOf(mat.shaderData) === -1) allDatas.push(mat.shaderData);
+            }
+            for (const uniformName in defaults) {
+                const entry = defaults[uniformName];
+                if (!entry || !entry.texture) continue;
+                // Unity 端 shader uniform 用 _MainTexture 带下划线, 但 Laya .bps 编译后 uniform name 不带下划线 (MainTexture).
+                // 同时 set 带 / 不带 _ 两个 ID, 让两种命名都能命中真实 shader uniform.
+                const ids = [Shader3D.propertyNameToID(uniformName)];
+                if (uniformName.startsWith("_")) ids.push(Shader3D.propertyNameToID(uniformName.substring(1)));
+                for (const sd of allDatas) {
+                    for (const aid of ids) sd.setTexture(aid, entry.texture);
+                }
+            }
+        }
+
         // 将 curveUniforms 和 bakedTexture 设置到所有粒子系统的 shaderData
         this.applyCurveUniforms();
+
+        // 应用 Inspector 序列化的 property override
+        this._applyPropertyOverrides();
+    }
+
+    /**
+     * 应用 Inspector 序列化的 property override 值（在 initAssetData 完成、_propertyValues 准备好后调用）
+     * propertyOverrides 字段是 JSON string，需要先 parse 成 object 再遍历应用。
+     * @internal
+     */
+    private _applyPropertyOverrides(): void {
+        if (!this.propertyOverrides) return;
+        let overrides: { [name: string]: number[] };
+        try {
+            // 兼容老版本场景里 propertyOverrides 可能是 object 不是 string
+            overrides = typeof this.propertyOverrides === "string"
+                ? JSON.parse(this.propertyOverrides)
+                : (this.propertyOverrides as any);
+        } catch (e) {
+            console.warn("[VFX] failed to parse propertyOverrides JSON:", e);
+            return;
+        }
+        if (!overrides || typeof overrides !== "object") return;
+        for (const name in overrides) {
+            const value = overrides[name];
+            if (!Array.isArray(value)) continue;
+            switch (value.length) {
+                case 1: this.setPropertyFloat(name, value[0]); break;
+                case 2: this.setPropertyVec2(name, value[0], value[1]); break;
+                case 3: this.setPropertyVec3(name, value[0], value[1], value[2]); break;
+                case 4: this.setPropertyVec4(name, value[0], value[1], value[2], value[3]); break;
+            }
+        }
     }
 
     private releaseAssetData(): void {
@@ -823,6 +920,72 @@ export class VisualEffect extends Script {
     updateVFX() {
         this.simulateVFX();
         // this.outputVFX();
+        this._evaluateShaderExpressions();   // 每帧 evaluate shader uniform expression chain → setVector
+    }
+
+    /**
+     * 每帧执行：evaluate shader property expression chains，写到 material shaderData
+     * VFX operator chain（SampleGradient/SampleCurve/Math 等）连到 shader uniform 的真正实施
+     * 参 ShaderExpressionEvaluator
+     */
+    private _tmpExprVec4 = new Vector4();
+    /**
+     * 每帧 evaluate VFX OutputContext 的 shader uniform expression chains（如 SampleGradient(time)）
+     * → setVector/setNumber 到 cache material 的 shaderData
+     * 转换器把 operator chain 序列化到 sys.shaderPropertyExpressions
+     * 参 ShaderExpressionEvaluator
+     */
+    private _evaluateShaderExpressions(): void {
+        const totalTime = this.state.totalTime;
+        const deltaTime = this.frameTime.deltaTime;
+        const propertyValues = this._propertyValues;
+        // 检测当前 effect 是否含 ConstantRate/PeriodicBurst 持续 spawn (区别于纯 SingleBurst)
+        // 决定 GlobalTimeRatio 行为：
+        //   SingleBurst-only: cap(totalTime, 1) — 跟 per-particle ageOverLifetime 近似 (system 时间 ~= 粒子 age)
+        //   持续 spawn: mod(totalTime, 1) — 让 fade cycle 持续循环 (避免 t>1 后 Disappear=1 让所有粒子永远不可见)
+        let hasContinuousSpawn = false;
+        for (const sys of this.systems) {
+            if (!(sys instanceof VFXSpawnerSystem)) continue;
+            for (const task of sys.tasks) {
+                const cn = (task as any).constructor?.name || "";
+                if (cn === "VFXSpawnerConstantRate" || cn === "VFXSpawnerPeriodicBurst" || cn === "VFXSpawnerVariableRate") {
+                    hasContinuousSpawn = true; break;
+                }
+            }
+            if (hasContinuousSpawn) break;
+        }
+        for (const sys of this.systems) {
+            if (!(sys instanceof VFXParticleSystem)) continue;
+            const expressions = (sys as any).shaderPropertyExpressions as { [uniformName: string]: ExprGraph } | null;
+            if (!expressions) continue;
+            // VFX render 用 VFXRenderer._customShaderMaterialCache 缓存的 mat（按 shaderName + blendMode key），
+            // 跟 outputDatas[0]（compute shader 用的）是两份独立 ShaderData。
+            // evaluator 必须写到 mat.shaderData 而不是 outputDatas — 否则 fragment 拿不到 uniform 值。
+            const allDatas = sys.getAllShaderDatas().slice();
+            const customShaderName = (sys as any).customShaderName as string;
+            const blendMode = (sys as any).blendMode as string || "Alpha";
+            if (customShaderName) {
+                const mat = VFXRenderer.getCustomShaderMaterial(customShaderName, blendMode);
+                if (mat && mat.shaderData && allDatas.indexOf(mat.shaderData) === -1) allDatas.push(mat.shaderData);
+            }
+            for (const uniformName in expressions) {
+                const graph = expressions[uniformName];
+                const result = ShaderExpressionEvaluator.evaluate(graph, { totalTime, deltaTime, propertyValues, hasContinuousSpawn });
+                if (result == null) continue;
+                // alias IDs：VFX 端 uniform name (_MainTextureColor) 跟 shader 端实际 uniform name 可能去掉 _ 前缀 (MainTextureColor)
+                // 同时 set 两个 ID 让 shader 不管哪个名字都能拿到
+                const ids = [Shader3D.propertyNameToID(uniformName)];
+                if (uniformName.startsWith("_")) ids.push(Shader3D.propertyNameToID(uniformName.substring(1)));
+                if (graph.outputType === "float") {
+                    const v = Number(result) || 0;
+                    for (const sd of allDatas) for (const id of ids) sd.setNumber(id, v);
+                } else {
+                    // vec2/vec3/vec4 / Gradient sample 输出都按 Vector4 写（shader 端 vec3 取 .xyz）
+                    ShaderExpressionEvaluator.toVector4(result, this._tmpExprVec4);
+                    for (const sd of allDatas) for (const id of ids) sd.setVector(id, this._tmpExprVec4);
+                }
+            }
+        }
     }
 
     /**
@@ -968,6 +1131,9 @@ export class VisualEffect extends Script {
                 }
             }
         }
+
+        // 每帧 evaluate shader expression chains（VFX operator chain → shader uniform）
+        this._evaluateShaderExpressions();
     }
 
     /** Output Event 派发入口 — 由各系统 readback 完成后调用 */

--- a/src/layaAir/laya/vfx/shader/BlueprintPixelVertexVFX.glsl
+++ b/src/layaAir/laya/vfx/shader/BlueprintPixelVertexVFX.glsl
@@ -31,6 +31,18 @@
     //   不加 #ifdef 包裹时函数定义体保留 attribute 引用，依赖编译器 DCE 行为不可靠。
     #ifdef VFX_INSTANCED
 
+// Per-particle data 通过 varying 传 fragment shader,
+// 让 ShaderGraph 内部用 uniform Float (如 MaskFlipbookIndex) 的 property 能改成 per-particle value.
+// ShaderBuild post-process 把 FS 内 uniform name `MaskFlipbookIndex` 等替换成 `v_TexIndex`.
+// 转换器 init context 加 setAttribute(texIndex, Random(0, range)) 让 GPU 每粒子写 unique value 到 a_AttrScale.w.
+varying float v_TexIndex;
+
+// per-particle ageOverLifetime: 让 SG Disappear/Lifetime/Age 等 uniform 走 per-particle 路径
+// (ShaderBuild 把 FS 内 `Disappear` 等 uniform 替换成 v_NormalizedAge varying)
+// 直接 0→1 linear 跟随粒子 age, 不是 sampleCurve V 形 (粒子生 visible/老化 fade-out, 没 fade-in 阶段)
+// 完整 curve sample 路径后续优化 (vertex 端 sample 256x1 curve texture)
+varying float v_NormalizedAge;
+
 struct VFXParticle {
     vec3 position;
     float normalizedAge;
@@ -68,6 +80,11 @@ VFXParticle vfxGetParticle()
 VFXParticle vfxTransformVertex(inout Vertex vertex)
 {
     VFXParticle p = vfxGetParticle();
+
+    // per-particle texIndex 通过 varying 传 fragment, 让 SG shader 内部 uniform 引用 (MaskFlipbookIndex 等) 被 ShaderBuild 替换成 per-particle 路径.
+    v_TexIndex = p.texIndex;
+    // per-particle normalizedAge: SG Disappear/Lifetime/Age 等 uniform 走 v_NormalizedAge per-particle 异步
+    v_NormalizedAge = p.normalizedAge;
 
     // 1. position
     vec3 vp = vertex.positionOS - p.pivot;

--- a/src/layaAir/laya/vfx/systems/VFXSpawnerTask.ts
+++ b/src/layaAir/laya/vfx/systems/VFXSpawnerTask.ts
@@ -92,8 +92,17 @@ export class VFXSpawnerSingleBurst extends VFXSpawnerTask {
         this.sampledCount = 0;
     }
 
-    internalInit(rand: Rand): void {
+    play(): void {
+        // VFX onPlay (stop → play / asset re-import) 应该让 SingleBurst 重新 fire 一次
+        // (跟 Unity 行为一致：每次 onPlay 视为一次新 VFX 生命周期)
         this.sleeping = false;
+    }
+
+    internalInit(rand: Rand): void {
+        // ⚠ 不要 reset sleeping — Unity SingleBurst 整个 VFX 生命周期只 fire 一次 (含 Infinite loop 模式).
+        // 之前每个 newLoop 重置 sleeping=false 让 durationMode=Infinite + SingleBurst 每个 loop 重新 fire
+        // → 看起来 "粒子播放 2 次" (实际是无限次重 fire). UNI VFX1/2/3 都受影响.
+        // 只在 VFX 完整重置 (init / play) 时才重置 sleeping.
         this.nextTriggerTime = sampleRange(this.delay, rand);
         this.sampledCount = Math.round(sampleRange(this.count, rand));
     }


### PR DESCRIPTION
﻿VFX: UNI VFX visual alignment (SG per-particle path + composite transform + SingleBurst sleeping + Triangle primitive)

UNI VFX (Unity 商业 asset) 接入 LayaAir 工程, VFX1-8 视觉对齐 Unity. 整合 3 个累积 commit (Triangle primitive + SingleBurst sleeping + SG per-particle path).

## SingleBurst sleeping (修 durationMode=Infinite 重 fire)
- VFXSpawnerTask.ts: VFXSpawnerSingleBurst.internalInit 不再重置 sleeping (Unity 行为整 VFX 生命周期 fire 一次)
- 加 play() reset sleeping for onPlay re-trigger
- 修 UNI VFX2 ring 看起来 "播 2 次" 根因

## ShaderExpressionEvaluator (composite type + adaptive GlobalTimeRatio)
- 加 CombineVec2/3/4 kind 支持 vec2/3/4 子分量合成 (转换器 walkSlotTree _MainTextureOffset.y 接 Random)
- VFXParameter 无 propertyValues override 时 return undefined (让 ShaderGraph 编译期 default 生效, 不被 .vfx VFXParameter trivial default 覆盖)
- _sampleGradient/_sampleCurve undefined 输入 -> null 让 caller skip setUniform
- GlobalTimeRatio 按 spawner 类型自适应: SingleBurst cap min(t,1) 避免 lifetime>1s curve fade 多次; ConstantRate/PeriodicBurst mod 1 避免 t>1 后 Disappear=1 永远不可见
- ExprEvalContext 加 hasContinuousSpawn 字段

## VisualEffect.ts
- _evaluateShaderExpressions 帧前扫 spawnerSystems 检测含 ConstantRate/PeriodicBurst/VariableRate 让 evaluator ctx 拿到 hasContinuousSpawn flag

## SG per-particle uniform path (varying)
- BlueprintPixelVertexVFX.glsl 加 varying float v_NormalizedAge + vfxTransformVertex 写 p.normalizedAge (跟 v_TexIndex 同 pattern)
- 让 SG shader 内部 uniform _Disappear 等走 per-particle 路径让每粒子异步 fade (跟 Unity ageOverLifetime 行为一致)

## shaderPropertyDefaults + Triangle primitive
- VFXRenderer setTexture include material shaderData (从 outputDatas 也加 mat.shaderData 让 fragment 拿到 mask texture)
- 加 Triangle primitive (UNI VFX1 wall plane wisps mesh 用)

## 视觉效果
- UNI VFX1 (Aura Yellow wisps): 5-arm star ring 视觉 ok
- UNI VFX2 (single ring): 单次播放 + 颜色 ok
- UNI VFX6 (60 particles wall ring): per-particle 异步 fade + ring 对称两段 ok

## 配套 PR
依赖 LayaPro 端 PR (feat/vfx-uni-alignment).
