### PR TITLE
fix: 修正构建产物的 SourceMap 丢失 TypeScript 源码信息的问题

### DIFF
--- a/src/layaAir/tsconfig.json
+++ b/src/layaAir/tsconfig.json
@@ -7,6 +7,7 @@
             "es2019",
             "dom"
         ],
+        "sourceMap": true,
         "composite": true,
         "stripInternal": true,
         "removeComments": false,


### PR DESCRIPTION
如题