### PR TITLE
fix(forum-55254): fix Spine3D SPINE_RB shader compile error - vec3 to vec4 mismatch

### DIFF
--- a/src/layaAir/laya/spine/shader/files/SpineVertexCommon.glsl
+++ b/src/layaAir/laya/spine/shader/files/SpineVertexCommon.glsl
@@ -86,7 +86,7 @@ vec4 getSpinePos(){
         
         #ifdef SPINE_RB
             vec2 pos;
-            transfrom(a_position,u_sBone0,u_sBone1,pos);
+            transfrom(a_position,vec4(u_sBone0,0.0),vec4(u_sBone1,0.0),pos);
             return vec4(pos,0.,1.);
             // return getBonePos(a_BoneId,1.0,a_position);
         #endif


### PR DESCRIPTION
修复论坛反馈 https://ask.layaair.com/d/55254