### PR TITLE
feat: per-particle shader curve baking and per-system material instances for VFX — 3.4 (VFX per-particle 颜色渐变/Disappear 曲线烘焙 + per-system 材质实例,3.4 分支)

### DIFF
--- a/src/layaAir/laya/vfx/ShaderExpressionEvaluator.ts
+++ b/src/layaAir/laya/vfx/ShaderExpressionEvaluator.ts
@@ -49,6 +49,16 @@ export interface ExprEvalContext {
 }
 
 export class ShaderExpressionEvaluator {
+    /**
+     * 转换器 unity-shader-to-laya.js 注入的“年龄中位数”全局常量 slot 名。
+     * SampleCurve(time = 该常量) 表示按 age 驱动 → 无法在全局表达式里 per-particle 采样，
+     * 走 {@link _sampleCurveAverage} 的时间平均近似。两端约定共用，改名需同步转换器。
+     */
+    static readonly AGE_MEDIAN_SLOT_NAME = "ageMedian";
+
+    /** {@link _sampleCurveAverage} 在 [0,1] 区间的中点采样点数，越大越精确、开销越高。 */
+    static readonly CURVE_AVERAGE_SAMPLE_COUNT = 32;
+
     /** evaluate 单个 expression graph，返回 root 节点的求值结果 */
     static evaluate(graph: ExprGraph, ctx: ExprEvalContext): any {
         if (!graph || !graph.nodes || !graph.rootNodeId) return null;
@@ -132,8 +142,18 @@ export class ShaderExpressionEvaluator {
             }
             case "SampleCurve": {
                 const curve = this._evalNode(n.inputs![0], nodes, cache, ctx) as CurveData;
-                const t = Number(this._evalNode(n.inputs![1], nodes, cache, ctx)) || 0;
-                result = this._sampleCurve(curve, t);
+                const timeNode = nodes[n.inputs![1]] as any;
+                // age 驱动的 SampleCurve(time=ageMedian 全局常量)在全局表达式里无法 per-particle 采样。
+                // 用曲线在 [0,1] 的【时间平均值】—— 数学上等于 Unity per-particle 随年龄采样后所有粒子的平均
+                // (粒子年龄在常 spawn 下均匀分布 [0,1])→ 整体亮度与 Unity 对齐。
+                // 注:Alpha_Multiplier 已在 VisualEffect._evaluateShaderExpressions 走真·per-particle 曲线 uniform,
+                // 此平均仅作其它 age 驱动属性 / per-particle 未注入时的兜底近似。
+                if (timeNode && timeNode.kind === "Constant" && timeNode.slotName === ShaderExpressionEvaluator.AGE_MEDIAN_SLOT_NAME) {
+                    result = this._sampleCurveAverage(curve);
+                } else {
+                    const t = Number(this._evalNode(n.inputs![1], nodes, cache, ctx)) || 0;
+                    result = this._sampleCurve(curve, t);
+                }
                 break;
             }
             case "Add":
@@ -255,7 +275,7 @@ export class ShaderExpressionEvaluator {
     }
 
     /** Unity AnimationCurve sample — 简化 linear lerp（不算 Hermite tangent，足够多数 material uniform 用例） */
-    private static _sampleCurve(c: CurveData, t: number): number {
+    static _sampleCurve(c: CurveData, t: number): number {
         // curve 未提供 → return null 让 caller skip setUniform 让 ShaderGraph default 生效
         if (!c) return null as any;
         if (!c.frames || c.frames.length === 0) return 0;
@@ -270,6 +290,16 @@ export class ShaderExpressionEvaluator {
         const denom = (f1.time - f0.time) || 1;
         const u = (clamp - f0.time) / denom;
         return f0.value + (f1.value - f0.value) * u;
+    }
+
+    /** 曲线在 [0,1] 的时间平均值（中点采样，点数见 {@link CURVE_AVERAGE_SAMPLE_COUNT}）— 见 SampleCurve 的 ageMedian 分支 */
+    static _sampleCurveAverage(c: CurveData): number {
+        if (!c || !c.frames || c.frames.length === 0) return 0;
+        if (c.frames.length === 1) return c.frames[0].value;
+        const N = this.CURVE_AVERAGE_SAMPLE_COUNT;
+        let sum = 0;
+        for (let i = 0; i < N; i++) sum += this._sampleCurve(c, (i + 0.5) / N);
+        return sum / N;
     }
 
     private static _binOp(kind: string, a: any, b: any): any {

--- a/src/layaAir/laya/vfx/VFXAssetParser.ts
+++ b/src/layaAir/laya/vfx/VFXAssetParser.ts
@@ -24,9 +24,6 @@ export class VFXAssetParser {
 
         const vfxAsset = new VFXAsset();
 
-        console.log(`[VFX-DBG] runtime parse systems=${(data.systems || []).length}`,
-            (data.systems || []).map((s: any, i: number) => `${i}:${s.type}${s.capacity != null ? `(cap=${s.capacity})` : ""}`).join(","));
-
         // 解析 updateMode
         let updateMode = VFXUpdateMode.FixedDeltaTime;
         if (data.fixedDeltaTime === false) {

--- a/src/layaAir/laya/vfx/VFXRenderer.ts
+++ b/src/layaAir/laya/vfx/VFXRenderer.ts
@@ -551,8 +551,13 @@ export class VFXRenderer extends BaseRender {
      * 反查到 res:// url 异步加载（每次只 kick off 一次），返回 VFXUnlit fallback；
      * .bps 加载完成后下一次 getCustomShaderMaterial 调用会命中已注册 shader。
      */
-    static getCustomShaderMaterial(shaderName: string, blendMode: string = "Alpha"): Material {
-        const key = `${shaderName}__${blendMode}`;
+    static getCustomShaderMaterial(shaderName: string, blendMode: string = "Alpha", instanceKey: string = ""): Material {
+        // instanceKey: per-system 材质实例标识。多个粒子系统共用同一 custom shader(如 UNI-Masked)时,
+        // 共享材质会让各 system 的 per-system uniform(shaderPropertyDefaults 的 _MaskTexture、
+        // per-particle 烘焙的 Alpha_Multiplier 年龄曲线/Disappear 曲线/颜色渐变)每帧互相覆盖
+        // (Barrier rings 的 mask/alpha 被 walls 覆盖 → 顶部亮环变暗的根因)。
+        // Unity 每个 output 是独立 material 实例,这里用 system 级 key 对齐。
+        const key = `${shaderName}__${blendMode}__${instanceKey}`;
         let mat = VFXRenderer._customShaderMaterialCache.get(key);
         if (mat) return mat;
 
@@ -576,7 +581,7 @@ export class VFXRenderer extends BaseRender {
                     .catch((err: any) => console.warn(`[VFX Renderer] custom shader '${shaderName}' load failed`, err));
             }
             // Shader 还没注册：返回 VFXUnlit fallback，不缓存（让下一帧重试）
-            return VFXRenderer.getCustomShaderMaterial("VFXUnlit", blendMode);
+            return VFXRenderer.getCustomShaderMaterial("VFXUnlit", blendMode, instanceKey);
         }
 
         mat = new Material();
@@ -924,7 +929,7 @@ export class VFXRenderer extends BaseRender {
 
                 // outputShaderGraphQuad 或用户指定了自定义 shader
                 if (customShaderName) {
-                    const mat = VFXRenderer.getCustomShaderMaterial(customShaderName, mode);
+                    const mat = VFXRenderer.getCustomShaderMaterial(customShaderName, mode, (geometry as any).matInstanceKey || "");
                     element.material = mat;
                     // (旧 P1 临时方案: 这里手动 mat.setColor u_AmbientColor / setFloat
                     // u_AmbientIntensity / u_ReflectionIntensity 给 fake IBL fallback 用.

--- a/src/layaAir/laya/vfx/VFXRenderer.ts
+++ b/src/layaAir/laya/vfx/VFXRenderer.ts
@@ -601,6 +601,45 @@ export class VFXRenderer extends BaseRender {
     }
 
     /**
+     * 基础 mesh 纹理材质：无 shadergraph(.bps)时,用内置 VFXUnlit + 绑定 MainTexture 到 u_AlbedoTexture。
+     * 对齐 Unity —— Output Mesh 自带 Main Texture,默认材质即可显示纹理,不依赖 Shader Graph。
+     * 按 (blendMode, 纹理 uuid, uvMode, flipbook) 缓存,避免共享材质被不同纹理互相覆盖。
+     */
+    static getMeshTexturedMaterial(blendMode: string = "Alpha", mainTextureUuid: string = "", uvMode: string = "Default", flipbookSize: Vector2 = null): Material {
+        // IDE Texture2D 字段存裸 assetId,转换器存 res://uuid —— 统一补前缀
+        if (mainTextureUuid && mainTextureUuid.indexOf("://") < 0)
+            mainTextureUuid = "res://" + mainTextureUuid;
+        const fbKey = flipbookSize ? `${flipbookSize.x}x${flipbookSize.y}` : "";
+        const key = `__meshtex__${blendMode}__${mainTextureUuid}__${uvMode}__${fbKey}`;
+        let mat = VFXRenderer._customShaderMaterialCache.get(key);
+        if (mat) return mat;
+        const shader = Shader3D.find("VFXUnlit");
+        if (!shader) {
+            console.error("[VFX Renderer] built-in 'VFXUnlit' shader not registered");
+            return null as any;
+        }
+        mat = new Material();
+        mat.setShaderName("VFXUnlit");
+        const vfxDef = Shader3D.getDefineByName("VFX_INSTANCED");
+        if (vfxDef) mat.addDefine(vfxDef);
+        const colorDef = Shader3D.getDefineByName("COLOR");
+        if (colorDef) mat.addDefine(colorDef);
+        mat.setColor("u_Color", new Color(1, 1, 1, 1));
+        mat.setTexture("u_AlbedoTexture", VFXRenderer.getDefaultDotTexture());
+        mat.renderQueue = 3000;
+        mat.cull = RenderState.CULL_NONE;
+        applyBlendMode(mat, blendMode);
+        applyFlipbook(mat, uvMode, flipbookSize);
+        VFXRenderer._customShaderMaterialCache.set(key, mat);
+        if (mainTextureUuid) {
+            VFXRenderer._tryLoadTextureOnce(mainTextureUuid, tex => {
+                if (mat) mat.setTexture("u_AlbedoTexture", tex);
+            });
+        }
+        return mat;
+    }
+
+    /**
      * 按 blendMode 获取/创建 strip 材质（缓存共享）
      * blendMode: "Alpha" | "Additive" | "Premultiplied" | "Opaque"
      *
@@ -952,8 +991,13 @@ export class VFXRenderer extends BaseRender {
                 else if (!meshMaterial && outType === "outputBillboard") {
                     element.material = VFXRenderer.getBillboardMaterial(mode);
                 } else if (!meshMaterial) {
-                    // outputMesh / outputStaticMesh 等：自动创建 VFXUnlit 默认材质
-                    element.material = VFXRenderer.getCustomShaderMaterial("VFXUnlit", mode);
+                    // 无 shadergraph(.bps)材质的 mesh 输出:有 MainTexture 时用基础 VFXUnlit + 绑纹理(对齐 Unity Output Mesh 自带 Main Texture),否则纯默认材质
+                    const meshMainTex = (geometry as any).mainTexture as string || "";
+                    if (meshMainTex) {
+                        element.material = VFXRenderer.getMeshTexturedMaterial(mode, meshMainTex, (geometry as any).uvMode || "Default", (geometry as any).flipbookSize);
+                    } else {
+                        element.material = VFXRenderer.getCustomShaderMaterial("VFXUnlit", mode);
+                    }
                 } else {
                     if (meshMaterial) {
                         applyBlendMode(meshMaterial, mode);
@@ -975,6 +1019,23 @@ export class VFXRenderer extends BaseRender {
                             if (!existing) {
                                 meshMaterial.setTexture("u_AlbedoTexture", VFXRenderer.getDefaultDotTexture());
                             }
+                        }
+                    }
+                    // mesh 输出(shadergraph 或基础):把 Output Mesh 的 MainTexture 字段直接绑到渲染材质。
+                    // 对齐 Unity —— Main Texture 字段驱动纹理,不依赖 shaderName/shadergraph 属性绑定(shaderName 常被 IDE 留空)。
+                    // 绑多个 sampler 名覆盖 .bps(MainTexture/_MainTexture)和基础材质(u_AlbedoTexture)。
+                    if (meshMaterial && outType !== "outputBillboard") {
+                        let meshFieldTex = (geometry as any).mainTexture as string;
+                        if (meshFieldTex && meshFieldTex.indexOf("://") < 0)
+                            meshFieldTex = "res://" + meshFieldTex;
+                        if (meshFieldTex) {
+                            VFXRenderer._tryLoadTextureOnce(meshFieldTex, tex => {
+                                if (tex) {
+                                    meshMaterial.setTexture("MainTexture", tex);
+                                    meshMaterial.setTexture("_MainTexture", tex);
+                                    meshMaterial.setTexture("u_AlbedoTexture", tex);
+                                }
+                            });
                         }
                     }
                     // Soft Particle / Flipbook / SubpixelAA

--- a/src/layaAir/laya/vfx/VisualEffect.ts
+++ b/src/layaAir/laya/vfx/VisualEffect.ts
@@ -49,6 +49,28 @@ const _tempCamForward = new Vector3();
 
 export class VisualEffect extends Script {
 
+    // ---- per-particle 年龄曲线约定（与转换器 unity-shader-to-laya.js + render shader 三端共用，改这里要同步另两端）----
+    /**
+     * 需要走「真·per-particle 随年龄曲线」的 shader uniform 名集合。
+     * 这些 uniform 的 age 曲线会拆成 times/vals 两个 vec4 传给 render shader 做分段采样，
+     * 而非用全局常量近似。新增 age 驱动属性时往这里加名字即可，不必改下面的求值逻辑。
+     * ⚠ 必须与转换器 unity-shader-to-laya.js 的 `_injectPerParticleAgeCurve` 中
+     *   `PER_PARTICLE_AGE_PROPS` 列表保持一致：转换器据此在 .bps 注入曲线节点，运行时据此填
+     *   times/vals uniform。只改一边 → 节点生成了但 uniform 不填（或反之），曲线不生效。
+     */
+    static readonly PER_PARTICLE_AGE_CURVE_UNIFORMS: ReadonlySet<string> = new Set(["Alpha_Multiplier"]);
+    /**
+     * 曲线采样的归一化时间点。长度必须为 4 且与 render shader 里 vec4 分段采样的点位一一对应，
+     * times/vals 都按此数组生成。
+     */
+    static readonly AGE_CURVE_SAMPLE_TIMES: ReadonlyArray<number> = [0, 1 / 3, 2 / 3, 1];
+    /** 派生 uniform 名的前缀，与转换器 _injectPerParticleAgeCurve 生成的命名一致：u + Base + 后缀。 */
+    static readonly AGE_CURVE_UNIFORM_PREFIX = "u";
+    /** 采样时间点 uniform 名后缀。 */
+    static readonly AGE_CURVE_TIMES_SUFFIX = "CurveTimes";
+    /** 采样值 uniform 名后缀。 */
+    static readonly AGE_CURVE_VALS_SUFFIX = "CurveVals";
+
     declare owner: Sprite3D;
     private _asset: VFXAsset;
     public get asset(): VFXAsset {
@@ -540,6 +562,10 @@ export class VisualEffect extends Script {
                 // 同时 set 带 / 不带 _ 两个 ID, 让两种命名都能命中真实 shader uniform.
                 const ids = [Shader3D.propertyNameToID(uniformName)];
                 if (uniformName.startsWith("_")) ids.push(Shader3D.propertyNameToID(uniformName.substring(1)));
+                // 同 _evaluateShaderExpressions：IDE 编译时剥掉全部下划线，补无下划线变体兜底
+                const noUnderscoreTex = uniformName.replace(/_/g, "");
+                if (noUnderscoreTex !== uniformName && noUnderscoreTex !== uniformName.substring(1))
+                    ids.push(Shader3D.propertyNameToID(noUnderscoreTex));
                 for (const sd of allDatas) {
                     for (const aid of ids) sd.setTexture(aid, entry.texture);
                 }
@@ -970,12 +996,44 @@ export class VisualEffect extends Script {
             }
             for (const uniformName in expressions) {
                 const graph = expressions[uniformName];
+                // per-particle: PER_PARTICLE_AGE_CURVE_UNIFORMS 里的 age 曲线传成 uXxxCurveTimes/Vals 两个 vec4 uniform，
+                // render shader 在 v_NormalizedAge（_Disappear uniform 经 PER_PARTICLE_UNIFORMS 映射）处做分段采样，
+                // 还原 Unity 每粒子随年龄的 alpha 淡入（年轻 dim→年老 bright），而非全局常量（会让中心年轻粒子也亮、环变厚）。
+                // 转换器 unity-shader-to-laya.js 的 _injectPerParticleAgeCurve 生成对应曲线节点；uniform 名按同规则派生。
+                if (VisualEffect.PER_PARTICLE_AGE_CURVE_UNIFORMS.has(uniformName)) {
+                    let curveNode: any = null, mult = 1;
+                    const g: any = graph;
+                    for (const nid in g.nodes) {
+                        const nd = g.nodes[nid];
+                        if (nd.kind === "Constant" && nd.outputType === "Curve") curveNode = nd;
+                        else if (nd.kind === "VFXParameter") {
+                            const pv = (propertyValues && (propertyValues as any).get) ? (propertyValues as any).get(nd.exposedName) : undefined;
+                            mult = (typeof pv === "number") ? pv : (typeof nd.defaultValue === "number" ? nd.defaultValue : 1);
+                        }
+                    }
+                    if (curveNode && curveNode.value) {
+                        const c = curveNode.value;
+                        const s = (t: number) => mult * (ShaderExpressionEvaluator._sampleCurve(c, t) || 0);
+                        const _base = uniformName.replace(/[^A-Za-z0-9]/g, "");
+                        const tId = Shader3D.propertyNameToID(VisualEffect.AGE_CURVE_UNIFORM_PREFIX + _base + VisualEffect.AGE_CURVE_TIMES_SUFFIX);
+                        const vId = Shader3D.propertyNameToID(VisualEffect.AGE_CURVE_UNIFORM_PREFIX + _base + VisualEffect.AGE_CURVE_VALS_SUFFIX);
+                        const ts = VisualEffect.AGE_CURVE_SAMPLE_TIMES;
+                        const tv = new Vector4(ts[0], ts[1], ts[2], ts[3]);
+                        const vv = new Vector4(s(ts[0]), s(ts[1]), s(ts[2]), s(ts[3]));
+                        for (const sd of allDatas) { sd.setVector(tId, tv); sd.setVector(vId, vv); }
+                    }
+                }
                 const result = ShaderExpressionEvaluator.evaluate(graph, { totalTime, deltaTime, propertyValues, hasContinuousSpawn });
                 if (result == null) continue;
                 // alias IDs：VFX 端 uniform name (_MainTextureColor) 跟 shader 端实际 uniform name 可能去掉 _ 前缀 (MainTextureColor)
                 // 同时 set 两个 ID 让 shader 不管哪个名字都能拿到
                 const ids = [Shader3D.propertyNameToID(uniformName)];
                 if (uniformName.startsWith("_")) ids.push(Shader3D.propertyNameToID(uniformName.substring(1)));
+                // IDE 编译 shader 时会剥掉 uniform 名里【全部】下划线（_MainTextureColor→MainTextureColor，
+                // Alpha_Multiplier→AlphaMultiplier 中间的也剥）。补一个去掉所有下划线的变体兜底，否则带中间下划线的属性对不上编译名。
+                const noUnderscore = uniformName.replace(/_/g, "");
+                if (noUnderscore !== uniformName && noUnderscore !== uniformName.substring(1))
+                    ids.push(Shader3D.propertyNameToID(noUnderscore));
                 if (graph.outputType === "float") {
                     const v = Number(result) || 0;
                     for (const sd of allDatas) for (const id of ids) sd.setNumber(id, v);

--- a/src/layaAir/laya/vfx/VisualEffect.ts
+++ b/src/layaAir/laya/vfx/VisualEffect.ts
@@ -72,6 +72,20 @@ export class VisualEffect extends Script {
     /** 采样值 uniform 名后缀。 */
     static readonly AGE_CURVE_VALS_SUFFIX = "CurveVals";
 
+    /**
+     * per-particle 颜色渐变 uniform 集合（.laya.vfx shaderPropertyExpressions 的 key）。
+     * Unity SG 里这些 uniform = SampleGradient(gradient, age) 按【每粒子年龄】采样；Laya material uniform
+     * 是 per-system 一份（evaluator 用 ageMedian=0.5 固定采样）→ 所有粒子同色（单色锐丝/顶环不亮/无混色层次）。
+     * 这里把 gradient 烘成 4-stop uniform（u_VfxColorGradTimes/C0..C3 + Enable），render shader（ShaderBuild
+     * supportVFX 注入的 vfxSampleColorGradient）按 v_NormalizedAge 分段采样还原 per-particle 颜色。
+     * ⚠ 必须与 LayaPro ShaderBuild.ts 的 per-particle color gradient 注入段 uniform 命名保持一致。
+     */
+    static readonly PER_PARTICLE_COLOR_GRADIENT_UNIFORMS: ReadonlySet<string> = new Set(["_MainTextureColor"]);
+    /** per-particle 颜色渐变 uniform 名（与 ShaderBuild 注入的 shader 端一致）。 */
+    static readonly COLOR_GRAD_ENABLE_UNIFORM = "u_VfxColorGradEnable";
+    static readonly COLOR_GRAD_TIMES_UNIFORM = "u_VfxColorGradTimes";
+    static readonly COLOR_GRAD_COLOR_UNIFORMS: ReadonlyArray<string> = ["u_VfxColorGradC0", "u_VfxColorGradC1", "u_VfxColorGradC2", "u_VfxColorGradC3"];
+
     declare owner: Sprite3D;
     private _asset: VFXAsset;
     public get asset(): VFXAsset {
@@ -553,7 +567,7 @@ export class VisualEffect extends Script {
             const customShaderName = (sys as any).customShaderName as string;
             const blendMode = (sys as any).blendMode as string || "Alpha";
             if (customShaderName) {
-                const mat = VFXRenderer.getCustomShaderMaterial(customShaderName, blendMode);
+                const mat = VFXRenderer.getCustomShaderMaterial(customShaderName, blendMode, (sys as any).matInstanceKey || "");
                 if (mat && mat.shaderData && allDatas.indexOf(mat.shaderData) === -1) allDatas.push(mat.shaderData);
             }
             for (const uniformName in defaults) {
@@ -642,12 +656,6 @@ export class VisualEffect extends Script {
     /// lifecycle methods
     onStart(): void {
         console.log("VisualEffect onStart", this, this.asset);
-        console.log(`[VFX-DBG] VE onStart systems=${this.systems.length}`,
-            this.systems.map((s: any, i: number) => {
-                const cap = (s as any).capacity ?? (s.desc && (s.desc as any).capacity);
-                const t = s.constructor.name;
-                return `${i}:${t}${cap != null ? `(cap=${cap})` : ""}`;
-            }).join(","));
     }
 
     // Strip 专用子节点和 Renderer（避免与 Mesh instancing 的渲染管线冲突）
@@ -992,7 +1000,7 @@ export class VisualEffect extends Script {
             const customShaderName = (sys as any).customShaderName as string;
             const blendMode = (sys as any).blendMode as string || "Alpha";
             if (customShaderName) {
-                const mat = VFXRenderer.getCustomShaderMaterial(customShaderName, blendMode);
+                const mat = VFXRenderer.getCustomShaderMaterial(customShaderName, blendMode, (sys as any).matInstanceKey || "");
                 if (mat && mat.shaderData && allDatas.indexOf(mat.shaderData) === -1) allDatas.push(mat.shaderData);
             }
             for (const uniformName in expressions) {
@@ -1022,6 +1030,76 @@ export class VisualEffect extends Script {
                         const tv = new Vector4(ts[0], ts[1], ts[2], ts[3]);
                         const vv = new Vector4(s(ts[0]), s(ts[1]), s(ts[2]), s(ts[3]));
                         for (const sd of allDatas) { sd.setVector(tId, tv); sd.setVector(vId, vv); }
+                    }
+                }
+                // per-particle Disappear 曲线 shaping: _Disappear = SampleCurve(curve, ageMedian) 时把 V 形曲线
+                // 4 关键点烘进 u_VfxDisTimes/Vals + Enable=1,render shader(ShaderBuild 注入的 vfxDisappearShape)
+                // 按 v_NormalizedAge 分段采样 → 还原 Unity 出生 fade-in + 死亡 fade-out
+                // (纯线性 v_NormalizedAge 让新生粒子立即全显 → Barrier walls 顶部亮环;老年慢淡 → 底部长尾)。
+                if (uniformName === "_Disappear" || uniformName === "Disappear") {
+                    const g: any = graph;
+                    const root = g.nodes && g.nodes[g.rootNodeId];
+                    if (root && root.kind === "SampleCurve" && root.inputs && root.inputs.length > 0) {
+                        const cnode = g.nodes[root.inputs[0]];
+                        const curve = cnode && cnode.kind === "Constant" ? cnode.value : null;
+                        if (curve && Array.isArray(curve.frames) && curve.frames.length > 0) {
+                            // 曲线原生关键帧 ≤4 个用原生 t(完整还原 V 形拐点),>4 均匀重采样
+                            let times = curve.frames.map((f: any) => Number(f.time) || 0).sort((a: number, b: number) => a - b);
+                            if (times.length > 4) times = [0, 1 / 3, 2 / 3, 1];
+                            while (times.length < 4) times.push(times[times.length - 1] ?? 1);
+                            const sc = (t: number) => ShaderExpressionEvaluator._sampleCurve(curve, t) || 0;
+                            const eId = Shader3D.propertyNameToID("u_VfxDisCurveEnable");
+                            const tId3 = Shader3D.propertyNameToID("u_VfxDisTimes");
+                            const vId3 = Shader3D.propertyNameToID("u_VfxDisVals");
+                            const tv3 = new Vector4(times[0], times[1], times[2], times[3]);
+                            const vv3 = new Vector4(sc(times[0]), sc(times[1]), sc(times[2]), sc(times[3]));
+                            for (const sd of allDatas) { sd.setNumber(eId, 1); sd.setVector(tId3, tv3); sd.setVector(vId3, vv3); }
+                        }
+                    }
+                }
+                // per-particle 颜色渐变: _MainTextureColor = SampleGradient(gradient, ageMedian) 时把 gradient
+                // 烘成 4-stop uniform(u_VfxColorGradTimes/C0..C3 + Enable=1),render shader(ShaderBuild supportVFX
+                // 注入的 vfxSampleColorGradient)按 v_NormalizedAge 分段采样 → 每粒子随年龄变色(新生亮青/老金棕),
+                // 而非全局 ageMedian 单色。未命中时 Enable 保持默认 0,shader 走原 uniform 路径,其它 VFX 零影响。
+                if (VisualEffect.PER_PARTICLE_COLOR_GRADIENT_UNIFORMS.has(uniformName)) {
+                    const g: any = graph;
+                    const root = g.nodes && g.nodes[g.rootNodeId];
+                    if (root && root.kind === "SampleGradient" && root.inputs && root.inputs.length > 0) {
+                        const gnode = g.nodes[root.inputs[0]];
+                        let grad: any = null;
+                        if (gnode && gnode.kind === "VFXParameter") {
+                            const pv: any = (propertyValues && gnode.exposedName) ? propertyValues.get(gnode.exposedName) : null;
+                            if (pv && pv.rawGradientStops && pv.rawGradientStops.length > 0) {
+                                grad = { __layaGradientStops: pv.rawGradientStops };
+                            } else if (gnode.defaultValue && (gnode.defaultValue.colorKeys || gnode.defaultValue.alphaKeys)) {
+                                grad = gnode.defaultValue;
+                            }
+                        }
+                        if (grad) {
+                            // 采样时间点: gradient 原生关键 t ≤4 个时用原生(完整还原陡变,如 Barrier ColorOverLife
+                            // 的 0/0.1/0.75/1),>4 个退化为均匀 4 点重采样
+                            const tSet = new Set<number>();
+                            if (grad.__layaGradientStops) {
+                                for (const s of grad.__layaGradientStops) tSet.add(Number(s.t) || 0);
+                            } else {
+                                for (const k of grad.colorKeys || []) tSet.add(Number(k.time) || 0);
+                                for (const k of grad.alphaKeys || []) tSet.add(Number(k.time) || 0);
+                            }
+                            let times = [...tSet].sort((a, b) => a - b);
+                            if (times.length > 4) times = [0, 1 / 3, 2 / 3, 1];
+                            while (times.length < 4) times.push(times[times.length - 1] ?? 1);
+                            const sampler = (ShaderExpressionEvaluator as any)._sampleGradient.bind(ShaderExpressionEvaluator);
+                            const eId = Shader3D.propertyNameToID(VisualEffect.COLOR_GRAD_ENABLE_UNIFORM);
+                            const tId2 = Shader3D.propertyNameToID(VisualEffect.COLOR_GRAD_TIMES_UNIFORM);
+                            const tv2 = new Vector4(times[0], times[1], times[2], times[3]);
+                            for (const sd of allDatas) { sd.setNumber(eId, 1); sd.setVector(tId2, tv2); }
+                            for (let ci = 0; ci < 4; ci++) {
+                                const col = sampler(grad, times[ci]) || { r: 1, g: 1, b: 1, a: 1 };
+                                const cId = Shader3D.propertyNameToID(VisualEffect.COLOR_GRAD_COLOR_UNIFORMS[ci]);
+                                const cv = new Vector4(col.r, col.g, col.b, col.a);
+                                for (const sd of allDatas) sd.setVector(cId, cv);
+                            }
+                        }
                     }
                 }
                 const result = ShaderExpressionEvaluator.evaluate(graph, { totalTime, deltaTime, propertyValues, hasContinuousSpawn });

--- a/src/layaAir/laya/vfx/VisualEffect.ts
+++ b/src/layaAir/laya/vfx/VisualEffect.ts
@@ -46,6 +46,7 @@ import { Laya } from "../../Laya";
 
 const globalRand = new Rand((Math.random() * 0xFFFFFFFF) >>> 0);
 const _tempCamForward = new Vector3();
+const _tempCamUp = new Vector3();
 
 export class VisualEffect extends Script {
 
@@ -1149,9 +1150,10 @@ export class VisualEffect extends Script {
             const camTransform = cameraModuleData.transform;
             const cameraWorldPos = camTransform.position;
             camTransform.getForward(_tempCamForward);
+            camTransform.getUp(_tempCamUp);   // 相机 up 轴(世界空间)→ LookAtPosition/Line orient 用它做 twist(对齐 Unity GetVFXToViewRotMatrix()[1])
             for (let system of this.systems) {
                 if (system instanceof VFXParticleSystem) {
-                    system.setOrientCamera(this.cmd, cameraWorldPos, _tempCamForward);
+                    system.setOrientCamera(this.cmd, cameraWorldPos, _tempCamForward, _tempCamUp);
                 }
             }
         }

--- a/src/layaAir/laya/vfx/systems/VFXParticleSystem.ts
+++ b/src/layaAir/laya/vfx/systems/VFXParticleSystem.ts
@@ -203,6 +203,12 @@ export class VFXParticleSystem extends VFXSystem {
     // 混合模式 — 对齐 Unity VFX Graph BlendMode
     blendMode: import("../VFXAsset").VFXBlendMode = "Alpha" as any;
 
+    private static _matUidCounter = 0;
+    /** per-system 材质实例 key:custom shader 材质若按 shaderName+blendMode 全局共享,
+     *  各 system 的 per-system uniform(_MaskTexture/alpha 年龄曲线/Disappear 曲线/颜色渐变)会互相覆盖。
+     *  对齐 Unity 每 output 独立 material 实例。 */
+    readonly matInstanceKey: string = "s" + (VFXParticleSystem._matUidCounter++);
+
     // Soft Particle 淡出距离（eye 空间单位，0 = 关闭）
     softParticleFade: number = 0;
 
@@ -849,6 +855,7 @@ export class VFXParticleSystem extends VFXSystem {
                     (this.geometry as any).subpixelAA = this.subpixelAA;
                     (this.geometry as any).customShaderName = this.customShaderName;
                 }
+                if (this.geometry) (this.geometry as any).matInstanceKey = this.matInstanceKey;
             } catch (e) {
                 console.warn("VFXParticleSystem: geometry creation failed, compute pipeline will still run.", e);
             }

--- a/src/layaAir/laya/vfx/systems/VFXParticleSystem.ts
+++ b/src/layaAir/laya/vfx/systems/VFXParticleSystem.ts
@@ -71,6 +71,7 @@ let ID: {
     u_VfxInvViewProjection: number;
     u_OrientCameraPos: number;
     u_OrientCameraDir: number;
+    u_OrientCameraUp: number;
     u_ParticlePerStrip: number;
     u_StripCapacity: number;
     StripDataBuffer: number;
@@ -113,6 +114,7 @@ export function ensureIDs(): void {
         u_VfxInvViewProjection: Shader3D.propertyNameToID("u_VfxInvViewProjection"),
         u_OrientCameraPos: Shader3D.propertyNameToID("u_OrientCameraPos"),
         u_OrientCameraDir: Shader3D.propertyNameToID("u_OrientCameraDir"),
+        u_OrientCameraUp: Shader3D.propertyNameToID("u_OrientCameraUp"),
         u_ParticlePerStrip: Shader3D.propertyNameToID("u_ParticlePerStrip"),
         u_StripCapacity: Shader3D.propertyNameToID("u_StripCapacity"),
         // SpawnState
@@ -628,10 +630,11 @@ export class VFXParticleSystem extends VFXSystem {
     /**
      * 通过 cmd 设置当前渲染相机的位置和朝向到 output shader
      */
-    setOrientCamera(cmd: ComputeCommandBuffer, cameraWorldPos: Vector3, cameraForward: Vector3): void {
+    setOrientCamera(cmd: ComputeCommandBuffer, cameraWorldPos: Vector3, cameraForward: Vector3, cameraUp: Vector3): void {
         for (const sd of this.outputDatas) {
             cmd.addSetShaderDataCommand(sd, ID.u_OrientCameraPos, ShaderDataType.Vector3, cameraWorldPos);
             cmd.addSetShaderDataCommand(sd, ID.u_OrientCameraDir, ShaderDataType.Vector3, cameraForward);
+            cmd.addSetShaderDataCommand(sd, ID.u_OrientCameraUp, ShaderDataType.Vector3, cameraUp);
         }
         // Multi-Output: extra outputDatas 也需要 orient camera 数据,
         // 不然 extra orient block 算出 (0,0,0) 假相机位置 → quaternion 错 → 粒子 quad 朝怪方向 / size collapse → 不可见
@@ -640,6 +643,7 @@ export class VFXParticleSystem extends VFXSystem {
             if (esd) {
                 cmd.addSetShaderDataCommand(esd, ID.u_OrientCameraPos, ShaderDataType.Vector3, cameraWorldPos);
                 cmd.addSetShaderDataCommand(esd, ID.u_OrientCameraDir, ShaderDataType.Vector3, cameraForward);
+                cmd.addSetShaderDataCommand(esd, ID.u_OrientCameraUp, ShaderDataType.Vector3, cameraUp);
             }
         }
     }

--- a/src/layaAir/laya/vfx/systems/VFXSpawnerTask.ts
+++ b/src/layaAir/laya/vfx/systems/VFXSpawnerTask.ts
@@ -99,10 +99,13 @@ export class VFXSpawnerSingleBurst extends VFXSpawnerTask {
     }
 
     internalInit(rand: Rand): void {
-        // ⚠ 不要 reset sleeping — Unity SingleBurst 整个 VFX 生命周期只 fire 一次 (含 Infinite loop 模式).
-        // 之前每个 newLoop 重置 sleeping=false 让 durationMode=Infinite + SingleBurst 每个 loop 重新 fire
-        // → 看起来 "粒子播放 2 次" (实际是无限次重 fire). UNI VFX1/2/3 都受影响.
-        // 只在 VFX 完整重置 (init / play) 时才重置 sleeping.
+        // internalInit 在 newLoop(每个 loop 开始)时被 VFXSpawnerTask.update 调用。这里重置 sleeping=false,
+        // 让【有限循环】(durationMode=Constant, loopDuration>0, loop 会周期性重启)的 SingleBurst 每个 loop 重新 fire,
+        // 对齐 Unity(有限 loop 的 Single Burst 每个 loop 触发一次)。BarrierVFX7 底圈脉冲依赖此行为。
+        // 为何不会重蹈旧 bug(Infinite + 无限重 fire): durationMode=Infinite → loopDuration=-1,
+        // VFXSpawnerState.endUpdate 对 currentMaximumDuration<0 不转换 loop 状态 → loop 永不重启 → newLoop 只第一次 true
+        // → Infinite 模式仍只 fire 一次。所以重置 sleeping 对 Infinite/Finite 两种都正确。
+        this.sleeping = false;
         this.nextTriggerTime = sampleRange(this.delay, rand);
         this.sampledCount = Math.round(sampleRange(this.count, rand));
     }


### PR DESCRIPTION
## Summary
Cherry-pick of #2247 onto LayaAir_3.4 (stacked on #2240's feat/vfx-uni-align-3.4):
- VisualEffect: bake _MainTextureColor gradient / _Disappear V-curve into 4-stop uniforms (u_VfxColorGrad* / u_VfxDis*), render shader samples per-particle by v_NormalizedAge
- VFXRenderer/VFXParticleSystem: per-system instanceKey for custom-shader material cache (systems sharing one shader overwrote each other's _MaskTexture / curves / gradients)
- fix: reset SingleBurst sleeping on loop restart
- Remove temporary [VFX-DBG] diagnostics

🤖 Generated with [Claude Code](https://claude.com/claude-code)