### PR TITLE
fix: 修复 Text 在 overflow 裁剪时未正确处理右侧和底部 padding

### DIFF
--- a/src/layaAir/laya/display/Text.ts
+++ b/src/layaAir/laya/display/Text.ts
@@ -314,7 +314,7 @@ export class Text extends Sprite {
         let rect = this._scrollRect || new Rectangle();
         let rectWidth = this._isWidthSet ? this._width : this._textWidth;
         let rectHeight = this._isHeightSet ? this._height : this._textHeight;
-        rect.setTo(0, 0, rectWidth, rectHeight);
+        rect.setTo(0, 0, Math.max(0, rectWidth - this._padding[1]), Math.max(0, rectHeight - this._padding[2]));
         this.scrollRect = rect;
     }
 
@@ -1714,7 +1714,7 @@ export class Text extends Sprite {
                 let rect = this._objContainer.scrollRect || new Rectangle();
                 let rectWidth = this._isWidthSet ? this._width : this._textWidth;
                 let rectHeight = this._isHeightSet ? this._height : this._textHeight;
-                this._objContainer.scrollRect = rect.setTo(0, 0, rectWidth, rectHeight);
+                this._objContainer.scrollRect = rect.setTo(0, 0, Math.max(0, rectWidth - padding[1]), Math.max(0, rectHeight - padding[2]));
             }
             else
                 this._objContainer.scrollRect = null;
@@ -1745,8 +1745,7 @@ export class Text extends Sprite {
         let bottom = rectHeight - padding[2];
         let clipped = this._overflow == Text.HIDDEN || this._overflow == Text.SCROLL;
 
-        rectWidth -= (padding[3] + padding[1]);
-        rectHeight -= (padding[0] + padding[2]);
+        let contentWidth = Math.max(0, rectWidth - padding[1]);
 
         let x = 0, y = 0;
         let lines = this._lines;
@@ -1827,7 +1826,7 @@ export class Text extends Sprite {
             }
 
             if (curLink) {
-                curLink.addRect(linkStartX, y, rectWidth - linkStartX + paddingLeft, line.height);
+                curLink.addRect(linkStartX, y, contentWidth - linkStartX, line.height);
                 linkStartX = paddingLeft;
             }
         }


### PR DESCRIPTION
## 摘要
修复 `Text` 在 `hidden` 和 `scroll` 溢出模式下的裁剪行为，使最终裁剪能够正确处理 `padding-right` 和 `padding-bottom`。

## 问题
`Text` 在文本测量和换行阶段已经考虑了 padding。  
但是当 `overflow` 为 `hidden` 或 `scroll` 时，最终裁剪区域仍然使用的是组件的完整尺寸。  
因此，`padding-right` 和 `padding-bottom` 在最终裁剪结果中没有生效。

## 根因
`Text.scrollRect` 和 `_objContainer.scrollRect` 都是基于组件完整宽高创建的。  
裁剪边界没有减去右侧和底部的 padding，导致内容在被裁剪之前仍然可以渲染到这些内边距区域。

## 修复
- 修改 `Text._updateScrollRect()`，在裁剪宽高上扣除 `padding[1]` 和 `padding[2]`。
- 对 `_objContainer.scrollRect` 做相同处理，保证普通文本与 HTML/对象内容的裁剪行为一致。
- 保持左侧和顶部的原有绘制行为不变。

## 影响范围
- 仅影响 `Text` 在 `overflow` 为 `hidden` 或 `scroll` 时的行为。
- 仅修改 `src/layaAir/laya/display/Text.ts`。

## 验证
- 已确认 PR diff 只包含 `Text.ts`。
- 已检查 `Text.ts` 的诊断信息，没有报错。