### PR TITLE
fix: clear stuck key state on window blur

### DIFF
--- a/src/layaAir/laya/events/InputManager.ts
+++ b/src/layaAir/laya/events/InputManager.ts
@@ -248,6 +248,17 @@ export class InputManager {
         }
 
         let doc = Browser.document;
+        let win = Browser.window;
+        win.addEventListener("blur", () => {
+            inst.clearPressedKeys();
+        });
+        win.addEventListener("pagehide", () => {
+            inst.clearPressedKeys();
+        });
+        doc.addEventListener("visibilitychange", () => {
+            if (doc.hidden)
+                inst.clearPressedKeys();
+        });
         doc.addEventListener("keydown", ev => {
             inst.handleKeys(ev);
         }, true);
@@ -257,6 +268,10 @@ export class InputManager {
         doc.addEventListener("keyup", ev => {
             inst.handleKeys(ev);
         }, true);
+    }
+
+    private clearPressedKeys(): void {
+        this._pressKeys.clear();
     }
 
     /**


### PR DESCRIPTION
## 概述

修复了浏览器中按下 `Windows/Meta` 键后，`InputManager.hasKeyDown` 状态可能持续卡住的问题。

在部分浏览器和操作系统下，按下 `Windows/Meta` 键时，浏览器能够收到 `keydown`，但由于系统界面抢占焦点，可能收不到对应的 `keyup`。这会导致该按键一直残留在 `_pressKeys` 中，用户返回页面后，`InputManager.hasKeyDown` 仍然错误地认为该键处于按下状态。

## 问题原因

`InputManager` 当前仅通过 `keydown` 和 `keyup` 来维护 `_pressKeys`。

当页面因 `Windows/Meta` 这类系统级按键而失去焦点时：
- 能收到 `keydown`
- 可能收不到对应的 `keyup`
- `_pressKeys` 无法被正确清理

## 修复方案

为按键状态增加页面失活时的兜底清理逻辑：

- 在 `window.blur` 时清空 `_pressKeys`
- 在 `window.pagehide` 时清空 `_pressKeys`
- 在 `document.visibilitychange` 且页面进入隐藏状态时清空 `_pressKeys`

这样即使浏览器没有派发对应的 `keyup`，失效的按键状态也会被及时清除。

## 修复结果

用户返回页面后，`InputManager.hasKeyDown(...)` 不会再错误地将 `Windows/Meta` 键判定为持续按下状态。

## 影响范围

本次修改仅影响 `InputManager` 中的键盘状态恢复逻辑，不改变页面保持激活时正常的 `keydown` / `keyup` 行为。