### PR TITLE
feat: add Bilibili minigame platform adapter（新增B站小游戏平台适配器）

### DIFF
--- a/scripts/config.mjs
+++ b/scripts/config.mjs
@@ -428,4 +428,11 @@ export const allBundles = [{
         'platforms/minigame/**/*.*',
         'platforms/xiaomi/**/*.*'
     ],
+},
+{
+    name: 'adapter-bilibili',
+    input: [
+        'platforms/minigame/**/*.*',
+        'platforms/bilibili/**/*.*'
+    ],
 }];

--- a/src/layaAir/platforms/bilibili/index.ts
+++ b/src/layaAir/platforms/bilibili/index.ts
@@ -1,0 +1,9 @@
+import { PAL } from "../../laya/platform/PlatformAdapters";
+import { Browser } from "../../laya/utils/Browser";
+import { MgBrowserAdapter } from "../minigame/MgBrowserAdapter";
+
+MgBrowserAdapter.beforeInit = function () {
+    Browser.onBLMiniGame = true;
+    Browser.isIOSHighPerformanceModePlus = GameGlobal.isIOSHighPerformanceModePlus;
+    PAL.g = (window as any).bl;
+};


### PR DESCRIPTION
## 改动说明（Summary）

将 Bilibili 小游戏平台适配同步到 3.3 稳定分支（对应 Master3.0 的 #2223）。

- `src/layaAir/platforms/bilibili/index.ts`：在 `MgBrowserAdapter.beforeInit` 中
  - 置 `Browser.onBLMiniGame = true`
  - 透传 iOS 高性能模式 `Browser.isIOSHighPerformanceModePlus`
  - 绑定 `PAL.g = window.bl`
- `scripts/config.mjs`：新增 `adapter-bilibili` 打包 bundle（仅追加该 bundle，未引入 Master3.0 独有的 ik/bridge/vfx bundle）。

## 测试（Testing）

B 站平台改动已本地测试通过。

## 同步说明

本 PR 由 Master3.0 的提交 cherry-pick 而来，对应双分支同步流程，配套 PR：layabox/LayaAir#2223。

🤖 Generated with [Claude Code](https://claude.com/claude-code)