### PR TITLE
vfx: HDR 渐变半精度直通 + initialEvent 重解析 + mesh define 按材质实例管理 (Master3.0)

### DIFF
--- a/src/layaAir/laya/vfx/ShaderExpressionEvaluator.ts
+++ b/src/layaAir/laya/vfx/ShaderExpressionEvaluator.ts
@@ -49,6 +49,16 @@ export interface ExprEvalContext {
 }
 
 export class ShaderExpressionEvaluator {
+    /**
+     * 转换器 unity-shader-to-laya.js 注入的“年龄中位数”全局常量 slot 名。
+     * SampleCurve(time = 该常量) 表示按 age 驱动 → 无法在全局表达式里 per-particle 采样，
+     * 走 {@link _sampleCurveAverage} 的时间平均近似。两端约定共用，改名需同步转换器。
+     */
+    static readonly AGE_MEDIAN_SLOT_NAME = "ageMedian";
+
+    /** {@link _sampleCurveAverage} 在 [0,1] 区间的中点采样点数，越大越精确、开销越高。 */
+    static readonly CURVE_AVERAGE_SAMPLE_COUNT = 32;
+
     /** evaluate 单个 expression graph，返回 root 节点的求值结果 */
     static evaluate(graph: ExprGraph, ctx: ExprEvalContext): any {
         if (!graph || !graph.nodes || !graph.rootNodeId) return null;
@@ -132,8 +142,18 @@ export class ShaderExpressionEvaluator {
             }
             case "SampleCurve": {
                 const curve = this._evalNode(n.inputs![0], nodes, cache, ctx) as CurveData;
-                const t = Number(this._evalNode(n.inputs![1], nodes, cache, ctx)) || 0;
-                result = this._sampleCurve(curve, t);
+                const timeNode = nodes[n.inputs![1]] as any;
+                // age 驱动的 SampleCurve(time=ageMedian 全局常量)在全局表达式里无法 per-particle 采样。
+                // 用曲线在 [0,1] 的【时间平均值】—— 数学上等于 Unity per-particle 随年龄采样后所有粒子的平均
+                // (粒子年龄在常 spawn 下均匀分布 [0,1])→ 整体亮度与 Unity 对齐。
+                // 注:Alpha_Multiplier 已在 VisualEffect._evaluateShaderExpressions 走真·per-particle 曲线 uniform,
+                // 此平均仅作其它 age 驱动属性 / per-particle 未注入时的兜底近似。
+                if (timeNode && timeNode.kind === "Constant" && timeNode.slotName === ShaderExpressionEvaluator.AGE_MEDIAN_SLOT_NAME) {
+                    result = this._sampleCurveAverage(curve);
+                } else {
+                    const t = Number(this._evalNode(n.inputs![1], nodes, cache, ctx)) || 0;
+                    result = this._sampleCurve(curve, t);
+                }
                 break;
             }
             case "Add":
@@ -255,7 +275,7 @@ export class ShaderExpressionEvaluator {
     }
 
     /** Unity AnimationCurve sample — 简化 linear lerp（不算 Hermite tangent，足够多数 material uniform 用例） */
-    private static _sampleCurve(c: CurveData, t: number): number {
+    static _sampleCurve(c: CurveData, t: number): number {
         // curve 未提供 → return null 让 caller skip setUniform 让 ShaderGraph default 生效
         if (!c) return null as any;
         if (!c.frames || c.frames.length === 0) return 0;
@@ -270,6 +290,16 @@ export class ShaderExpressionEvaluator {
         const denom = (f1.time - f0.time) || 1;
         const u = (clamp - f0.time) / denom;
         return f0.value + (f1.value - f0.value) * u;
+    }
+
+    /** 曲线在 [0,1] 的时间平均值（中点采样，点数见 {@link CURVE_AVERAGE_SAMPLE_COUNT}）— 见 SampleCurve 的 ageMedian 分支 */
+    static _sampleCurveAverage(c: CurveData): number {
+        if (!c || !c.frames || c.frames.length === 0) return 0;
+        if (c.frames.length === 1) return c.frames[0].value;
+        const N = this.CURVE_AVERAGE_SAMPLE_COUNT;
+        let sum = 0;
+        for (let i = 0; i < N; i++) sum += this._sampleCurve(c, (i + 0.5) / N);
+        return sum / N;
     }
 
     private static _binOp(kind: string, a: any, b: any): any {

--- a/src/layaAir/laya/vfx/ShaderExpressionEvaluator.ts
+++ b/src/layaAir/laya/vfx/ShaderExpressionEvaluator.ts
@@ -3,7 +3,7 @@ import { Vector4 } from "../maths/Vector4";
 /**
  * VFX → ShaderGraph 之间 operator chain 的 runtime evaluator。
  *
- * Unity VFX Graph 中 OutputContext 的 shader uniform（如 _MainTextureColor）可以接到
+ * OutputContext 的 shader uniform（如 _MainTextureColor）可以接到
  * operator chain（SampleGradient/SampleCurve/Math 等），每帧求值后写到 material。
  * 转换器把这些 chain 序列化到 .lvfx 的 shaderPropertyExpressions，runtime 这里 evaluate。
  *
@@ -50,7 +50,7 @@ export interface ExprEvalContext {
 
 export class ShaderExpressionEvaluator {
     /**
-     * 转换器 unity-shader-to-laya.js 注入的“年龄中位数”全局常量 slot 名。
+     * 转换器注入的“年龄中位数”全局常量 slot 名。
      * SampleCurve(time = 该常量) 表示按 age 驱动 → 无法在全局表达式里 per-particle 采样，
      * 走 {@link _sampleCurveAverage} 的时间平均近似。两端约定共用，改名需同步转换器。
      */
@@ -122,7 +122,7 @@ export class ShaderExpressionEvaluator {
                     : Math.min(ctx.totalTime, 1);
                 break;
             case "Random": {
-                // Unity 端 Random(min, max, seed) 是 per-particle random, Laya material uniform 是 per-system 一份不能 per-particle.
+                // 源引擎端 Random(min, max, seed) 是 per-particle random, Laya material uniform 是 per-system 一份不能 per-particle.
                 // 之前写死 result=0.5 完全 ignore inputs 让 _MaskFlipbookIndex Random(0,3) 永远 0.5 而不是 0~3 范围
                 // 改成读 min/max input + 用 totalTime+seed-based deterministic random 让每帧动画 (frame 切换 mask flipbook)
                 const min = Number(this._evalNode(n.inputs![0], nodes, cache, ctx)) || 0;
@@ -144,8 +144,8 @@ export class ShaderExpressionEvaluator {
                 const curve = this._evalNode(n.inputs![0], nodes, cache, ctx) as CurveData;
                 const timeNode = nodes[n.inputs![1]] as any;
                 // age 驱动的 SampleCurve(time=ageMedian 全局常量)在全局表达式里无法 per-particle 采样。
-                // 用曲线在 [0,1] 的【时间平均值】—— 数学上等于 Unity per-particle 随年龄采样后所有粒子的平均
-                // (粒子年龄在常 spawn 下均匀分布 [0,1])→ 整体亮度与 Unity 对齐。
+                // 用曲线在 [0,1] 的【时间平均值】—— 数学上等于源引擎 per-particle 随年龄采样后所有粒子的平均
+                // (粒子年龄在常 spawn 下均匀分布 [0,1])→ 整体亮度与源引擎对齐。
                 // 注:Alpha_Multiplier 已在 VisualEffect._evaluateShaderExpressions 走真·per-particle 曲线 uniform,
                 // 此平均仅作其它 age 驱动属性 / per-particle 未注入时的兜底近似。
                 if (timeNode && timeNode.kind === "Constant" && timeNode.slotName === ShaderExpressionEvaluator.AGE_MEDIAN_SLOT_NAME) {
@@ -218,7 +218,7 @@ export class ShaderExpressionEvaluator {
     }
 
     /** Gradient sample lerp — 支持两种格式：
-     *  Unity {colorKeys:[{color,time}], alphaKeys:[{alpha,time}]}
+     *  源格式 {colorKeys:[{color,time}], alphaKeys:[{alpha,time}]}
      *  Laya  {__layaGradientStops:[{time,r,g,b,a}]} (color+alpha 同 stop)
      */
     private static _sampleGradient(g: any, t: number): { r: number; g: number; b: number; a: number } | null {
@@ -246,7 +246,7 @@ export class ShaderExpressionEvaluator {
                 a: c0[3] + (c1[3] - c0[3]) * u,
             };
         }
-        // Unity 格式
+        // 源格式
         if (!g.colorKeys || g.colorKeys.length === 0) return { r: 1, g: 1, b: 1, a: 1 };
         const keys = g.colorKeys;
         const aKeys = g.alphaKeys || [{ alpha: 1, time: 0 }];
@@ -274,7 +274,7 @@ export class ShaderExpressionEvaluator {
         return { r, g: g_, b, a };
     }
 
-    /** Unity AnimationCurve sample — 简化 linear lerp（不算 Hermite tangent，足够多数 material uniform 用例） */
+    /** AnimationCurve sample — 简化 linear lerp（不算 Hermite tangent，足够多数 material uniform 用例） */
     static _sampleCurve(c: CurveData, t: number): number {
         // curve 未提供 → return null 让 caller skip setUniform 让 ShaderGraph default 生效
         if (!c) return null as any;

--- a/src/layaAir/laya/vfx/VFXAsset.ts
+++ b/src/layaAir/laya/vfx/VFXAsset.ts
@@ -69,7 +69,7 @@ export class VFXSpawnerSetEventAttributeTaskDesc implements VFXSpawnerTaskDesc {
     value: [number, number, number, number] = [0, 0, 0, 0];
     fromLoopIndex: boolean = false;
     loopIndexModulo: number = 0;
-    // Unity Add(spawnState.loopDuration, spawnState.delayAfterLoop) → src.lifetime 模式
+    // Add(spawnState.loopDuration, spawnState.delayAfterLoop) → src.lifetime 模式
     fromSpawnStateLoop: boolean = false;
 }
 
@@ -87,7 +87,7 @@ export interface VFXGPUEventInput {
 }
 
 /**
- * Output Event 描述（CPU readback 通知，对齐 Unity VFXOutputEvent）
+ * Output Event 描述（CPU readback 通知，对齐 VFXOutputEvent）
  * 每个 outputEvent context 对应 update shader 中一份 OutputEventBuffer_<eventIdx>
  * Runtime 每帧 readback，按 eventName 派发到 VisualEffect.outputEventReceived 回调
  */
@@ -129,7 +129,7 @@ interface VFXSystemDesc {
 
 /**
  * VFXStaticMeshSystem 描述：渲染单个 mesh，不跑 particle simulation
- * Unity VFXStaticMeshOutput 对齐 — mesh 跟随 owner transform，material 由用户提供
+ * VFXStaticMeshOutput 对齐 — mesh 跟随 owner transform，material 由用户提供
  * bindings: setStaticMeshAttr block 收集到的 graph driven 绑定
  *   target: "position" | "rotation" | "scale" | "color"
  *   source: "inline" → value 是静态值 / "property" → name 引用 effect graph property
@@ -205,7 +205,7 @@ export class VFXParticleSystemDesc implements VFXSystemDesc {
     // Soft Particle 淡出距离（eye 空间单位，0 = 关闭）
     softParticleFade: number = 0;
 
-    // Flipbook 帧动画图集模式（对齐 Unity VFX Graph Output Context UV Mode）
+    // Flipbook 帧动画图集模式（对齐 Output Context UV Mode）
     // "Default" | "Flipbook" | "FlipbookBlend"
     uvMode: string = "Default";
     // Flipbook atlas 的列数/行数（cols, rows），启用 Flipbook 时用
@@ -213,13 +213,13 @@ export class VFXParticleSystemDesc implements VFXSystemDesc {
     // Flipbook 模式专用 atlas 资源（res:// uuid），runtime 加载后设到 BillboardMaterial.u_AlbedoTexture
     mainTexture: string = "";
 
-    // Subpixel AA 开关（对齐 Unity subpixelAA block）
+    // Subpixel AA 开关（对齐 subpixelAA block）
     subpixelAA: boolean = false;
 
     // 自定义 Shader 名（outputShaderGraphQuad 使用，空 = 默认 VFXUnlit）
     customShaderName: string = "";
 
-    // Billboard procedural 配置（对齐 Unity VFXPlanarPrimitiveOutput）
+    // Billboard procedural 配置（对齐 VFXPlanarPrimitiveOutput）
     // 空 = 走旧 mesh 路径（createQuad）兼容现有 VFX；
     // "Quad" / "Triangle" / "Octagon" = 走 VFXBillboardGeometry + gl_VertexID procedural
     billboardPrimitive: string = "";
@@ -228,12 +228,12 @@ export class VFXParticleSystemDesc implements VFXSystemDesc {
     // Octagon 裁角因子 [0, 0.5]，运行时可通过 property 系统动态调整
     billboardCropFactor: number = 0.146;
 
-    // Alpha Clipping (Unity VFXPlanarPrimitiveOutput useAlphaClipping):
+    // Alpha Clipping (VFXPlanarPrimitiveOutput useAlphaClipping):
     // 让 atlas mask 字符 (alpha<threshold 时 fragment discard)，背景方块透明
     useAlphaClipping: boolean = false;
     alphaThreshold: number = 0.5;
 
-    // Strip output 专属字段（对齐 Unity Output Trail）
+    // Strip output 专属字段（对齐 Output Trail）
     stripColorMapping: string = "Default";   // "Default" | "GradientMapped"
     stripUvScale: { x: number, y: number } = { x: 1, y: 1 };
     stripUvBias: { x: number, y: number } = { x: 0, y: 0 };
@@ -253,7 +253,7 @@ export class VFXParticleSystemDesc implements VFXSystemDesc {
     // 运行时通过 VisualEffect.setBuffer(name, buffer) 公开 API 绑定
     bufferUniforms: Array<{ uniformName: string; propertyName: string }> = [];
 
-    // Output Event 描述（CPU readback 通知，对齐 Unity VFXOutputEvent）
+    // Output Event 描述（CPU readback 通知，对齐 VFXOutputEvent）
     outputEvents: Array<VFXOutputEventDesc> = [];
 }
 

--- a/src/layaAir/laya/vfx/VFXAssetParser.ts
+++ b/src/layaAir/laya/vfx/VFXAssetParser.ts
@@ -24,9 +24,6 @@ export class VFXAssetParser {
 
         const vfxAsset = new VFXAsset();
 
-        console.log(`[VFX-DBG] runtime parse systems=${(data.systems || []).length}`,
-            (data.systems || []).map((s: any, i: number) => `${i}:${s.type}${s.capacity != null ? `(cap=${s.capacity})` : ""}`).join(","));
-
         // 解析 updateMode
         let updateMode = VFXUpdateMode.FixedDeltaTime;
         if (data.fixedDeltaTime === false) {
@@ -135,12 +132,12 @@ export class VFXAssetParser {
                     desc.outputType = sys.outputType || "outputMesh";
                     desc.particlePerStripCount = sys.particlePerStripCount ?? 128;
                     desc.stripCapacity = sys.stripCapacity ?? 1;
-                    // Billboard procedural：对齐 Unity VFXPlanarPrimitiveOutput，编译器写入 primitive/vertexCount/cropFactor
+                    // Billboard procedural：对齐 VFXPlanarPrimitiveOutput，编译器写入 primitive/vertexCount/cropFactor
                     desc.billboardPrimitive = (sys.billboardPrimitive as string) || "";
                     desc.billboardVertexCount = Number(sys.billboardVertexCount) || 0;
                     desc.distortionMode = (sys.distortionMode as string) || "Procedural";
                     desc.billboardCropFactor = Number(sys.billboardCropFactor ?? 0.146);
-                    // Alpha Clipping (Unity VFXPlanarPrimitiveOutput useAlphaClipping)
+                    // Alpha Clipping (VFXPlanarPrimitiveOutput useAlphaClipping)
                     (desc as any).useAlphaClipping = !!sys.useAlphaClipping;
                     (desc as any).alphaThreshold = Number(sys.alphaThreshold ?? 0.5);
 
@@ -164,7 +161,7 @@ export class VFXAssetParser {
                         desc.softParticleFade = sys.softParticleFade;
                     }
 
-                    // 解析 Flipbook UV Mode + 图集尺寸（对齐 Unity VFX Output UV Mode）
+                    // 解析 Flipbook UV Mode + 图集尺寸（对齐 Output UV Mode）
                     if (typeof sys.uvMode === "string") desc.uvMode = sys.uvMode;
                     if (Array.isArray(sys.flipbookSize)) {
                         desc.flipbookSize = new Vector2(
@@ -187,7 +184,7 @@ export class VFXAssetParser {
                         const shaderUrl: string = sys.customShaderRes;
                         loadPromises.push(
                             (Laya.loader.load(shaderUrl) as Promise<any>).then(
-                                () => { console.log(`[VFX Parser] preloaded custom shader '${sys.customShaderName}' from ${shaderUrl}`); },
+                                () => { },
                                 (err: any) => { console.warn(`[VFX Parser] failed preloading custom shader '${sys.customShaderName}' from ${shaderUrl}`, err); }
                             )
                         );
@@ -223,7 +220,7 @@ export class VFXAssetParser {
                         (desc as any).shaderPropertyExpressions = sys.shaderPropertyExpressions;
                     }
 
-                    // Strip 专属字段（对齐 Unity Output Trail）
+                    // Strip 专属字段（对齐 Output Trail）
                     if (typeof sys.colorMapping === "string") desc.stripColorMapping = sys.colorMapping;
                     if (typeof sys.tilingMode === "string") (desc as any).tilingMode = sys.tilingMode;
                     if (sys.uvScale && typeof sys.uvScale === "object") {
@@ -232,7 +229,7 @@ export class VFXAssetParser {
                     if (sys.uvBias && typeof sys.uvBias === "object") {
                         desc.stripUvBias = { x: Number(sys.uvBias.x ?? 0), y: Number(sys.uvBias.y ?? 0) };
                     }
-                    // gradient: Unity 格式 colorKeys+alphaKeys → 合并成 Laya stops 格式 (跟 sampleGradient 一致)
+                    // gradient: 源引擎格式 colorKeys+alphaKeys → 合并成 Laya stops 格式 (跟 sampleGradient 一致)
                     if (sys.gradient && typeof sys.gradient === "object" && Array.isArray(sys.gradient.colorKeys)) {
                         const gck = sys.gradient.colorKeys, gak = sys.gradient.alphaKeys || [];
                         const allTimes = new Set<number>();
@@ -326,8 +323,8 @@ export class VFXAssetParser {
                         // outputShaderGraphQuad / Billboard / Point / Line 无显式 mesh：用内置 Quad
                         return PrimitiveMesh.createQuad(1, 1);
                     };
-                    // builtin: 前缀表示 Unity 内置 primitive mesh（converter 检测 guid=0000-e000+fileID 后写入）
-                    // 直接用 PrimitiveMesh.createXxx 创建对齐尺寸（Unity 内置 Sphere/Cube 都是 1m，Plane 是 10m，Quad 1m）
+                    // builtin: 前缀表示内置 primitive mesh（converter 检测 guid=0000-e000+fileID 后写入）
+                    // 直接用 PrimitiveMesh.createXxx 创建对齐尺寸（内置 Sphere/Cube 都是 1m，Plane 是 10m，Quad 1m）
                     const buildBuiltinMesh = (name: string): Mesh | null => {
                         switch (name) {
                             case "Sphere":   return PrimitiveMesh.createSphere(0.5, 12, 12);
@@ -426,9 +423,6 @@ export class VFXAssetParser {
                                 const loadMeshTex = Laya.loader.load(meshUrl).then((mesh: Mesh) => {
                                     if (mesh) {
                                         entry.texture = bakeMeshAttributeTexture(mesh, normalizedRole as MeshRole);
-                                        const positions: any[] = [];
-                                        try { mesh.getPositions(positions); } catch {}
-                                        console.log(`[VFX] sampleMesh OK: ${meshUrl} role=${normalizedRole} vertexCount=${positions.length} firstVert=${positions[0] ? `(${positions[0].x.toFixed(2)},${positions[0].y.toFixed(2)},${positions[0].z.toFixed(2)})` : 'null'}`);
                                     } else {
                                         console.warn(`[VFX] sampleMesh: failed to load mesh ${meshUrl}`);
                                     }
@@ -497,7 +491,7 @@ export class VFXAssetParser {
                                 const exShaderUrl: string = eo.customShaderRes;
                                 loadPromises.push(
                                     (Laya.loader.load(exShaderUrl) as Promise<any>).then(
-                                        () => { console.log(`[VFX Parser] preloaded extra custom shader '${eo.customShaderName}' from ${exShaderUrl}`); },
+                                        () => { },
                                         (err: any) => { console.warn(`[VFX Parser] failed preloading extra custom shader '${eo.customShaderName}' from ${exShaderUrl}`, err); }
                                     )
                                 );
@@ -655,7 +649,7 @@ export class VFXAssetParser {
                     }
                     case VFXPropertyType.Texture2D: {
                         // Texture2D property: d 是 string "res://uuid" 或 array ["res://uuid"] (转换器统一输出后者)
-                        // Unity VFX exposed prop 跟 ShaderGraph 内 shader uniform 是双命名空间，OutputContext 含 binding；
+                        // VFX exposed prop 跟 ShaderGraph 内 shader uniform 是双命名空间，OutputContext 含 binding；
                         // 这里只 load 资源存到 desc.texture，setTexture 绑定 shader uniform 在 VisualEffect.onStart 用 binding 名做
                         let url: string | null = null;
                         if (Array.isArray(d) && typeof d[0] === "string") url = d[0];
@@ -728,7 +722,7 @@ export class VFXAssetParser {
 /**
  * 把 Mesh 顶点的 position 打包成 RGBA32F Texture2D（宽 = 顶点数 / 高 = 1）。
  * setPositionMesh block 在 compute shader 里通过 texelFetch(tex, ivec2(i, 0), 0) 取点。
- * 对齐 Unity VFX Graph 的 Point Cache 方案。
+ * 对齐 Point Cache 方案。
  */
 /**
  * 按关键帧烘焙 256×1 RGBA8 Gradient Texture2D
@@ -761,9 +755,9 @@ function bakeInlineGradientTexture(stops: { t: number; color: [number, number, n
         { t: 1, color: [1, 1, 1, 0] as [number, number, number, number] },
     ];
     // ⭐2026-06-11 HDR 直通：烘到 R16G16B16A16 半精度浮点纹理，不再 max-channel 归一化。
-    // 归一化是 LDR framebuffer 时代的 crutch——保了 chroma 但丢强度，让 Unity 的 HDR 红(23.97,0,0)
-    // 在 additive 下永远压不过低强度橙 → Buff 爆心橙白 vs Unity 饱和红的根因。
-    // 场景 enableHDR(浮点 framebuffer)下直通才是 Unity 语义(LDR 场景 clip 爆白同样是 Unity 行为)。
+    // 归一化是 LDR framebuffer 时代的 crutch——保了 chroma 但丢强度，让源引擎的 HDR 红(23.97,0,0)
+    // 在 additive 下永远压不过低强度橙 → Buff 爆心橙白 vs 源引擎饱和红的根因。
+    // 场景 enableHDR(浮点 framebuffer)下直通才是源引擎语义(LDR 场景 clip 爆白同样是源引擎行为)。
     const sanitizeStop = (c: number[]): [number, number, number, number] => [
         Math.max(0, c[0]), Math.max(0, c[1]), Math.max(0, c[2]), Math.max(0, Math.min(1, c[3])),
     ];
@@ -1005,7 +999,7 @@ export function bakeSkinnedMeshBonesTexture(renderer: any, existingTex: Texture2
         } else {
             boneWorld.cloneTo(tmpMtx);
         }
-        // GLSL mat4 是 column-major，elements 已是 column-major（同 Three / Unity）
+        // GLSL mat4 是 column-major，elements 已是 column-major（同 Three）
         const e = tmpMtx.elements;
         const off = i * 16;
         for (let k = 0; k < 16; k++) data[off + k] = e[k];

--- a/src/layaAir/laya/vfx/VFXAssetParser.ts
+++ b/src/layaAir/laya/vfx/VFXAssetParser.ts
@@ -735,34 +735,41 @@ export class VFXAssetParser {
  * 用于 sampleGradient operator 的 inline gradient 分支（textureLod(tex, vec2(t, 0.5), 0)）
  * 与 VisualEffect.bakeGradientTexture（Graph Property 用）算法一致但独立定义避免跨文件耦合
  */
+// float32 → float16 bits（渐变 HDR 烘焙用；R16G16B16A16=rgba16float 原始字节直传）
+const _f16ScratchF32 = new Float32Array(1);
+const _f16ScratchU32 = new Uint32Array(_f16ScratchF32.buffer);
+function _f32ToF16(v: number): number {
+    _f16ScratchF32[0] = v;
+    const bits = _f16ScratchU32[0];
+    const sign = (bits >> 16) & 0x8000;
+    const exp = ((bits >> 23) & 0xff) - 127 + 15;
+    const frac = bits & 0x7fffff;
+    if (exp <= 0) {
+        if (exp < -10) return sign;
+        const m = (frac | 0x800000) >> (1 - exp);
+        return sign | (m >> 13);
+    }
+    if (exp >= 31) return sign | 0x7c00;
+    return sign | (exp << 10) | (frac >> 13);
+}
+
 function bakeInlineGradientTexture(stops: { t: number; color: [number, number, number, number] }[]): Texture2D {
     const width = 256;
-    const data = new Uint8Array(width * 4);
+    const data = new Uint16Array(width * 4);
     const rawKeys = stops.length >= 2 ? stops : [
         { t: 0, color: [1, 1, 1, 1] as [number, number, number, number] },
         { t: 1, color: [1, 1, 1, 0] as [number, number, number, number] },
     ];
-    // Unity Gradient editor 用 HDR color picker 输出值 (e.g., 0,89.97,46.39) → 没 HDR pipeline 时需 clamp 到 [0,1]
-    // 之前 per-channel clamp 让所有三通道都 >1 的 HDR 颜色（如 (1.22, 5.66, 3.62) HDR teal）变成 (1,1,1) 纯白
-    // 丢失 chroma → TexIndexAdvanced Core Cube 这种 stop 该显示 teal 但 Laya 显示纯白
-    // 修：per-stop 用 max-channel 归一化保留 chroma 方向，仅 max>1 时缩放（max<=1 保留原值）
-    //   (1.22, 5.66, 3.62) max=5.66 → (0.216, 1.0, 0.640) 保留 teal-green chroma
-    //   (2.95, 0.012, 0.24) max=2.95 → (1.0, 0.004, 0.081) 保留 red chroma
-    // 副作用：失去 Unity HDR 强度信息（bloom glow 不可见），但 chroma 准确
-    const normalizeStop = (c: number[]): [number, number, number, number] => {
-        const r = Math.max(0, c[0]);
-        const g = Math.max(0, c[1]);
-        const b = Math.max(0, c[2]);
-        const a = Math.max(0, Math.min(1, c[3]));
-        const maxRGB = Math.max(r, g, b);
-        if (maxRGB > 1) {
-            return [r / maxRGB, g / maxRGB, b / maxRGB, a];
-        }
-        return [r, g, b, a];
-    };
+    // ⭐2026-06-11 HDR 直通：烘到 R16G16B16A16 半精度浮点纹理，不再 max-channel 归一化。
+    // 归一化是 LDR framebuffer 时代的 crutch——保了 chroma 但丢强度，让 Unity 的 HDR 红(23.97,0,0)
+    // 在 additive 下永远压不过低强度橙 → Buff 爆心橙白 vs Unity 饱和红的根因。
+    // 场景 enableHDR(浮点 framebuffer)下直通才是 Unity 语义(LDR 场景 clip 爆白同样是 Unity 行为)。
+    const sanitizeStop = (c: number[]): [number, number, number, number] => [
+        Math.max(0, c[0]), Math.max(0, c[1]), Math.max(0, c[2]), Math.max(0, Math.min(1, c[3])),
+    ];
     const keys = rawKeys.map(k => ({
         t: k.t,
-        color: normalizeStop(k.color),
+        color: sanitizeStop(k.color),
     }));
     for (let i = 0; i < width; i++) {
         const t = i / (width - 1);
@@ -776,12 +783,12 @@ function bakeInlineGradientTexture(stops: { t: number; color: [number, number, n
         const g = a.color[1] + (b.color[1] - a.color[1]) * u;
         const bB = a.color[2] + (b.color[2] - a.color[2]) * u;
         const aA = a.color[3] + (b.color[3] - a.color[3]) * u;
-        data[i * 4]     = Math.round(r * 255);
-        data[i * 4 + 1] = Math.round(g * 255);
-        data[i * 4 + 2] = Math.round(bB * 255);
-        data[i * 4 + 3] = Math.round(aA * 255);
+        data[i * 4]     = _f32ToF16(r);
+        data[i * 4 + 1] = _f32ToF16(g);
+        data[i * 4 + 2] = _f32ToF16(bB);
+        data[i * 4 + 3] = _f32ToF16(aA);
     }
-    const tex = new Texture2D(width, 1, TextureFormat.R8G8B8A8, false, false, false, false);
+    const tex = new Texture2D(width, 1, TextureFormat.R16G16B16A16, false, false, false, false);
     tex.setPixelsData(data, false, false);
     tex.wrapModeU = WrapMode.Clamp;
     tex.wrapModeV = WrapMode.Clamp;

--- a/src/layaAir/laya/vfx/VFXBillboardGeometry.ts
+++ b/src/layaAir/laya/vfx/VFXBillboardGeometry.ts
@@ -12,7 +12,7 @@ import { VertexElement } from "../renders/VertexElement";
 import { VertexElementFormat } from "../renders/VertexElementFormat";
 import { BufferState } from "../webgl/utils/BufferState";
 /**
- * VFXBillboardGeometry — 对齐 Unity VFXPlanarPrimitiveOutput
+ * VFXBillboardGeometry — 对齐 VFXPlanarPrimitiveOutput
  *
  * Procedural billboard 渲染：不依赖 mesh 资源，vertex shader 根据 gl_VertexID
  * 生成 Quad(6)/Triangle(3)/Octagon(18) 的顶点。配合 per-particle instance buffer。

--- a/src/layaAir/laya/vfx/VFXLineStripGeometry.ts
+++ b/src/layaAir/laya/vfx/VFXLineStripGeometry.ts
@@ -11,7 +11,7 @@ import { VertexElementFormat } from "../renders/VertexElementFormat";
 import { BufferState } from "../webgl/utils/BufferState";
 /**
  * VFXLineStripGeometry — Output LineStrip 渲染几何
- * 对齐 Unity VFXLineStripOutput
+ * 对齐 VFXLineStripOutput
  *
  * 每粒子 1 vertex（同 VFXPointGeometry layout，48 bytes）：
  *   [0] xyz=position, w=size (size 不使用，但保持 layout 兼容)

--- a/src/layaAir/laya/vfx/VFXRenderer.ts
+++ b/src/layaAir/laya/vfx/VFXRenderer.ts
@@ -43,7 +43,7 @@ export class VFXRenderer extends BaseRender {
     private static _defaultDotTexture: Texture2D | null = null;
 
     /**
-     * 程序生成 DefaultDot 软圆纹理（对齐 Unity VFX Graph DefaultParticle.png）
+     * 程序生成 DefaultDot 软圆纹理（对齐 DefaultParticle.png）
      * 64×64 白色软圆，alpha 为距中心的平滑衰减
      */
     static getDefaultDotTexture(): Texture2D {
@@ -110,7 +110,7 @@ export class VFXRenderer extends BaseRender {
     private static _smoothedNormalMeshIds: Set<number> = new Set();
 
     /**
-     * 给 mesh 跑 smooth normal: Unity .fbx import 默认 split vertex by hard edge + smooth normal
+     * 给 mesh 跑 smooth normal: 源引擎 .fbx import 默认 split vertex by hard edge + smooth normal
      * 平均化, 让相邻 face 共享 normal → shading 平滑无 alternating. Laya .fbx import 没这步,
      * 让蓝图 PBR shader 算 SurfaceShading 时邻接 face normal 不一致 → fragment shading 跳变 →
      * 三角形 alternating striping (image 56 蜡池区现象). 这里 weld by position + 平均 normal 复用
@@ -214,7 +214,7 @@ export class VFXRenderer extends BaseRender {
     /**
      * 给 mesh 跑 Laplacian vertex color smooth: 蓝图 ShaderGraph 用 mesh 顶点色驱动多区域选色
      * (e.g. SG_Candle 用 vc.g 分饰圈/蜡池/dripping), per-vertex 颜色直接 dump 显示三角形渐变.
-     * Unity 端因为有 bloom + AA + tonemap 视觉融合, Laya 简单 lighting 直接暴露相邻三角形色差.
+     * 源引擎端因为有 bloom + AA + tonemap 视觉融合, Laya 简单 lighting 直接暴露相邻三角形色差.
      * 这里对相邻 vertex (共三角形) 颜色做加权平均, 减少 striping 同时保留大尺度 region 差异.
      * 只 smooth r/g/a 通道 (b 通道在 vertex shader vfxTransformVertex 阶段 override 给 per-particle).
      */
@@ -329,10 +329,10 @@ export class VFXRenderer extends BaseRender {
         Laya.loader.load(url).then(async (tex: BaseTexture) => {
             if (tex) {
                 // PNG RGB-only atlas (e.g. TX_Flipbook_example.png 白数字 + 橙/cyan 方块底,
-                // colorType=2 无 alpha channel) 走 alpha blend 时方块底色全显示. Unity 端默认 Particles
-                // shader Color Mapping Default = color * tex, PNG no alpha → tex.a=1 → Unity 端实际行为不明,
+                // colorType=2 无 alpha channel) 走 alpha blend 时方块底色全显示. 源引擎端默认 Particles
+                // shader Color Mapping Default = color * tex, PNG no alpha → tex.a=1 → 源引擎端实际行为不明,
                 // 但 visually 蜡烛场景方块透明跟数字白显示. 这里跑 saturation 检测把彩色像素 alpha 设 0,
-                // 灰度像素保留 luminance, 让 atlas 视觉对齐 Unity (背景透明). 检测条件:
+                // 灰度像素保留 luminance, 让 atlas 视觉对齐源引擎 (背景透明). 检测条件:
                 // 所有 pixel alpha 都是 255 (PNG 无 alpha 让 IDE import 自动填 1) 才跑.
                 await VFXRenderer._patchTextureAlphaFromLuminance(tex, url);
                 VFXRenderer._atlasTextureCache.set(url, tex);
@@ -353,7 +353,6 @@ export class VFXRenderer extends BaseRender {
     private static async _patchTextureAlphaFromLuminance(tex: BaseTexture, url: string): Promise<void> {
         if (VFXRenderer._patchedTextureUrls.has(url)) return;
         VFXRenderer._patchedTextureUrls.add(url);
-        console.log("[VFX alpha] start url=", url);
         try {
             // ⚠不能用 loader.load(url, BUFFER)：同 url 已按 Texture 加载过时，资产缓存按 url 直接命中
             // 返回 Texture 对象（请求类型被忽略）→ "non-ArrayBuffer: object"，alpha 修补静默失效。
@@ -365,7 +364,6 @@ export class VFXRenderer extends BaseRender {
             }
             // 只处理 PNG (其它格式如 KTX/DDS 通常带正确 alpha)
             if (!url.toLowerCase().endsWith(".png")) {
-                console.log("[VFX alpha] skip - not png");
                 return;
             }
             const blob = new Blob([buffer], { type: "image/png" });
@@ -383,7 +381,6 @@ export class VFXRenderer extends BaseRender {
             for (let i = 3; i < pixels.length; i += 4) {
                 if (pixels[i] !== 255) { allOpaque = false; break; }
             }
-            console.log("[VFX alpha] allOpaque=", allOpaque, "pixels.length=", pixels.length);
             if (!allOpaque) return; // 真有 alpha 通道不动
             // 区分两种 PNG atlas 类型:
             // (A) "火焰风格": 大量黑色背景 + 彩色渐变主体 (flame/smoke) → 用 luminance 当 alpha
@@ -395,7 +392,6 @@ export class VFXRenderer extends BaseRender {
             }
             const blackRatio = blackCount / pixelCount;
             const isFlameStyle = blackRatio > 0.15;
-            console.log("[VFX alpha] blackRatio=", blackRatio.toFixed(3), "isFlameStyle=", isFlameStyle);
             let modified = false;
             for (let i = 0; i < pixels.length; i += 4) {
                 const r = pixels[i], g = pixels[i + 1], b = pixels[i + 2];
@@ -423,7 +419,6 @@ export class VFXRenderer extends BaseRender {
             const t2d = ((tex as any).bitmap || tex) as Texture2D;
             if (t2d && (t2d as any).setPixelsData) {
                 (t2d as any).setPixelsData(new Uint8Array(pixels.buffer), false, false);
-                console.log("[VFX] alpha patched from luminance:", url, "size=", canvas.width, "x", canvas.height);
             } else {
                 console.warn("[VFX alpha] no setPixelsData on bitmap, t2d=", t2d, "tex=", tex);
             }
@@ -433,7 +428,7 @@ export class VFXRenderer extends BaseRender {
     }
 
     /**
-     * 对齐 Unity VFXPlanarPrimitiveOutput：procedural billboard（用 gl_VertexID 生成顶点）
+     * 对齐 VFXPlanarPrimitiveOutput：procedural billboard（用 gl_VertexID 生成顶点）
      * primitive: "Quad" / "Triangle" / "Octagon"
      * cropFactor: Octagon 专用裁角因子 [0, 0.5]
      * mainTextureUuid / uvMode / fbW / fbH 加入 cache key —— Multi-Output 同一 system 多 output ctx
@@ -482,11 +477,11 @@ export class VFXRenderer extends BaseRender {
         return mat;
     }
 
-    /** Distortion procedural material 缓存（Unity VFXDistortion 对齐） */
+    /** Distortion procedural material 缓存（VFXDistortion 对齐） */
     private static _distortionMaterialCache: Map<string, Material> = new Map();
 
     /**
-     * 对齐 Unity VFXDistortion：采样 u_CameraOpaqueTexture 做 UV 偏移
+     * 对齐 VFXDistortion：采样 u_CameraOpaqueTexture 做 UV 偏移
      * mode: "Procedural"（径向透镜）/ "NormalMap"（用 u_AlbedoTexture 的 RG 当法线）
      * distortionStrength: UV 偏移乘法因子 [0, 1]
      * Camera 必须启用 opaqueTexture 才能看到效果
@@ -515,11 +510,11 @@ export class VFXRenderer extends BaseRender {
         return mat;
     }
 
-    /** Cube procedural material 缓存（Unity VFXBasicCubeOutput 对齐） */
+    /** Cube procedural material 缓存（VFXBasicCubeOutput 对齐） */
     private static _cubeProceduralCache: Map<string, Material> = new Map();
 
     /**
-     * 对齐 Unity VFXBasicCubeOutput：3D cube 粒子（6 面，带简易 Lambert 光照）
+     * 对齐 VFXBasicCubeOutput：3D cube 粒子（6 面，带简易 Lambert 光照）
      */
     static getCubeProceduralMaterial(blendMode: string = "Alpha"): Material | null {
         let mat = VFXRenderer._cubeProceduralCache.get(blendMode);
@@ -603,7 +598,7 @@ export class VFXRenderer extends BaseRender {
                     : (Laya as any).AssetDb?.inst?.shaderName_to_URL_async?.(shaderName)
                         .then((u: string) => u ? Laya.loader.load(u) : null);
                 Promise.resolve(loadPromise)
-                    .then(() => console.log(`[VFX Renderer] custom shader '${shaderName}' loaded (url=${url})`))
+                    .then(() => { })
                     .catch((err: any) => console.warn(`[VFX Renderer] custom shader '${shaderName}' load failed`, err));
             }
             // Shader 还没注册：返回 VFXUnlit fallback，不缓存（让下一帧重试）
@@ -677,12 +672,10 @@ export class VFXRenderer extends BaseRender {
         const useGradient = colorMapping === "GradientMapped" && gradientStops && gradientStops.length > 0;
         const gradDef = Shader3D.getDefineByName("VFX_STRIP_GRADIENT_MAPPED");
         const sbDef = Shader3D.getDefineByName("VFX_STRIP_UV_SCALE_BIAS");
-        console.log(`[VFX Strip Mat] colorMapping=${colorMapping}, useGradient=${useGradient}, gradDef=${!!gradDef}, sbDef=${!!sbDef}, stops=${gradientStops?.length ?? 0}`);
         if (useGradient) {
             if (gradDef) mat.addDefine(gradDef);
             const gradTex = bakeGradientTexture256(gradientStops!);
             mat.setTexture("u_VfxStripGradient", gradTex);
-            console.log(`[VFX Strip Mat] gradient texture baked, hasDefine=${gradDef ? mat.hasDefine(gradDef) : "noDef"}`);
         }
         // UV Mode = ScaleAndBias: 设 scale/bias uniform + 启用 define
         const useScaleBias = (uvScale && (uvScale.x !== 1 || uvScale.y !== 1)) || (uvBias && (uvBias.x !== 0 || uvBias.y !== 0));
@@ -875,14 +868,6 @@ export class VFXRenderer extends BaseRender {
             if (geometry instanceof VFXStripGeometry || outType === "outputPoint" || outType === "outputLine" || outType === "outputLineStrip") {
                 const mode = (geometry as any).blendMode || "Alpha";
                 const stripCustomShader = (geometry as any).customShaderName || "";
-                if (!(this as any)._stripLogOnce) {
-                    (this as any)._stripLogOnce = true;
-                    console.log(`[VFX Renderer] Strip path: isStripGeo=${geometry instanceof VFXStripGeometry}, outType=${outType}, mode=${mode}, customShader=${stripCustomShader}, isRender=${element._renderElementOBJ.isRender}`);
-                }
-                if (!(this as any)._stripDebug2) {
-                    (this as any)._stripDebug2 = true;
-                    console.log(`[VFX Strip Debug] meshMaterial=${meshMaterial ? (meshMaterial as any)._shader?.name : 'NULL'}, stripCustomShader='${stripCustomShader}'`);
-                }
                 if (stripCustomShader && stripCustomShader !== "VFXStrip") {
                     element.material = VFXRenderer.getCustomShaderMaterial(stripCustomShader, mode, "strip");
                 } else {
@@ -938,19 +923,19 @@ export class VFXRenderer extends BaseRender {
                     // 现在 _onEnable + _renderUpdate 接通真 reflection probe block bind,
                     // 引擎自动 push u_IBLTex / u_AmbientColor 等真值, 不需要手动 set.)
                 }
-                // Cube procedural（Unity VFXBasicCubeOutput 对齐）
+                // Cube procedural（VFXBasicCubeOutput 对齐）
                 else if (outType === "outputCube") {
                     const cubeMat = VFXRenderer.getCubeProceduralMaterial(mode);
                     if (cubeMat) element.material = cubeMat;
                 }
-                // Distortion（Unity VFXDistortion 对齐）
+                // Distortion（VFXDistortion 对齐）
                 else if (outType === "outputDistortion") {
                     const dMode = (geometry as any).distortionMode || "Procedural";
                     const dStrength = (geometry as any).cropFactor ?? 0.05; // 复用 cropFactor 字段传 strength
                     const dMat = VFXRenderer.getDistortionMaterial(dMode, mode, dStrength);
                     if (dMat) element.material = dMat;
                 }
-                // Billboard procedural（Unity VFXPlanarPrimitive 对齐）
+                // Billboard procedural（VFXPlanarPrimitive 对齐）
                 else if (isBillboardProcedural) {
                     const cropF = (geometry as any).cropFactor ?? 0.146;
                     // cache key 包含 mainTexture+uvMode+flipbookSize，让 multi-output 各 ctx 独立 material
@@ -982,7 +967,7 @@ export class VFXRenderer extends BaseRender {
                         const softFade = (geometry as any).softParticleFade || 0;
                         applySoftParticle(bbMat, softFade);
                         applySubpixelAA(bbMat, !!(geometry as any).subpixelAA);
-                        // Alpha Clipping (Unity VFXPlanarPrimitiveOutput useAlphaClipping)
+                        // Alpha Clipping (VFXPlanarPrimitiveOutput useAlphaClipping)
                         // atlas mask 字符用：alpha<threshold 时 fragment discard，atlas 背景方块消失
                         const useAlphaClip = !!(geometry as any).useAlphaClipping;
                         const alphaThresh = Number((geometry as any).alphaThreshold ?? 0.5);
@@ -1061,7 +1046,7 @@ export class VFXRenderer extends BaseRender {
 }
 
 /**
- * 按 blendMode 配置材质的 blend 状态（对齐 Unity VFX BlendMode 枚举）
+ * 按 blendMode 配置材质的 blend 状态（对齐 BlendMode 枚举）
  *   Alpha         = (SrcAlpha, OneMinusSrcAlpha)   — 普通半透明
  *   Additive      = (SrcAlpha, One)                — 发光/火花叠加
  *   Premultiplied = (One,      OneMinusSrcAlpha)   — 预乘 alpha
@@ -1078,7 +1063,7 @@ function bakeGradientTexture256(stops: { t: number; color: [number, number, numb
         sorted.push({ t: 1, color: [1, 1, 1, 0] });
     }
     const W = 256;
-    // 用 R32G32B32A32 float 格式保留 HDR (Unity gradient 末端 r=g=b=16)
+    // 用 R32G32B32A32 float 格式保留 HDR (源引擎 gradient 末端 r=g=b=16)
     const floats = new Float32Array(W * 4);
     for (let i = 0; i < W; i++) {
         const t = i / (W - 1);
@@ -1158,7 +1143,7 @@ function applySoftParticle(mat: Material, softFade: number): void {
 
 /**
  * 按 uvMode 开启/关闭 Flipbook / FlipbookBlend defines，并设置 u_FlipbookSize
- * 对齐 Unity VFX Output Context UV Mode（Default / Flipbook / FlipbookBlend）
+ * 对齐 Output Context UV Mode（Default / Flipbook / FlipbookBlend）
  */
 function applyFlipbook(mat: Material, uvMode: string, flipbookSize: Vector2): void {
     const defFB = Shader3D.getDefineByName("FLIPBOOK");

--- a/src/layaAir/laya/vfx/VFXRenderer.ts
+++ b/src/layaAir/laya/vfx/VFXRenderer.ts
@@ -355,13 +355,12 @@ export class VFXRenderer extends BaseRender {
         VFXRenderer._patchedTextureUrls.add(url);
         console.log("[VFX alpha] start url=", url);
         try {
-            // 不能直接 fetch(res://...)，浏览器不认 res: scheme。
-            // 改走 Laya.loader.load(url, BUFFER) 拿 ArrayBuffer：
-            //   - Loader 内部把 res:// 解析成实际 IDE preview server URL (http://localhost:xxx/library/...)
-            //   - 同一 url 加载有 cache，不会触发二次实际下载
-            const buffer = await Laya.loader.load(url, Loader.BUFFER);
+            // ⚠不能用 loader.load(url, BUFFER)：同 url 已按 Texture 加载过时，资产缓存按 url 直接命中
+            // 返回 Texture 对象（请求类型被忽略）→ "non-ArrayBuffer: object"，alpha 修补静默失效。
+            // 改用 loader.fetch：内部走 AssetDb.resolveURL 解析 res://，纯下载字节不进资产缓存。
+            const buffer = await (Laya.loader as any).fetch(url, "arraybuffer");
             if (!buffer || !(buffer instanceof ArrayBuffer)) {
-                console.warn("[VFX alpha] loader returned non-ArrayBuffer:", typeof buffer);
+                console.warn("[VFX alpha] fetch returned non-ArrayBuffer:", typeof buffer);
                 return;
             }
             // 只处理 PNG (其它格式如 KTX/DDS 通常带正确 alpha)
@@ -551,8 +550,40 @@ export class VFXRenderer extends BaseRender {
      * 反查到 res:// url 异步加载（每次只 kick off 一次），返回 VFXUnlit fallback；
      * .bps 加载完成后下一次 getCustomShaderMaterial 调用会命中已注册 shader。
      */
-    static getCustomShaderMaterial(shaderName: string, blendMode: string = "Alpha"): Material {
-        const key = `${shaderName}__${blendMode}`;
+    /** mesh 顶点能力 → 材质 define 同步（COLOR=slot1 / UV=slot2 / TANGENT=slot4）。
+     *  WebGPU 要求 shader 引用的顶点槽必须出现在 VertexState；mesh 缺元素时必须关掉对应 define。 */
+    static _syncMeshAttrDefines(mat: Material, geometry: any): void {
+        try {
+            const mesh = geometry && (geometry._mesh || geometry.mesh);
+            if (!mesh || !mat) return;
+            const vb = mesh.vertexBuffer || mesh._vertexBuffer;
+            const decl = vb && vb.vertexDeclaration;
+            const elems = decl && (decl._vertexElements || decl.vertexElements);
+            if (!elems || !elems.length) return;
+            const usages = new Set<number>();
+            for (const e of elems) usages.add(e.elementUsage !== undefined ? e.elementUsage : e._elementUsage);
+            // 官方 mesh define 集合（MeshUtil.getMeshDefine 与 MeshRenderer 同源），加上手动 usage 双保险
+            let meshDefs: any[] | null = null;
+            try {
+                meshDefs = [];
+                MeshUtil.getMeshDefine(mesh, meshDefs as any);
+            } catch (e) { meshDefs = null; }
+            const sync = (defName: string, usage: number) => {
+                const def = Shader3D.getDefineByName(defName);
+                if (!def) return;
+                const has = meshDefs ? meshDefs.indexOf(def) >= 0 : usages.has(usage);
+                if (has || usages.has(usage)) mat.addDefine(def);
+                else mat.removeDefine(def);
+            };
+            sync("COLOR", 1);
+            sync("UV", 2);
+            sync("UV1", 7);
+            sync("TANGENT", 4);
+        } catch (e) { }
+    }
+
+    static getCustomShaderMaterial(shaderName: string, blendMode: string = "Alpha", variant: "instanced" | "strip" = "instanced"): Material {
+        const key = `${shaderName}__${blendMode}__${variant}`;
         let mat = VFXRenderer._customShaderMaterialCache.get(key);
         if (mat) return mat;
 
@@ -576,15 +607,25 @@ export class VFXRenderer extends BaseRender {
                     .catch((err: any) => console.warn(`[VFX Renderer] custom shader '${shaderName}' load failed`, err));
             }
             // Shader 还没注册：返回 VFXUnlit fallback，不缓存（让下一帧重试）
-            return VFXRenderer.getCustomShaderMaterial("VFXUnlit", blendMode);
+            return VFXRenderer.getCustomShaderMaterial("VFXUnlit", blendMode, variant);
         }
 
         mat = new Material();
         mat.setShaderName(shaderName);
         // 蓝图 shader 启 supportVFX 后用 VFX_INSTANCED define 选 vfxTransformVertex 分支
         // (普通 mesh 用 shader 时此 define 关，VS 走原始 path)。
-        const vfxDef = Shader3D.getDefineByName("VFX_INSTANCED");
-        if (vfxDef) mat.addDefine(vfxDef);
+        // ⚠ strip 变体绝不能加 VFX_INSTANCED：strip 几何是普通顶点流(a_Position/a_Color/a_Texcoord0/a_Normal)
+        //   没有实例属性 a_AttrScale/a_AttrColor 等 → p.scale 读 0 → 顶点全缩到 pivot 退化不可见且零报错
+        //   (Buff VFX4 UNI-Masked 丝带不显示根因)。strip 的粒子色走标准 a_Color → vertex.vertexColor 通道。
+        if (variant !== "strip") {
+            const vfxDef = Shader3D.getDefineByName("VFX_INSTANCED");
+            if (vfxDef) mat.addDefine(vfxDef);
+        } else {
+            // strip 顶点流自带 a_Texcoord0，但 UV define 通常由 Mesh 顶点声明自动推导——strip 几何
+            // 不是 Mesh 不走那条路，必须显式开，否则 Vertex 结构无 texCoord0 字段（SG 纹理采样退化到 (0,0) 单点）
+            const uvDef = Shader3D.getDefineByName("UV");
+            if (uvDef) mat.addDefine(uvDef);
+        }
         // 同步强制开 COLOR define：让蓝图 #ifdef COLOR 路径启用，FS 端 pixel.vertexColor
         // 能拿到 vfxTransformVertex 写入的 p.color (instance a_AttrColor)。
         // 不强制的话 Laya 按 mesh 是否有顶点色决定 COLOR，让粒子色全链路断 → 蓝图算
@@ -767,12 +808,12 @@ export class VFXRenderer extends BaseRender {
         if (!supportedCompute)
             return;
 
-        const shaderData = this._baseRenderNode.shaderData;
-
-        // 更新 mesh defines: 先清除旧的，再添加所有 geometry 的
+        // ⭐不再把各 mesh 的能力 define 并集到【节点级】shaderData（原 addMeshDefines）：
+        // 多 mesh 能力不同时（实心 mesh 有色/切线 + 内置 quad 无），节点级并集会让无色/无切线
+        // 元素的 shader 变体强制引用缺失顶点槽 → WebGPU CreateRenderPipeline 失败（Detonation 根因）。
+        // mesh define 现由 _syncMeshAttrDefines 按【系统材质实例】精确管理（onAwake 预同步+每帧幂等）。
         for (const geo of this._geometries) {
             if (geo instanceof VFXGeometry) {
-                addMeshDefines(geo.mesh, shaderData);
                 // 跑 mesh smooth: 让相邻 face 共享 vertex normal → 消除 fragment shading 跳变三角形
                 // alternating; vc smooth 让区域边界 baseColor 过渡柔和.
                 VFXRenderer.smoothMeshNormals(geo.mesh);
@@ -843,7 +884,7 @@ export class VFXRenderer extends BaseRender {
                     console.log(`[VFX Strip Debug] meshMaterial=${meshMaterial ? (meshMaterial as any)._shader?.name : 'NULL'}, stripCustomShader='${stripCustomShader}'`);
                 }
                 if (stripCustomShader && stripCustomShader !== "VFXStrip") {
-                    element.material = VFXRenderer.getCustomShaderMaterial(stripCustomShader, mode);
+                    element.material = VFXRenderer.getCustomShaderMaterial(stripCustomShader, mode, "strip");
                 } else {
                     const stripMainTex = ((geometry as any).mainTexture as string) || "";
                     const stripColorMapping = ((geometry as any).stripColorMapping as string) || "Default";
@@ -886,6 +927,11 @@ export class VFXRenderer extends BaseRender {
                 // outputShaderGraphQuad 或用户指定了自定义 shader
                 if (customShaderName) {
                     const mat = VFXRenderer.getCustomShaderMaterial(customShaderName, mode);
+                    // mesh 顶点能力 → define 同步：WebGPU 严格校验 shader 引用的顶点槽必须在 VertexState 里，
+                    // mesh 缺 color/tangent 元素时不关 define 会 CreateRenderPipeline 失败（Detonation 根因）。
+                    // ⚠依赖 per-system 材质实例（bundle 的 matInstanceKey 参数，本源尚缺需提交前补齐），
+                    // 共享材质下不同 mesh 的系统会互相覆盖 define。
+                    VFXRenderer._syncMeshAttrDefines(mat, geometry);
                     element.material = mat;
                     // (旧 P1 临时方案: 这里手动 mat.setColor u_AmbientColor / setFloat
                     // u_AmbientIntensity / u_ReflectionIntensity 给 fake IBL fallback 用.

--- a/src/layaAir/laya/vfx/VisualEffect.ts
+++ b/src/layaAir/laya/vfx/VisualEffect.ts
@@ -49,6 +49,28 @@ const _tempCamForward = new Vector3();
 
 export class VisualEffect extends Script {
 
+    // ---- per-particle 年龄曲线约定（与转换器 unity-shader-to-laya.js + render shader 三端共用，改这里要同步另两端）----
+    /**
+     * 需要走「真·per-particle 随年龄曲线」的 shader uniform 名集合。
+     * 这些 uniform 的 age 曲线会拆成 times/vals 两个 vec4 传给 render shader 做分段采样，
+     * 而非用全局常量近似。新增 age 驱动属性时往这里加名字即可，不必改下面的求值逻辑。
+     * ⚠ 必须与转换器 unity-shader-to-laya.js 的 `_injectPerParticleAgeCurve` 中
+     *   `PER_PARTICLE_AGE_PROPS` 列表保持一致：转换器据此在 .bps 注入曲线节点，运行时据此填
+     *   times/vals uniform。只改一边 → 节点生成了但 uniform 不填（或反之），曲线不生效。
+     */
+    static readonly PER_PARTICLE_AGE_CURVE_UNIFORMS: ReadonlySet<string> = new Set(["Alpha_Multiplier"]);
+    /**
+     * 曲线采样的归一化时间点。长度必须为 4 且与 render shader 里 vec4 分段采样的点位一一对应，
+     * times/vals 都按此数组生成。
+     */
+    static readonly AGE_CURVE_SAMPLE_TIMES: ReadonlyArray<number> = [0, 1 / 3, 2 / 3, 1];
+    /** 派生 uniform 名的前缀，与转换器 _injectPerParticleAgeCurve 生成的命名一致：u + Base + 后缀。 */
+    static readonly AGE_CURVE_UNIFORM_PREFIX = "u";
+    /** 采样时间点 uniform 名后缀。 */
+    static readonly AGE_CURVE_TIMES_SUFFIX = "CurveTimes";
+    /** 采样值 uniform 名后缀。 */
+    static readonly AGE_CURVE_VALS_SUFFIX = "CurveVals";
+
     declare owner: Sprite3D;
     private _asset: VFXAsset;
     public get asset(): VFXAsset {
@@ -540,6 +562,10 @@ export class VisualEffect extends Script {
                 // 同时 set 带 / 不带 _ 两个 ID, 让两种命名都能命中真实 shader uniform.
                 const ids = [Shader3D.propertyNameToID(uniformName)];
                 if (uniformName.startsWith("_")) ids.push(Shader3D.propertyNameToID(uniformName.substring(1)));
+                // 同 _evaluateShaderExpressions：IDE 编译时剥掉全部下划线，补无下划线变体兜底
+                const noUnderscoreTex = uniformName.replace(/_/g, "");
+                if (noUnderscoreTex !== uniformName && noUnderscoreTex !== uniformName.substring(1))
+                    ids.push(Shader3D.propertyNameToID(noUnderscoreTex));
                 for (const sd of allDatas) {
                     for (const aid of ids) sd.setTexture(aid, entry.texture);
                 }
@@ -970,12 +996,44 @@ export class VisualEffect extends Script {
             }
             for (const uniformName in expressions) {
                 const graph = expressions[uniformName];
+                // per-particle: PER_PARTICLE_AGE_CURVE_UNIFORMS 里的 age 曲线传成 uXxxCurveTimes/Vals 两个 vec4 uniform，
+                // render shader 在 v_NormalizedAge（_Disappear uniform 经 PER_PARTICLE_UNIFORMS 映射）处做分段采样，
+                // 还原 Unity 每粒子随年龄的 alpha 淡入（年轻 dim→年老 bright），而非全局常量（会让中心年轻粒子也亮、环变厚）。
+                // 转换器 unity-shader-to-laya.js 的 _injectPerParticleAgeCurve 生成对应曲线节点；uniform 名按同规则派生。
+                if (VisualEffect.PER_PARTICLE_AGE_CURVE_UNIFORMS.has(uniformName)) {
+                    let curveNode: any = null, mult = 1;
+                    const g: any = graph;
+                    for (const nid in g.nodes) {
+                        const nd = g.nodes[nid];
+                        if (nd.kind === "Constant" && nd.outputType === "Curve") curveNode = nd;
+                        else if (nd.kind === "VFXParameter") {
+                            const pv = (propertyValues && (propertyValues as any).get) ? (propertyValues as any).get(nd.exposedName) : undefined;
+                            mult = (typeof pv === "number") ? pv : (typeof nd.defaultValue === "number" ? nd.defaultValue : 1);
+                        }
+                    }
+                    if (curveNode && curveNode.value) {
+                        const c = curveNode.value;
+                        const s = (t: number) => mult * (ShaderExpressionEvaluator._sampleCurve(c, t) || 0);
+                        const _base = uniformName.replace(/[^A-Za-z0-9]/g, "");
+                        const tId = Shader3D.propertyNameToID(VisualEffect.AGE_CURVE_UNIFORM_PREFIX + _base + VisualEffect.AGE_CURVE_TIMES_SUFFIX);
+                        const vId = Shader3D.propertyNameToID(VisualEffect.AGE_CURVE_UNIFORM_PREFIX + _base + VisualEffect.AGE_CURVE_VALS_SUFFIX);
+                        const ts = VisualEffect.AGE_CURVE_SAMPLE_TIMES;
+                        const tv = new Vector4(ts[0], ts[1], ts[2], ts[3]);
+                        const vv = new Vector4(s(ts[0]), s(ts[1]), s(ts[2]), s(ts[3]));
+                        for (const sd of allDatas) { sd.setVector(tId, tv); sd.setVector(vId, vv); }
+                    }
+                }
                 const result = ShaderExpressionEvaluator.evaluate(graph, { totalTime, deltaTime, propertyValues, hasContinuousSpawn });
                 if (result == null) continue;
                 // alias IDs：VFX 端 uniform name (_MainTextureColor) 跟 shader 端实际 uniform name 可能去掉 _ 前缀 (MainTextureColor)
                 // 同时 set 两个 ID 让 shader 不管哪个名字都能拿到
                 const ids = [Shader3D.propertyNameToID(uniformName)];
                 if (uniformName.startsWith("_")) ids.push(Shader3D.propertyNameToID(uniformName.substring(1)));
+                // IDE 编译 shader 时会剥掉 uniform 名里【全部】下划线（_MainTextureColor→MainTextureColor，
+                // Alpha_Multiplier→AlphaMultiplier 中间的也剥）。补一个去掉所有下划线的变体兜底，否则带中间下划线的属性对不上编译名。
+                const noUnderscore = uniformName.replace(/_/g, "");
+                if (noUnderscore !== uniformName && noUnderscore !== uniformName.substring(1))
+                    ids.push(Shader3D.propertyNameToID(noUnderscore));
                 if (graph.outputType === "float") {
                     const v = Number(result) || 0;
                     for (const sd of allDatas) for (const id of ids) sd.setNumber(id, v);

--- a/src/layaAir/laya/vfx/VisualEffect.ts
+++ b/src/layaAir/laya/vfx/VisualEffect.ts
@@ -49,12 +49,12 @@ const _tempCamForward = new Vector3();
 
 export class VisualEffect extends Script {
 
-    // ---- per-particle 年龄曲线约定（与转换器 unity-shader-to-laya.js + render shader 三端共用，改这里要同步另两端）----
+    // ---- per-particle 年龄曲线约定（与转换器 + render shader 三端共用，改这里要同步另两端）----
     /**
      * 需要走「真·per-particle 随年龄曲线」的 shader uniform 名集合。
      * 这些 uniform 的 age 曲线会拆成 times/vals 两个 vec4 传给 render shader 做分段采样，
      * 而非用全局常量近似。新增 age 驱动属性时往这里加名字即可，不必改下面的求值逻辑。
-     * ⚠ 必须与转换器 unity-shader-to-laya.js 的 `_injectPerParticleAgeCurve` 中
+     * ⚠ 必须与转换器的 `_injectPerParticleAgeCurve` 中
      *   `PER_PARTICLE_AGE_PROPS` 列表保持一致：转换器据此在 .bps 注入曲线节点，运行时据此填
      *   times/vals uniform。只改一边 → 节点生成了但 uniform 不填（或反之），曲线不生效。
      */
@@ -160,7 +160,7 @@ export class VisualEffect extends Script {
     state: VFXState = new VFXState();
 
     /**
-     * Output Event 回调（对齐 Unity VFXOutputEventArgs）
+     * Output Event 回调（对齐 VFXOutputEventArgs）
      *
      * 当 triggerEvent block 路由到 outputEvent context 且触发条件满足时，
      * 每一条触发都会异步回调一次（typically 1-2 帧延迟 due to GPU readback）。
@@ -190,7 +190,7 @@ export class VisualEffect extends Script {
         size: number;
     }) => void) | null = null;
 
-    // CustomSpawn 回调注册表 — Unity VFXSpawnerCustomWrapper 对齐
+    // CustomSpawn 回调注册表 — VFXSpawnerCustomWrapper 对齐
     // 用 customSpawn block 的 Callback Name 索引到对应回调
     private _customSpawnCallbacks: Map<string, IVFXCustomSpawnCallback> = new Map();
 
@@ -367,12 +367,12 @@ export class VisualEffect extends Script {
                     (particleSystem as any).shaderPropertyDefaults = (particleDesc as any).shaderPropertyDefaults || null;
                     // ShaderGraph property expression chains（每帧 evaluate 写 shader uniform，参 ShaderExpressionEvaluator）
                     (particleSystem as any).shaderPropertyExpressions = (particleDesc as any).shaderPropertyExpressions || null;
-                    // Billboard procedural 配置（对齐 Unity VFXPlanarPrimitiveOutput）
+                    // Billboard procedural 配置（对齐 VFXPlanarPrimitiveOutput）
                     particleSystem.billboardPrimitive = particleDesc.billboardPrimitive;
                     particleSystem.billboardVertexCount = particleDesc.billboardVertexCount;
                     particleSystem.distortionMode = particleDesc.distortionMode || "Procedural";
                     particleSystem.billboardCropFactor = particleDesc.billboardCropFactor;
-                    // Alpha Clipping (Unity VFXPlanarPrimitiveOutput useAlphaClipping)
+                    // Alpha Clipping (VFXPlanarPrimitiveOutput useAlphaClipping)
                     particleSystem.useAlphaClipping = (particleDesc as any).useAlphaClipping || false;
                     particleSystem.alphaThreshold = (particleDesc as any).alphaThreshold ?? 0.5;
                     // Strip 专属字段
@@ -562,7 +562,7 @@ export class VisualEffect extends Script {
             for (const uniformName in defaults) {
                 const entry = defaults[uniformName];
                 if (!entry || !entry.texture) continue;
-                // Unity 端 shader uniform 用 _MainTexture 带下划线, 但 Laya .bps 编译后 uniform name 不带下划线 (MainTexture).
+                // 源引擎端 shader uniform 用 _MainTexture 带下划线, 但 Laya .bps 编译后 uniform name 不带下划线 (MainTexture).
                 // 同时 set 带 / 不带 _ 两个 ID, 让两种命名都能命中真实 shader uniform.
                 const ids = [Shader3D.propertyNameToID(uniformName)];
                 if (uniformName.startsWith("_")) ids.push(Shader3D.propertyNameToID(uniformName.substring(1)));
@@ -651,13 +651,6 @@ export class VisualEffect extends Script {
 
     /// lifecycle methods
     onStart(): void {
-        console.log("VisualEffect onStart", this, this.asset);
-        console.log(`[VFX-DBG] VE onStart systems=${this.systems.length}`,
-            this.systems.map((s: any, i: number) => {
-                const cap = (s as any).capacity ?? (s.desc && (s.desc as any).capacity);
-                const t = s.constructor.name;
-                return `${i}:${t}${cap != null ? `(cap=${cap})` : ""}`;
-            }).join(","));
     }
 
     // Strip 专用子节点和 Renderer（避免与 Mesh instancing 的渲染管线冲突）
@@ -830,8 +823,6 @@ export class VisualEffect extends Script {
         this.frameTime.deltaTime = MathUtil.clamp(currentDeltaTime, 0, maxDeltaTime);
         this.frameTime.unscaledFixedDeltaTime = this.frameTime.unscaledTimeStepCount * fixedTimeStep;
         this.frameTime.unscaledDeltaTime = MathUtil.clamp(currentUnscaledDeltaTime, 0.0, maxDeltaTime);
-
-        // console.log(`VisualEffect onUpdate deltaTime:${this.frameTime.deltaTime.toFixed(4)} fixedDeltaTime:${this.frameTime.fixedDeltaTime.toFixed(4)} timeStepCount:${this.frameTime.timeStepCount}`);
 
         // update state
         let currentUnscaledVfxDeltaTime = 0;
@@ -1025,8 +1016,8 @@ export class VisualEffect extends Script {
                 const graph = expressions[uniformName];
                 // per-particle: PER_PARTICLE_AGE_CURVE_UNIFORMS 里的 age 曲线传成 uXxxCurveTimes/Vals 两个 vec4 uniform，
                 // render shader 在 v_NormalizedAge（_Disappear uniform 经 PER_PARTICLE_UNIFORMS 映射）处做分段采样，
-                // 还原 Unity 每粒子随年龄的 alpha 淡入（年轻 dim→年老 bright），而非全局常量（会让中心年轻粒子也亮、环变厚）。
-                // 转换器 unity-shader-to-laya.js 的 _injectPerParticleAgeCurve 生成对应曲线节点；uniform 名按同规则派生。
+                // 还原源引擎每粒子随年龄的 alpha 淡入（年轻 dim→年老 bright），而非全局常量（会让中心年轻粒子也亮、环变厚）。
+                // 转换器的 _injectPerParticleAgeCurve 生成对应曲线节点；uniform 名按同规则派生。
                 if (VisualEffect.PER_PARTICLE_AGE_CURVE_UNIFORMS.has(uniformName)) {
                     let curveNode: any = null, mult = 1;
                     const g: any = graph;
@@ -1555,7 +1546,7 @@ function bakeGradientTexture(stops: { t: number; color: [number, number, number,
         { t: 1, color: [1, 1, 1, 0] as [number, number, number, number] },
     ];
     // ⭐2026-06-11 HDR 直通：烘到 R16G16B16A16 半精度浮点，不再 max-normalize（LDR 时代 crutch，
-    // 保 chroma 丢强度 → Unity HDR 红压不过低强度橙）。enableHDR 场景下直通才是 Unity 语义。
+    // 保 chroma 丢强度 → HDR 红压不过低强度橙）。enableHDR 场景下直通才是源引擎语义。
     const sanitizeStop = (c: number[]): [number, number, number, number] => [
         Math.max(0, c[0]), Math.max(0, c[1]), Math.max(0, c[2]), Math.max(0, Math.min(1, c[3])),
     ];

--- a/src/layaAir/laya/vfx/VisualEffect.ts
+++ b/src/layaAir/laya/vfx/VisualEffect.ts
@@ -122,6 +122,8 @@ export class VisualEffect extends Script {
         return this._initialEvent;
     }
     public set initialEvent(value: string) {
+        // 空值回退资产默认（再退 OnPlay）：场景里序列化空字符串时避免派发空事件名 → 整个特效静默不播
+        if (!value) value = (this._asset && this._asset.initialEventName) || "OnPlay";
         this._initialEvent = value;
         this.initialEventID = Shader3D.propertyNameToID(this._initialEvent);
     }
@@ -552,7 +554,9 @@ export class VisualEffect extends Script {
             const customShaderName = (sys as any).customShaderName as string;
             const blendMode = (sys as any).blendMode as string || "Alpha";
             if (customShaderName) {
-                const mat = VFXRenderer.getCustomShaderMaterial(customShaderName, blendMode);
+                // strip 输出用无 VFX_INSTANCED 的材质变体（与 VFXRenderer 渲染用同一实例，defaults 才能生效）
+                const variant = VisualEffect._matVariantOf(sys);
+                const mat = VFXRenderer.getCustomShaderMaterial(customShaderName, blendMode, variant);
                 if (mat && mat.shaderData && allDatas.indexOf(mat.shaderData) === -1) allDatas.push(mat.shaderData);
             }
             for (const uniformName in defaults) {
@@ -638,6 +642,13 @@ export class VisualEffect extends Script {
         this.initialEvent = "OnPlay";
     }
 
+    /** strip 族输出（普通顶点流几何）→ 自定义 shader 材质取 "strip" 变体（无 VFX_INSTANCED）；其它取实例化变体 */
+    private static _matVariantOf(sys: any): "instanced" | "strip" {
+        const t = sys.outputType as string;
+        return (t === "outputTrail" || t === "outputParticleStripSGQuad" || t === "outputPoint" || t === "outputLine" || t === "outputLineStrip")
+            ? "strip" : "instanced";
+    }
+
     /// lifecycle methods
     onStart(): void {
         console.log("VisualEffect onStart", this, this.asset);
@@ -667,6 +678,17 @@ export class VisualEffect extends Script {
         const isNonMeshOutput = (t: string) => t === "outputTrail" || t === "outputParticleStripSGQuad" || t === "outputPoint" || t === "outputLine";
         let hasStrip = false;
         let hasMesh = false;
+        // ⭐define 同步必须在首帧渲染前完成：渲染元素的 shader 实例按"首次编译时的 define 集合"缓存，
+        // 之后材质 define 变更不触发重编译（失效管线被无限复用）。这里在任何 draw 之前按 mesh 顶点能力定型。
+        // ⚠依赖 per-system 材质实例（bundle 的 matInstanceKey，本源尚缺需提交前补齐）。
+        for (let system of this.systems) {
+            const sysAny = system as any;
+            if (system instanceof VFXParticleSystem && sysAny.geometry && sysAny.customShaderName
+                && !isNonMeshOutput(sysAny.outputType)) {
+                const _m = VFXRenderer.getCustomShaderMaterial(sysAny.customShaderName, sysAny.blendMode || "Alpha");
+                VFXRenderer._syncMeshAttrDefines(_m, sysAny.geometry);
+            }
+        }
         for (let system of this.systems) {
             if (system instanceof VFXParticleSystem && system.geometry) {
                 if (isNonMeshOutput(system.outputType)) {
@@ -914,7 +936,10 @@ export class VisualEffect extends Script {
     }
 
     processInitialize(evt: VFXEvent, state: VFXState) {
-
+        // Initialize 事件在 asset setter(initAssetData)时刻入队，但场景反序列化是先 asset 后 initialEvent，
+        // 入队时捕获的 id 永远是 asset 默认值，组件 Inspector 设置的 initialEvent 被吞掉。
+        // 处理时刻(首帧 simulate)重新解析当前 initialEventID 让组件 override 生效。
+        evt.id = this.initialEventID;
         this.processEvent(evt, state);
 
         this.asset.prewarmDeltaTime;
@@ -991,7 +1016,9 @@ export class VisualEffect extends Script {
             const customShaderName = (sys as any).customShaderName as string;
             const blendMode = (sys as any).blendMode as string || "Alpha";
             if (customShaderName) {
-                const mat = VFXRenderer.getCustomShaderMaterial(customShaderName, blendMode);
+                // strip 输出用无 VFX_INSTANCED 的材质变体（与 VFXRenderer 渲染用同一实例，表达式 uniform 才能生效）
+                const variant = VisualEffect._matVariantOf(sys);
+                const mat = VFXRenderer.getCustomShaderMaterial(customShaderName, blendMode, variant);
                 if (mat && mat.shaderData && allDatas.indexOf(mat.shaderData) === -1) allDatas.push(mat.shaderData);
             }
             for (const uniformName in expressions) {
@@ -1500,31 +1527,41 @@ export class VisualEffect extends Script {
  * 按关键帧烘焙 256×1 RGBA8 Gradient Texture2D
  * 用于 sampleGradient 在 VFX shader 里 textureLod(tex, vec2(t, 0.5), 0) 采样
  */
+// float32 → float16 bits（渐变 HDR 烘焙用；R16G16B16A16=rgba16float 原始字节直传）
+const _veF16F32 = new Float32Array(1);
+const _veF16U32 = new Uint32Array(_veF16F32.buffer);
+function _veF32ToF16(v: number): number {
+    _veF16F32[0] = v;
+    const bits = _veF16U32[0];
+    const sign = (bits >> 16) & 0x8000;
+    const exp = ((bits >> 23) & 0xff) - 127 + 15;
+    const frac = bits & 0x7fffff;
+    if (exp <= 0) {
+        if (exp < -10) return sign;
+        const m = (frac | 0x800000) >> (1 - exp);
+        return sign | (m >> 13);
+    }
+    if (exp >= 31) return sign | 0x7c00;
+    return sign | (exp << 10) | (frac >> 13);
+}
+
 function bakeGradientTexture(stops: { t: number; color: [number, number, number, number] }[]): Texture2D {
     const width = 256;
-    const data = new Uint8Array(width * 4);
+    const data = new Uint16Array(width * 4);
 
     // 保底至少两个关键帧
     const rawKeys = stops.length >= 2 ? stops : [
         { t: 0, color: [1, 1, 1, 1] as [number, number, number, number] },
         { t: 1, color: [1, 1, 1, 0] as [number, number, number, number] },
     ];
-    // Unity HDR color picker 让 gradient stops 含 >1 值；之前 per-channel clamp 让 (1.22, 5.66, 3.62) 全 >1
-    // 的 HDR teal 变成 (1,1,1) 纯白丢 chroma。修：per-stop max-normalize 保留 chroma 方向
-    const normalizeStop = (c: number[]): [number, number, number, number] => {
-        const r = Math.max(0, c[0]);
-        const g = Math.max(0, c[1]);
-        const b = Math.max(0, c[2]);
-        const a = Math.max(0, Math.min(1, c[3]));
-        const maxRGB = Math.max(r, g, b);
-        if (maxRGB > 1) {
-            return [r / maxRGB, g / maxRGB, b / maxRGB, a];
-        }
-        return [r, g, b, a];
-    };
+    // ⭐2026-06-11 HDR 直通：烘到 R16G16B16A16 半精度浮点，不再 max-normalize（LDR 时代 crutch，
+    // 保 chroma 丢强度 → Unity HDR 红压不过低强度橙）。enableHDR 场景下直通才是 Unity 语义。
+    const sanitizeStop = (c: number[]): [number, number, number, number] => [
+        Math.max(0, c[0]), Math.max(0, c[1]), Math.max(0, c[2]), Math.max(0, Math.min(1, c[3])),
+    ];
     const keys = rawKeys.map(k => ({
         t: k.t,
-        color: normalizeStop(k.color),
+        color: sanitizeStop(k.color),
     }));
 
     for (let i = 0; i < width; i++) {
@@ -1544,13 +1581,13 @@ function bakeGradientTexture(stops: { t: number; color: [number, number, number,
         const g = a.color[1] + (b.color[1] - a.color[1]) * u;
         const bB = a.color[2] + (b.color[2] - a.color[2]) * u;
         const aA = a.color[3] + (b.color[3] - a.color[3]) * u;
-        data[i * 4] = Math.round(r * 255);
-        data[i * 4 + 1] = Math.round(g * 255);
-        data[i * 4 + 2] = Math.round(bB * 255);
-        data[i * 4 + 3] = Math.round(aA * 255);
+        data[i * 4] = _veF32ToF16(r);
+        data[i * 4 + 1] = _veF32ToF16(g);
+        data[i * 4 + 2] = _veF32ToF16(bB);
+        data[i * 4 + 3] = _veF32ToF16(aA);
     }
 
-    const tex = new Texture2D(width, 1, TextureFormat.R8G8B8A8, false, false, false, false);
+    const tex = new Texture2D(width, 1, TextureFormat.R16G16B16A16, false, false, false, false);
     tex.setPixelsData(data, false, false);
     tex.wrapModeU = WrapMode.Clamp;
     tex.wrapModeV = WrapMode.Clamp;

--- a/src/layaAir/laya/vfx/shader/BlueprintPixelVertexVFX.glsl
+++ b/src/layaAir/laya/vfx/shader/BlueprintPixelVertexVFX.glsl
@@ -29,12 +29,13 @@
     //   下面所有 a_AttrPosition 等 attribute 引用完全从源码消失，GLSL→SPIR-V 编译器不会保留
     //   未使用 in 变量声明，WebGPU pipeline 创建不会要求绑定 instance buffer。
     //   不加 #ifdef 包裹时函数定义体保留 attribute 引用，依赖编译器 DCE 行为不可靠。
-    #ifdef VFX_INSTANCED
-
 // Per-particle data 通过 varying 传 fragment shader,
 // 让 ShaderGraph 内部用 uniform Float (如 MaskFlipbookIndex) 的 property 能改成 per-particle value.
 // ShaderBuild post-process 把 FS 内 uniform name `MaskFlipbookIndex` 等替换成 `v_TexIndex`.
 // 转换器 init context 加 setAttribute(texIndex, Random(0, range)) 让 GPU 每粒子写 unique value 到 a_AttrScale.w.
+// ⭐声明在 #ifdef VFX_INSTANCED 之外：FS 的 per-particle 替换是无条件文本替换，strip 材质变体
+//   (VFX_INSTANCED off，粒子属性走顶点流而非实例 buffer) 下声明若被剥掉而引用仍在 → 编译炸。
+//   非实例分支由 ShaderBuild 注入的 #else 写默认值（v_TexIndex=0/v_NormalizedAge=0/v_MainTexRand=0）。
 varying float v_TexIndex;
 
 // per-particle ageOverLifetime: 让 SG Disappear/Lifetime/Age 等 uniform 走 per-particle 路径
@@ -42,6 +43,8 @@ varying float v_TexIndex;
 // 直接 0→1 linear 跟随粒子 age, 不是 sampleCurve V 形 (粒子生 visible/老化 fade-out, 没 fade-in 阶段)
 // 完整 curve sample 路径后续优化 (vertex 端 sample 256x1 curve texture)
 varying float v_NormalizedAge;
+
+    #ifdef VFX_INSTANCED
 
 struct VFXParticle {
     vec3 position;

--- a/src/layaAir/laya/vfx/systems/VFXParticleSystem.ts
+++ b/src/layaAir/laya/vfx/systems/VFXParticleSystem.ts
@@ -50,7 +50,7 @@ let ID: {
     u_LoopIndex: number;
     u_EventCount: number;
     u_MaxSpawnCount: number;
-    // SpawnState operator (Unity SpawnState.cs 对齐) — Initialize stage uniforms
+    // SpawnState operator (SpawnState 对齐) — Initialize stage uniforms
     u_NewLoop: number;
     u_LoopState: number;
     u_SpawnCount: number;
@@ -198,13 +198,13 @@ export class VFXParticleSystem extends VFXSystem {
     particlePerStripCount: number = 128;
     stripCapacity: number = 1;
 
-    // 混合模式 — 对齐 Unity VFX Graph BlendMode
+    // 混合模式 — 对齐 BlendMode
     blendMode: import("../VFXAsset").VFXBlendMode = "Alpha" as any;
 
     // Soft Particle 淡出距离（eye 空间单位，0 = 关闭）
     softParticleFade: number = 0;
 
-    // Flipbook UV 模式 + 图集尺寸（对齐 Unity Output Context UV Mode）
+    // Flipbook UV 模式 + 图集尺寸（对齐 Output Context UV Mode）
     uvMode: string = "Default";
     flipbookSize: Vector2 = new Vector2(4, 4);
     // Flipbook atlas 资源（res:// uuid），uvMode != Default 时由 runtime 加载到 BillboardMaterial.u_AlbedoTexture
@@ -213,7 +213,7 @@ export class VFXParticleSystem extends VFXSystem {
     // Subpixel AA 开关
     subpixelAA: boolean = false;
 
-    // Strip output 专属字段（对齐 Unity Output Trail）
+    // Strip output 专属字段（对齐 Output Trail）
     stripColorMapping: string = "Default";   // "Default" | "GradientMapped"
     stripUvScale: { x: number, y: number } = { x: 1, y: 1 };
     stripUvBias: { x: number, y: number } = { x: 0, y: 0 };
@@ -223,7 +223,7 @@ export class VFXParticleSystem extends VFXSystem {
     // 自定义 Shader 名（空 = VFXUnlit）
     customShaderName: string = "";
 
-    // Billboard procedural 配置（对齐 Unity VFXPlanarPrimitiveOutput）
+    // Billboard procedural 配置（对齐 VFXPlanarPrimitiveOutput）
     // 空 = 走旧 mesh 路径；"Quad"/"Triangle"/"Octagon" = VFXBillboardGeometry
     billboardPrimitive: string = "";
     billboardVertexCount: number = 0;
@@ -255,7 +255,7 @@ export class VFXParticleSystem extends VFXSystem {
     spawnedCount: number = 0;
     eventCount: number = 0;
 
-    /** 本系统历史上已成功 Initialize 的粒子总数（用于 spawnIndex / particleId 与 Unity 对齐） */
+    /** 本系统历史上已成功 Initialize 的粒子总数（用于 spawnIndex / particleId 与源引擎对齐） */
     private _cumulativeSpawnTotal: number = 0;
 
     maxEventsPerFrame: number = 32;
@@ -671,7 +671,7 @@ export class VFXParticleSystem extends VFXSystem {
 
         // Strip: StripDataBuffer (5 uint per strip) for ring buffer tracking
         // Layout: [firstIndex, nextIndex, snapFirst, snapNext, minAlive(hi16)|maxAlive(lo16)]
-        // Matches Unity: firstIndex, nextIndex, prevNextIndex, minAlive, maxAlive
+        // 对齐: firstIndex, nextIndex, prevNextIndex, minAlive, maxAlive
         if (this.isStripOutput) {
             const stripCount = this.stripCapacity;
             const stripDataSize = stripCount * 5 * 4; // 5 uint per strip
@@ -761,7 +761,6 @@ export class VFXParticleSystem extends VFXSystem {
             // 包在 try-catch 中，确保 geometry 创建失败不会阻断后续的 Bounds 和 GPU Event 初始化
             try {
                 if (isStrip) {
-                    console.log(`[VFX] Creating StripGeometry: capacity=${capacity}, stripCap=${this.stripCapacity}, perStrip=${this.particlePerStripCount}, blend=${this.blendMode}`);
                     const stripParams = new VFXStripGeometryParams();
                     stripParams.capacity = capacity;
                     stripParams.stripVertexBuffer = this.renderBuffer;
@@ -779,7 +778,6 @@ export class VFXParticleSystem extends VFXSystem {
                     (this.geometry as any).stripGradientStops = this.stripGradientStops;
                     (this.geometry as any).stripTilingMode = this.stripTilingMode;
                     (this.geometry as any).stripPpsc = this.particlePerStripCount;
-                    console.log(`[VFX] StripGeometry created:`, this.geometry ? "OK" : "FAILED");
                 } else if (isPoint) {
                     const pointParams = new VFXPointGeometryParams();
                     pointParams.capacity = capacity;
@@ -805,7 +803,7 @@ export class VFXParticleSystem extends VFXSystem {
                     (this.geometry as any).blendMode = this.blendMode;
                     (this.geometry as any).outputType = this.outputType;
                 } else if (isBillboardProc) {
-                    // 对齐 Unity VFXPlanarPrimitiveOutput：DrawArrayIndirect + gl_VertexID 生成顶点
+                    // 对齐 VFXPlanarPrimitiveOutput：DrawArrayIndirect + gl_VertexID 生成顶点
                     const bbParams = new VFXBillboardGeometryParams();
                     bbParams.capacity = capacity;
                     bbParams.vertexCount = this.billboardVertexCount;
@@ -1032,12 +1030,7 @@ export class VFXParticleSystem extends VFXSystem {
     /**
      * 阶段3: Output — 压缩输出到 RenderBuffer
      */
-    private _outputLogOnce = false;
     outputPhase(state: VFXState, cmd: ComputeCommandBuffer): void {
-        if (!this._outputLogOnce && this.isStripOutput) {
-            this._outputLogOnce = true;
-            console.log(`[VFX OutputPhase] type=${this.outputType}, hasShader=${!!this.outputShader}, hasAlive=${!!this.aliveListBufferRead}, hasRender=${!!this.renderBuffer}, hasIndirect=${!!this.indirectBuffer}, isStrip=${this.isStripOutput}, geometry=${this.geometry?.constructor?.name}`);
-        }
         if (this.outputType === "none" || !this.outputShader) return;
         if (!this.aliveListBufferRead || !this.renderBuffer || !this.indirectBuffer) return;
 
@@ -1172,7 +1165,7 @@ export class VFXParticleSystem extends VFXSystem {
         shaderData.setInt(ID.u_TotalSpawnedCount, this._cumulativeSpawnTotal);
         shaderData.setInt(ID.u_SpawnedCount, sc);
         shaderData.setInt(ID.u_EventCount, this.eventCount);
-        // 传递 LoopIndex + SpawnState 全套（Unity SpawnState.cs 对齐）
+        // 传递 LoopIndex + SpawnState 全套（SpawnState 对齐）
         if (this.spawnerSystems.length > 0) {
             const spawner = this.effect.systems[this.spawnerSystems[0]] as VFXSpawnerSystem;
             if (spawner) {

--- a/src/layaAir/laya/vfx/systems/VFXSpawnerSystem.ts
+++ b/src/layaAir/laya/vfx/systems/VFXSpawnerSystem.ts
@@ -53,9 +53,9 @@ export class VFXSpawnerSystem extends VFXSystem {
         {
             const buffer = attrDesc.createBuffer();
             this.eventAttribute.initBuffer(buffer);
-            // 给关键 attribute 设 Unity 风格 default：粒子 setAttribute(lifetime, source=Source)
+            // 给关键 attribute 设源引擎风格 default：粒子 setAttribute(lifetime, source=Source)
             // 但 spawn event 没 setSpawnEventAttribute(lifetime) 时，src.lifetime=0 让粒子瞬死。
-            // Unity 默认 lifetime=1，保持一致避免 sample 默认配置不可见。
+            // 源引擎默认 lifetime=1，保持一致避免 sample 默认配置不可见。
             if (attrDesc.hasAttribute("lifetime")) {
                 this.eventAttribute.setFloat("lifetime", 1);
             }

--- a/src/layaAir/laya/vfx/systems/VFXSpawnerTask.ts
+++ b/src/layaAir/laya/vfx/systems/VFXSpawnerTask.ts
@@ -99,10 +99,13 @@ export class VFXSpawnerSingleBurst extends VFXSpawnerTask {
     }
 
     internalInit(rand: Rand): void {
-        // ⚠ 不要 reset sleeping — Unity SingleBurst 整个 VFX 生命周期只 fire 一次 (含 Infinite loop 模式).
-        // 之前每个 newLoop 重置 sleeping=false 让 durationMode=Infinite + SingleBurst 每个 loop 重新 fire
-        // → 看起来 "粒子播放 2 次" (实际是无限次重 fire). UNI VFX1/2/3 都受影响.
-        // 只在 VFX 完整重置 (init / play) 时才重置 sleeping.
+        // internalInit 在 newLoop(每个 loop 开始)时被 VFXSpawnerTask.update 调用。这里重置 sleeping=false,
+        // 让【有限循环】(durationMode=Constant, loopDuration>0, loop 会周期性重启)的 SingleBurst 每个 loop 重新 fire,
+        // 对齐 Unity(有限 loop 的 Single Burst 每个 loop 触发一次)。BarrierVFX7 底圈脉冲依赖此行为。
+        // 为何不会重蹈旧 bug(Infinite + 无限重 fire): durationMode=Infinite → loopDuration=-1,
+        // VFXSpawnerState.endUpdate 对 currentMaximumDuration<0 不转换 loop 状态 → loop 永不重启 → newLoop 只第一次 true
+        // → Infinite 模式仍只 fire 一次。所以重置 sleeping 对 Infinite/Finite 两种都正确。
+        this.sleeping = false;
         this.nextTriggerTime = sampleRange(this.delay, rand);
         this.sampledCount = Math.round(sampleRange(this.count, rand));
     }

--- a/src/layaAir/laya/vfx/systems/VFXSpawnerTask.ts
+++ b/src/layaAir/laya/vfx/systems/VFXSpawnerTask.ts
@@ -78,7 +78,7 @@ export class VFXSpawnerSingleBurst extends VFXSpawnerTask {
     // 循环开始后到首次爆发的延迟时间（x=min, y=max），单位：秒
     delay: Vector2 = new Vector2();
 
-    // 当为 true 时，burst count = spawnerState.loopIndex % countModulo（对齐 Unity VFX LoopIndex → burst count 连接）
+    // 当为 true 时，burst count = spawnerState.loopIndex % countModulo（对齐 LoopIndex → burst count 连接）
     countFromLoopIndex: boolean = false;
     countModulo: number = 0;
 
@@ -94,14 +94,14 @@ export class VFXSpawnerSingleBurst extends VFXSpawnerTask {
 
     play(): void {
         // VFX onPlay (stop → play / asset re-import) 应该让 SingleBurst 重新 fire 一次
-        // (跟 Unity 行为一致：每次 onPlay 视为一次新 VFX 生命周期)
+        // (与源引擎行为一致：每次 onPlay 视为一次新 VFX 生命周期)
         this.sleeping = false;
     }
 
     internalInit(rand: Rand): void {
         // internalInit 在 newLoop(每个 loop 开始)时被 VFXSpawnerTask.update 调用。这里重置 sleeping=false,
         // 让【有限循环】(durationMode=Constant, loopDuration>0, loop 会周期性重启)的 SingleBurst 每个 loop 重新 fire,
-        // 对齐 Unity(有限 loop 的 Single Burst 每个 loop 触发一次)。BarrierVFX7 底圈脉冲依赖此行为。
+        // 对齐源引擎(有限 loop 的 Single Burst 每个 loop 触发一次)。BarrierVFX7 底圈脉冲依赖此行为。
         // 为何不会重蹈旧 bug(Infinite + 无限重 fire): durationMode=Infinite → loopDuration=-1,
         // VFXSpawnerState.endUpdate 对 currentMaximumDuration<0 不转换 loop 状态 → loop 永不重启 → newLoop 只第一次 true
         // → Infinite 模式仍只 fire 一次。所以重置 sleeping 对 Infinite/Finite 两种都正确。
@@ -123,7 +123,7 @@ export class VFXSpawnerSingleBurst extends VFXSpawnerTask {
 
         this.sleeping = true;
         if (this.countFromLoopIndex) {
-            // Unity Modulo(loopIndex, N) → count 语义：loop 0 spawn 0 颗，loop 1 spawn 1 颗，... loop N-1 spawn N-1 颗，loop N 又 0 颗循环。
+            // Modulo(loopIndex, N) → count 语义：loop 0 spawn 0 颗，loop 1 spawn 1 颗，... loop N-1 spawn N-1 颗，loop N 又 0 颗循环。
             // 之前写 `idx + 1` 让 loop 0 就 spawn 1 颗 texIndex=0 → 数字 atlas 起点错位（看到 "0" 而非 "1"）。
             const idx = this.countModulo > 0 ? (spawnerState.loopIndex % this.countModulo) : spawnerState.loopIndex;
             spawnerState.spawnCount += idx;
@@ -212,7 +212,7 @@ export class VFXSpawnerCustomWrapper extends VFXSpawnerTask {
     release(): void { }
 }
 
-// 写 spawn event attribute（对齐 Unity VFXSpawnerSetAttribute）
+// 写 spawn event attribute（对齐 VFXSpawnerSetAttribute）
 // 每帧把固定值或 loopIndex(%N) 写入 spawnerState.eventAttribute，
 // 让粒子 Initialize 阶段 setAttribute(attr, source=Source) 能读到。
 // 这是 Strip / GPU Event 链上 stripIndex / texIndex / lifetime 等正确分配的关键
@@ -222,7 +222,7 @@ export class VFXSpawnerSetEventAttribute extends VFXSpawnerTask {
     value: [number, number, number, number] = [0, 0, 0, 0];
     fromLoopIndex: boolean = false;
     loopIndexModulo: number = 0;
-    // Unity SpawnContext 模式：lifetime ← Add(spawnState.loopDuration, spawnState.delayAfterLoop)
+    // SpawnContext 模式：lifetime ← Add(spawnState.loopDuration, spawnState.delayAfterLoop)
     // runtime 时用 spawnerState.loopDuration + delayAfterLoop 当 lifetime 值
     fromSpawnStateLoop: boolean = false;
 

--- a/src/layaAir/laya/vfx/systems/VFXStaticMeshSystem.ts
+++ b/src/layaAir/laya/vfx/systems/VFXStaticMeshSystem.ts
@@ -12,7 +12,7 @@ import { Material } from "../../resource/Material";
 import { Laya } from "../../../Laya";
 
 /**
- * Unity VFXStaticMeshOutput 对齐：渲染单个 mesh，不跑 particle simulation
+ * VFXStaticMeshOutput 对齐：渲染单个 mesh，不跑 particle simulation
  * - 在 owner（VisualEffect 节点）下创建子 Sprite3D + MeshFilter + MeshRenderer
  * - 子节点 transform 默认 identity（mesh 跟随 owner 世界 transform）
  * - material 由 .vfx props 提供 UUID，runtime 异步加载；未指定 / 加载失败 fallback unlit material


### PR DESCRIPTION
## 内容

VFX 引擎源码同步（与 IDE 插件 bundle 对齐的根因修复）：

- **HDR 渐变半精度直通**：VFXAssetParser/VisualEffect 渐变烘焙改 R16G16B16A16 半精度浮点，不再 max-normalize（原实现保色度丢强度，HDR 高强度色在 additive 下被低强度色压制）；writeRenderData 端配套 clamp(0,64) 直通
- **组件 initialEvent 修复**：processInitialize 重解析事件 ID（此前组件上改 initialEvent 是 no-op，入队的是资产设置时捕获的旧 ID）；空值回退 asset.initialEventName
- **mesh define 按材质实例管理**：移除节点级 mesh 能力 define 并集，改由 _syncMeshAttrDefines 按系统材质实例精确同步——多 mesh 能力不同时（实心 mesh 有色/切线 + 内置 quad 无），节点级并集会让 shader 变体强制引用缺失顶点槽，WebGPU CreateRenderPipeline 失败
- BlueprintPixelVertexVFX.glsl：v_TexIndex/v_NormalizedAge 声明移出 VFX_INSTANCED 守卫（strip 变体需要）

## 验证

UNI VFX 包 Buff Red / Detonation Dark / Heal Green 整合特效逐帧对照 Unity 渲染结果确认。

🤖 Generated with [Claude Code](https://claude.com/claude-code)