### PR TITLE
fix(forum-55313): 修复斜体文本宽度测量缺少italic导致被截断

### DIFF
--- a/src/layaAir/laya/display/Text.ts
+++ b/src/layaAir/laya/display/Text.ts
@@ -1163,7 +1163,7 @@ export class Text extends Sprite {
                 charWidth = bfont.getMaxWidth(fontSize);
                 charHeight = bfont.getMaxHeight(fontSize);
             } else {
-                Browser.context.font = ctxFont = (style.bold ? "bold " : "") + fontSize + "px " + this._realFont;
+                Browser.context.font = ctxFont = (style.italic ? "italic " : "") + (style.bold ? "bold " : "") + fontSize + "px " + this._realFont;
                 charWidth = fontSize;
                 charHeight = textRender.getFontHeight(this._realFont, fontSize, style.bold);
             }


### PR DESCRIPTION
修复论坛反馈 https://ask.layaair.com/d/55313