### PR TITLE
fix(forum-55292): TrailFilter crash when camera is null during bounds update

### DIFF
--- a/src/layaAir/laya/trail/trail3D/TrailFilter.ts
+++ b/src/layaAir/laya/trail/trail3D/TrailFilter.ts
@@ -88,6 +88,8 @@ export class TrailFilter extends TrailBaseFilter {
 				var pointAtoBVector3: Vector3 = TrailGeometry._tempVector35;
 				switch (this.alignment) {
 					case TrailAlignment.View:
+						if (!state.camera)
+							return;
 						var cameraMatrix = state.camera.viewMatrix;
 						Vector3.transformCoordinate(curPos, cameraMatrix, TrailGeometry._tempVector33);
 						Vector3.transformCoordinate(this._trialGeometry._lastFixedVertexPosition, cameraMatrix, TrailGeometry._tempVector34);


### PR DESCRIPTION
修复论坛反馈 https://ask.layaair.com/d/55292