### PR TITLE
fix(forum-55348): Color.parse handles unexpected types gracefully

### DIFF
--- a/src/layaAir/laya/maths/Color.ts
+++ b/src/layaAir/laya/maths/Color.ts
@@ -215,15 +215,13 @@ export class Color implements IClone {
         if (value == null)
             value = 0;
 
-        if (typeof value !== 'string' && typeof value !== 'number') {
-            this.setValue(0, 0, 0, 1);
-            return this;
-        }
-
         if (typeof value === 'number') {
             if (value < 0 || isNaN(value))
                 value = 0;
             this.setRGB(value);
+        }
+        else if (typeof value !== 'string') {
+            this.setValue(0, 0, 0, 1);
         }
         else if (value.indexOf("rgba(") >= 0 || value.indexOf("rgb(") >= 0) {
             let p1 = value.indexOf("(");

--- a/src/layaAir/laya/maths/Color.ts
+++ b/src/layaAir/laya/maths/Color.ts
@@ -215,6 +215,11 @@ export class Color implements IClone {
         if (value == null)
             value = 0;
 
+        if (typeof value !== 'string' && typeof value !== 'number') {
+            this.setValue(0, 0, 0, 1);
+            return this;
+        }
+
         if (typeof value === 'number') {
             if (value < 0 || isNaN(value))
                 value = 0;


### PR DESCRIPTION
修复论坛反馈 https://ask.layaair.com/d/55348

## 问题
`Color.parse()` 在接收非 string/number 类型（如布尔值）时，调用 `value.indexOf()` 崩溃：`Uncaught TypeError: value.indexOf is not a function`

## 修复
在 `Color.parse` 中增加类型守卫：非 string 且非 number 时，回退为黑色 (0,0,0,1)，不再崩溃。