### PR TITLE
fix(platform): use native WebSocket for oppo/xiaomi quick game

### DIFF
--- a/src/layaAir/platforms/oppo/index.ts
+++ b/src/layaAir/platforms/oppo/index.ts
@@ -1,4 +1,5 @@
 import { Config } from "../../Config";
+import { _WebSocket } from "../../laya/net/WebSocket";
 import { PAL } from "../../laya/platform/PlatformAdapters";
 import { Browser } from "../../laya/utils/Browser";
 import { MgBrowserAdapter } from "../minigame/MgBrowserAdapter";
@@ -7,4 +8,8 @@ MgBrowserAdapter.beforeInit = function () {
     Config.fixedFrames = false;
     Browser.onQGMiniGame = true;
     PAL.g = (window as any).qg;
+};
+
+MgBrowserAdapter.afterInit = function () {
+    PAL.browser.webSocketClass = _WebSocket;
 };

--- a/src/layaAir/platforms/xiaomi/index.ts
+++ b/src/layaAir/platforms/xiaomi/index.ts
@@ -1,4 +1,5 @@
 import { Config } from "../../Config";
+import { _WebSocket } from "../../laya/net/WebSocket";
 import { PAL } from "../../laya/platform/PlatformAdapters";
 import { Browser } from "../../laya/utils/Browser";
 import { MgBrowserAdapter } from "../minigame/MgBrowserAdapter";
@@ -7,4 +8,8 @@ MgBrowserAdapter.beforeInit = function () {
     Config.useWebGL2 = false;
     Browser.onKGMiniGame = true;
     PAL.g = (window as any).qg;
+};
+
+MgBrowserAdapter.afterInit = function () {
+    PAL.browser.webSocketClass = _WebSocket;
 };


### PR DESCRIPTION
OPPO/小米快游戏不提供 connectSocket，init 阶段会将 webSocketClass 置为 null。 新增 afterInit 覆盖为标准浏览器 _WebSocket，与华为快游戏处理保持一致。