### PR TITLE
fix: 修正缩放容器内的画布输入坐标

### DIFF
--- a/src/layaAir/laya/events/InputManager.ts
+++ b/src/layaAir/laya/events/InputManager.ts
@@ -284,7 +284,7 @@ export class InputManager {
         //console.log("handleMouse", type);
         let touch: TouchInfo = this._mouseTouch;
 
-        _tempPoint.setTo(ev.pageX || ev.clientX, ev.pageY || ev.clientY);
+        this.getCanvasPoint(ev.clientX, ev.clientY, _tempPoint);
         this._stage._canvasTransform.invertTransformPoint(_tempPoint);
         InputManager.mouseX = _tempPoint.x;
         InputManager.mouseY = _tempPoint.y;
@@ -410,7 +410,7 @@ export class InputManager {
                 && this._touches[0].touchId != uTouch.identifier)
                 continue;
 
-            _tempPoint.setTo(uTouch.pageX, uTouch.pageY);
+            this.getCanvasPoint(uTouch.clientX, uTouch.clientY, _tempPoint);
             this._stage._canvasTransform.invertTransformPoint(_tempPoint);
             InputManager.mouseX = _tempPoint.x;
             InputManager.mouseY = _tempPoint.y;
@@ -516,6 +516,20 @@ export class InputManager {
         this._touches.push(touch);
 
         return touch;
+    }
+
+    private getCanvasPoint(clientX: number, clientY: number, out: Point): Point {
+        let target = Browser.mainCanvas.source.parentElement;
+        if (!target)
+            return out.setTo(clientX, clientY);
+
+        let rect = target.getBoundingClientRect();
+        if (!rect.width || !rect.height)
+            return out.setTo(clientX, clientY);
+
+        let scaleX = target.clientWidth / rect.width;
+        let scaleY = target.clientHeight / rect.height;
+        return out.setTo((clientX - rect.left) * scaleX, (clientY - rect.top) * scaleY);
     }
 
     /**


### PR DESCRIPTION
## 改动说明

修正 LayaAir canvas 放在被 CSS 缩放或偏移的容器中时，鼠标和触摸输入坐标可能偏移的问题。

此前 `InputManager` 直接使用原生事件的页面/视口坐标，再进入现有的 `_canvasTransform` 流程。当 canvas 外层容器被移动或缩放时，例如开发工具内嵌预览面板，命中测试
坐标会和实际显示位置不一致。

本次改动会先把原生 `clientX/clientY` 换算到主画布父容器的本地坐标系，再继续沿用现有的 `_canvasTransform` 和 `clientScale` 处理流程。

## 改动内容

- 鼠标和触摸输入统一使用 `clientX/clientY`
- 基于主画布父容器的 `getBoundingClientRect()` 换算输入坐标
- 保持现有 Stage transform、缩放和事件派发流程不变

## 测试

- 已通过 LayaAir 引擎构建验证
- 已在实际项目中测试使用
<img width="3046" height="1558" alt="image" src="https://github.com/user-attachments/assets/8107897f-d796-42b0-9bf5-9af24d6bc7c8" />
