### PR TITLE
fix: set bilibili miniGame context key to "bl" instead of null（修复B站小游戏上下文key由null改为"bl"）

### DIFF
--- a/src/layaAir/laya/utils/Browser.ts
+++ b/src/layaAir/laya/utils/Browser.ts
@@ -302,7 +302,7 @@ export class Browser {
                 miniGame = ["ttMiniGame", "TTMiniAdapter", "tt"];
             } else if ("bl" in Browser.window) {
                 //手机B站小游戏
-                miniGame = ["biliMiniGame", "BLMiniAdapter", null];
+                miniGame = ["biliMiniGame", "BLMiniAdapter", "bl"];
             }
             else if ("qq" in Browser.window) {
                 //手机QQ小游戏


### PR DESCRIPTION
## 问题

B站手机小游戏初始化时，`Browser.__init__` 里平台检测的 `miniGame` 数组第三个元素（小游戏上下文取值 key）为 `null`：

```ts
miniGame = ["biliMiniGame", "BLMiniAdapter", null];
```

该值用于 `Browser.miniGameContext = Browser.window[miniGame[2]]`，传 `null` 时取不到 B 站小游戏上下文，导致 `miniGameContext` 为 undefined。

## 修复

将第三个元素由 `null` 改为 `"bl"`，与微信(`wx`)、抖音(`tt`) 等保持一致，正确取到 `Browser.window["bl"]` 作为上下文。

## 验证

- `tsc --noEmit` 类型检查通过，无错误。

🤖 Generated with [Claude Code](https://claude.com/claude-code)