### PR TITLE
fix: WebReflectionProbe destroy后访问空shaderData导致崩溃

### DIFF
--- a/src/layaAir/laya/RenderDriver/RenderModuleData/WebModuleData/3D/WebBaseRenderNode.ts
+++ b/src/layaAir/laya/RenderDriver/RenderModuleData/WebModuleData/3D/WebBaseRenderNode.ts
@@ -314,6 +314,8 @@ export class WebBaseRenderNode implements IBaseRenderNode {
     _applyReflection() {
         if (!this.probeReflection || this.reflectionMode == ReflectionProbeMode.off)
             return;
+        if (!this.probeReflection.shaderData)
+            return;
         if (this.probeReflection.needUpdate()) {
             this.probeReflection.applyRenderData();
         }

--- a/src/layaAir/laya/RenderDriver/RenderModuleData/WebModuleData/3D/WebReflectionProb.ts
+++ b/src/layaAir/laya/RenderDriver/RenderModuleData/WebModuleData/3D/WebReflectionProb.ts
@@ -103,6 +103,9 @@ export class WebReflectionProbe implements IReflectionProbeData {
     }
     /**@internal */
     applyRenderData(): void {
+        if (!this.shaderData)
+            return;
+
         this._updateMaskFlag = this.updateMark;
 
         let data = this.shaderData;

--- a/src/layaAir/laya/d3/component/Volume/reflectionProbe/ReflectionProbe.ts
+++ b/src/layaAir/laya/d3/component/Volume/reflectionProbe/ReflectionProbe.ts
@@ -380,6 +380,10 @@ export class ReflectionProbe extends Volume {
      * @internal
      */
     protected _onDestroy() {
+        if (this._isScene) {
+            console.warn("Scene reflection probe can not be destroyed directly.");
+            return;
+        }
         this.iblTex = null;
         this._dataModule.destroy();
     }

--- a/src/layaAir/laya/d3/core/render/BaseRender.ts
+++ b/src/layaAir/laya/d3/core/render/BaseRender.ts
@@ -821,6 +821,8 @@ export class BaseRender extends Component {
     _setUnBelongScene() {
         this._statRemove();
         this._scene._volumeManager.removeMotionObject(this);
+        this.probReflection = null;
+        this.lightProbe = null;
         let batch = this._batchRender;
         //this._batchRender && this._batchRender._removeOneRender(this);
         this._batchRender = batch;

--- a/src/layaAir/platforms/minigame/MgBrowserAdapter.ts
+++ b/src/layaAir/platforms/minigame/MgBrowserAdapter.ts
@@ -45,12 +45,14 @@ export class MgBrowserAdapter extends BrowserAdapter {
             this.webSocketClass = null;
 
         let platform: string = "";
+        let systemName: string = "";
         let systemInfo = PAL.hasAPI("getSystemInfoSync") ? PAL.g.getSystemInfoSync() : null;
 
         if (systemInfo) {
             this._pixelRatio = systemInfo.pixelRatio;
             this._orientation = systemInfo.deviceOrientation === "landscape" ? "landscape-primary" : "portrait-primary";
             platform = systemInfo.platform || "";
+            systemName = systemInfo.system || "";
         }
         else if (PAL.hasAPI("getWindowInfo")) {
             let windowInfo = PAL.g.getWindowInfo();
@@ -58,6 +60,7 @@ export class MgBrowserAdapter extends BrowserAdapter {
             if (PAL.g.getDeviceInfo) {
                 let deviceInfo = PAL.g.getDeviceInfo();
                 platform = deviceInfo.platform || "";
+                systemName = deviceInfo.system || "";
             }
         }
 
@@ -65,7 +68,7 @@ export class MgBrowserAdapter extends BrowserAdapter {
             this._pixelRatio = window.devicePixelRatio;
         }
 
-        this.setPlatform("", platform);
+        this.setPlatform("", this.normalizePlatform(platform, systemName));
 
         systemInfo = systemInfo || <any>{};
 
@@ -306,6 +309,30 @@ export class MgBrowserAdapter extends BrowserAdapter {
             if (PAL.g.offUnhandledRejection)
                 PAL.g.offUnhandledRejection(func);
         }
+    }
+
+    // Some mini-game platforms, such as Xiaomi, may return host version strings in platform.
+    protected normalizePlatform(platform: string, system: string): string {
+        let p = (platform || "").toLowerCase();
+
+        if (p.indexOf("openharmony") !== -1)
+            return "ohos";
+        if (p.indexOf("iphone") !== -1 || p.indexOf("ipad") !== -1)
+            return "ios";
+
+        if (p.indexOf("ios") !== -1 || p.indexOf("android") !== -1 || p.indexOf("ohos") !== -1
+            || p.indexOf("mac") !== -1 || p.indexOf("win") !== -1 || p === "devtools")
+            return platform;
+
+        let s = (system || "").toLowerCase();
+        if (s.indexOf("android") !== -1 || s.indexOf("adr") !== -1)
+            return "android";
+        if (s.indexOf("ios") !== -1 || s.indexOf("iphone") !== -1 || s.indexOf("ipad") !== -1)
+            return "ios";
+        if (s.indexOf("ohos") !== -1 || s.indexOf("openharmony") !== -1)
+            return "ohos";
+
+        return platform;
     }
 
     alert(msg: string): void {

--- a/src/layaAir/platforms/taobao/index.ts
+++ b/src/layaAir/platforms/taobao/index.ts
@@ -108,6 +108,8 @@ class TbDownloader extends MgDownloader {
 
 MgBrowserAdapter.beforeInit = function () {
     PAL.g = (window as any).my;
+    if (!PAL.g.loadSubpackage && PAL.g.loadSubPackage)
+        PAL.g.loadSubpackage = PAL.g.loadSubPackage;
     // 淘宝高性能字段是 my.env.isHighPerformanceMode（不带 iOS，安卓也可能 true），存到通用的 Browser.isIOSHighPerformanceMode
     Browser.isIOSHighPerformanceMode = !!((PAL.g as any)?.env?.isHighPerformanceMode);
     if (!Browser.isIOSHighPerformanceMode) {


### PR DESCRIPTION
- WebReflectionProb.applyRenderData: shaderData为null时提前返回，防止NPE
- WebBaseRenderNode._applyReflection: 调用needUpdate前检测probeReflection.shaderData，死引用时跳过
- ReflectionProbe._onDestroy: 场景级探针不允许直接销毁，打印警告并返回