### PR TITLE
feat: add Bilibili minigame platform adapter（新增B站小游戏平台适配器）

### DIFF
--- a/scripts/config.mjs
+++ b/scripts/config.mjs
@@ -477,6 +477,13 @@ export const allBundles = [{
     ],
 },
 {
+    name: 'adapter-bilibili',
+    input: [
+        'platforms/minigame/**/*.*',
+        'platforms/bilibili/**/*.*'
+    ],
+},
+{
     name: 'ik',
     input: [
         'laya/ik/**/*.ts'
@@ -494,4 +501,5 @@ export const allBundles = [{
         'laya/vfx/**/*.*'
     ]
 },
+
 ];

--- a/src/layaAir/platforms/bilibili/index.ts
+++ b/src/layaAir/platforms/bilibili/index.ts
@@ -1,0 +1,9 @@
+import { PAL } from "../../laya/platform/PlatformAdapters";
+import { Browser } from "../../laya/utils/Browser";
+import { MgBrowserAdapter } from "../minigame/MgBrowserAdapter";
+
+MgBrowserAdapter.beforeInit = function () {
+    Browser.onBLMiniGame = true;
+    Browser.isIOSHighPerformanceModePlus = GameGlobal.isIOSHighPerformanceModePlus;
+    PAL.g = (window as any).bl;
+};


### PR DESCRIPTION
## 改动说明（Summary）

新增 Bilibili 小游戏平台适配，与现有 weixin/alipay 等平台适配器保持一致的结构。

- `src/layaAir/platforms/bilibili/index.ts`：在 `MgBrowserAdapter.beforeInit` 中
  - 置 `Browser.onBLMiniGame = true`
  - 透传 iOS 高性能模式 `Browser.isIOSHighPerformanceModePlus`
  - 绑定 `PAL.g = window.bl`
- `scripts/config.mjs`：新增 `adapter-bilibili` 打包 bundle（input 含 `platforms/minigame/**` + `platforms/bilibili/**`），位置与其他 `adapter-*` 一致。

## 测试（Testing）

B 站平台改动已本地测试通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)