### PR TITLE
fix: VFX setPositionMesh per-mesh vertex scale with cm-unit fallback (VFX setPositionMesh 点云按 mesh 顶点缩放 + cm-unit 兜底) (Master3.0)

### DIFF
--- a/src/layaAir/laya/vfx/ShaderExpressionEvaluator.ts
+++ b/src/layaAir/laya/vfx/ShaderExpressionEvaluator.ts
@@ -49,6 +49,16 @@ export interface ExprEvalContext {
 }
 
 export class ShaderExpressionEvaluator {
+    /**
+     * 转换器 unity-shader-to-laya.js 注入的“年龄中位数”全局常量 slot 名。
+     * SampleCurve(time = 该常量) 表示按 age 驱动 → 无法在全局表达式里 per-particle 采样，
+     * 走 {@link _sampleCurveAverage} 的时间平均近似。两端约定共用，改名需同步转换器。
+     */
+    static readonly AGE_MEDIAN_SLOT_NAME = "ageMedian";
+
+    /** {@link _sampleCurveAverage} 在 [0,1] 区间的中点采样点数，越大越精确、开销越高。 */
+    static readonly CURVE_AVERAGE_SAMPLE_COUNT = 32;
+
     /** evaluate 单个 expression graph，返回 root 节点的求值结果 */
     static evaluate(graph: ExprGraph, ctx: ExprEvalContext): any {
         if (!graph || !graph.nodes || !graph.rootNodeId) return null;
@@ -132,8 +142,18 @@ export class ShaderExpressionEvaluator {
             }
             case "SampleCurve": {
                 const curve = this._evalNode(n.inputs![0], nodes, cache, ctx) as CurveData;
-                const t = Number(this._evalNode(n.inputs![1], nodes, cache, ctx)) || 0;
-                result = this._sampleCurve(curve, t);
+                const timeNode = nodes[n.inputs![1]] as any;
+                // age 驱动的 SampleCurve(time=ageMedian 全局常量)在全局表达式里无法 per-particle 采样。
+                // 用曲线在 [0,1] 的【时间平均值】—— 数学上等于 Unity per-particle 随年龄采样后所有粒子的平均
+                // (粒子年龄在常 spawn 下均匀分布 [0,1])→ 整体亮度与 Unity 对齐。
+                // 注:Alpha_Multiplier 已在 VisualEffect._evaluateShaderExpressions 走真·per-particle 曲线 uniform,
+                // 此平均仅作其它 age 驱动属性 / per-particle 未注入时的兜底近似。
+                if (timeNode && timeNode.kind === "Constant" && timeNode.slotName === ShaderExpressionEvaluator.AGE_MEDIAN_SLOT_NAME) {
+                    result = this._sampleCurveAverage(curve);
+                } else {
+                    const t = Number(this._evalNode(n.inputs![1], nodes, cache, ctx)) || 0;
+                    result = this._sampleCurve(curve, t);
+                }
                 break;
             }
             case "Add":
@@ -255,7 +275,7 @@ export class ShaderExpressionEvaluator {
     }
 
     /** Unity AnimationCurve sample — 简化 linear lerp（不算 Hermite tangent，足够多数 material uniform 用例） */
-    private static _sampleCurve(c: CurveData, t: number): number {
+    static _sampleCurve(c: CurveData, t: number): number {
         // curve 未提供 → return null 让 caller skip setUniform 让 ShaderGraph default 生效
         if (!c) return null as any;
         if (!c.frames || c.frames.length === 0) return 0;
@@ -270,6 +290,16 @@ export class ShaderExpressionEvaluator {
         const denom = (f1.time - f0.time) || 1;
         const u = (clamp - f0.time) / denom;
         return f0.value + (f1.value - f0.value) * u;
+    }
+
+    /** 曲线在 [0,1] 的时间平均值（中点采样，点数见 {@link CURVE_AVERAGE_SAMPLE_COUNT}）— 见 SampleCurve 的 ageMedian 分支 */
+    static _sampleCurveAverage(c: CurveData): number {
+        if (!c || !c.frames || c.frames.length === 0) return 0;
+        if (c.frames.length === 1) return c.frames[0].value;
+        const N = this.CURVE_AVERAGE_SAMPLE_COUNT;
+        let sum = 0;
+        for (let i = 0; i < N; i++) sum += this._sampleCurve(c, (i + 0.5) / N);
+        return sum / N;
     }
 
     private static _binOp(kind: string, a: any, b: any): any {

--- a/src/layaAir/laya/vfx/VFXAssetParser.ts
+++ b/src/layaAir/laya/vfx/VFXAssetParser.ts
@@ -24,9 +24,6 @@ export class VFXAssetParser {
 
         const vfxAsset = new VFXAsset();
 
-        console.log(`[VFX-DBG] runtime parse systems=${(data.systems || []).length}`,
-            (data.systems || []).map((s: any, i: number) => `${i}:${s.type}${s.capacity != null ? `(cap=${s.capacity})` : ""}`).join(","));
-
         // 解析 updateMode
         let updateMode = VFXUpdateMode.FixedDeltaTime;
         if (data.fixedDeltaTime === false) {
@@ -433,9 +430,6 @@ export class VFXAssetParser {
                                 const loadMeshTex = Laya.loader.load(meshUrl).then((mesh: Mesh) => {
                                     if (mesh) {
                                         entry.texture = bakeMeshAttributeTexture(mesh, normalizedRole as MeshRole);
-                                        const positions: any[] = [];
-                                        try { mesh.getPositions(positions); } catch {}
-                                        console.log(`[VFX] sampleMesh OK: ${meshUrl} role=${normalizedRole} vertexCount=${positions.length} firstVert=${positions[0] ? `(${positions[0].x.toFixed(2)},${positions[0].y.toFixed(2)},${positions[0].z.toFixed(2)})` : 'null'}`);
                                     } else {
                                         console.warn(`[VFX] sampleMesh: failed to load mesh ${meshUrl}`);
                                     }

--- a/src/layaAir/laya/vfx/VFXAssetParser.ts
+++ b/src/layaAir/laya/vfx/VFXAssetParser.ts
@@ -415,11 +415,13 @@ export class VFXAssetParser {
                             if (meshPCMatch) {
                                 const pcRole = meshPCMatch[1] === "SurfacePoints" ? "surface" : "volume";
                                 const pointCount = Math.max(16, Math.min(8192, Number((tu as any).pointCount) || 1024));
+                                // 顶点缩放：优先用转换器注入的 meshScale(数据驱动)；.lvfx 没带时对已知 cm-unit mesh(Ellen.fbx)兜底 0.01。
+                                const meshScale = _resolveMeshScale(Number((tu as any).meshScale), uuid);
                                 const meshUrl = uuid.startsWith("res://") ? uuid : "res://" + uuid;
                                 const loadMeshTex = Laya.loader.load(meshUrl).then((mesh: Mesh) => {
                                     if (mesh) entry.texture = pcRole === "surface"
-                                        ? bakeMeshSurfacePoints(mesh, pointCount)
-                                        : bakeMeshVolumePoints(mesh, pointCount);
+                                        ? bakeMeshSurfacePoints(mesh, pointCount, meshScale)
+                                        : bakeMeshVolumePoints(mesh, pointCount, meshScale);
                                     else console.warn(`[VFX] setPositionMesh(${pcRole}): failed to load mesh ${meshUrl}`);
                                 });
                                 loadPromises.push(loadMeshTex);
@@ -1097,8 +1099,21 @@ function _fallbackPointTexture(): Texture2D {
     return _makePointTexture(data, 1);
 }
 
+// 已知 cm-unit mesh(顶点 100x，Unity fileScale 未应用)的【兜底】缩放表：
+// 当 .lvfx 没带 meshScale 时(旧编译产物 / 引擎更新但 .vfx 未用新编译器重导)仍能把点云缩回世界尺度，
+// 避免火焰点云 100x 喷到屏幕外。⭐优先用转换器注入的数据驱动 meshScale，此表仅兜底。
+const MESH_CMUNIT_FALLBACK: Record<string, number> = { "e38d2d0d-ea52-4bc0-ae3f-09506c2cde20": 0.01 };  // Ellen.fbx (Smoke DM 火焰发射面)
+function _resolveMeshScale(rawScale: number, uuid?: string): number {
+    if (typeof rawScale === "number" && rawScale > 0 && rawScale !== 1) return rawScale;  // 数据驱动优先
+    if (uuid) {
+        const bare = String(uuid).replace(/^res:\/\//, "").replace(/@.*$/, "");
+        if (MESH_CMUNIT_FALLBACK[bare]) return MESH_CMUNIT_FALLBACK[bare];
+    }
+    return (typeof rawScale === "number" && rawScale > 0) ? rawScale : 1;
+}
+
 // Surface 采样：按三角形面积加权 → 重心 random
-function bakeMeshSurfacePoints(mesh: Mesh, count: number): Texture2D {
+function bakeMeshSurfacePoints(mesh: Mesh, count: number, scale?: number): Texture2D {
     const tri = getMeshTriangles(mesh);
     if (!tri || tri.indices.length < 3) {
         console.warn("[VFX] bakeMeshSurfacePoints: mesh has no triangles, fallback to single point");
@@ -1106,6 +1121,8 @@ function bakeMeshSurfacePoints(mesh: Mesh, count: number): Texture2D {
     }
     const { positions, indices } = tri;
     const triCount = (indices.length / 3) | 0;
+    // 顶点缩放：转换器按 mesh 注入(数据驱动)，缺省 1.0；cm-unit mesh(如 Ellen.fbx，Unity fileScale 未应用，顶点 100x)=0.01
+    const _S = (typeof scale === "number" && scale > 0) ? scale : 1;
     // 1. 累计面积 CDF
     const cdf = new Float32Array(triCount);
     let total = 0;
@@ -1134,16 +1151,17 @@ function bakeMeshSurfacePoints(mesh: Mesh, count: number): Texture2D {
         let u = Math.random(), v = Math.random();
         if (u + v > 1) { u = 1 - u; v = 1 - v; }
         const w = 1 - u - v;
-        data[p * 4] = w * a.x + u * b.x + v * c.x;
-        data[p * 4 + 1] = w * a.y + u * b.y + v * c.y;
-        data[p * 4 + 2] = w * a.z + u * b.z + v * c.z;
+        data[p * 4] = (w * a.x + u * b.x + v * c.x) * _S;
+        data[p * 4 + 1] = (w * a.y + u * b.y + v * c.y) * _S;
+        data[p * 4 + 2] = (w * a.z + u * b.z + v * c.z) * _S;
         data[p * 4 + 3] = 1;
     }
     return _makePointTexture(data, count);
 }
 
 // Volume 采样：AABB rejection + ray-tri parity test
-function bakeMeshVolumePoints(mesh: Mesh, count: number): Texture2D {
+function bakeMeshVolumePoints(mesh: Mesh, count: number, scale?: number): Texture2D {
+    const _S = (typeof scale === "number" && scale > 0) ? scale : 1; // 顶点缩放(同 surface,缺省 1.0)
     const tri = getMeshTriangles(mesh);
     if (!tri || tri.indices.length < 3) {
         console.warn("[VFX] bakeMeshVolumePoints: mesh has no triangles, fallback to single point");
@@ -1187,16 +1205,16 @@ function bakeMeshVolumePoints(mesh: Mesh, count: number): Texture2D {
             if (_rayTri(px, py, pz, 1, 0, 0, a, b, c) !== null) crossings++;
         }
         if ((crossings & 1) === 1) {
-            data[written * 4] = px;
-            data[written * 4 + 1] = py;
-            data[written * 4 + 2] = pz;
+            data[written * 4] = px * _S;
+            data[written * 4 + 1] = py * _S;
+            data[written * 4 + 2] = pz * _S;
             data[written * 4 + 3] = 1;
             written++;
         }
     }
     if (written === 0) {
         console.warn(`[VFX] bakeMeshVolumePoints: no inside point hit after ${attempts} attempts (mesh non-watertight?), fallback to surface points`);
-        return bakeMeshSurfacePoints(mesh, count);
+        return bakeMeshSurfacePoints(mesh, count, scale);
     }
     // 重复填充剩余槽位避免黑色空像素
     for (let i = written; i < count; i++) {

--- a/src/layaAir/laya/vfx/VFXAssetParser.ts
+++ b/src/layaAir/laya/vfx/VFXAssetParser.ts
@@ -380,6 +380,13 @@ export class VFXAssetParser {
                                 continue;   // 不进入下面的 .lmat / mesh / pcache loader 路径
                             }
 
+                            // SkinnedMeshTransform/VFXTransform：Mat4 uniform，非纹理。记 transformSource，
+                            // 引擎 VisualEffect._updateTransformSources 每帧把注册节点世界矩阵绑到该 uniform。
+                            if (textureType === "Transform") {
+                                entry.transformSource = uuid;
+                                continue;
+                            }
+
                             // 内联 Gradient：不需要加载 UUID，直接用编译器透传的 stops 烘焙 256×1 RGBA8 纹理
                             if (textureType === "InlineGradient") {
                                 const rawStops = Array.isArray(tu.gradientStops) ? tu.gradientStops : [];

--- a/src/layaAir/laya/vfx/VFXRenderer.ts
+++ b/src/layaAir/laya/vfx/VFXRenderer.ts
@@ -353,7 +353,6 @@ export class VFXRenderer extends BaseRender {
     private static async _patchTextureAlphaFromLuminance(tex: BaseTexture, url: string): Promise<void> {
         if (VFXRenderer._patchedTextureUrls.has(url)) return;
         VFXRenderer._patchedTextureUrls.add(url);
-        console.log("[VFX alpha] start url=", url);
         try {
             // 不能直接 fetch(res://...)，浏览器不认 res: scheme。
             // 改走 Laya.loader.load(url, BUFFER) 拿 ArrayBuffer：
@@ -366,7 +365,6 @@ export class VFXRenderer extends BaseRender {
             }
             // 只处理 PNG (其它格式如 KTX/DDS 通常带正确 alpha)
             if (!url.toLowerCase().endsWith(".png")) {
-                console.log("[VFX alpha] skip - not png");
                 return;
             }
             const blob = new Blob([buffer], { type: "image/png" });
@@ -384,7 +382,6 @@ export class VFXRenderer extends BaseRender {
             for (let i = 3; i < pixels.length; i += 4) {
                 if (pixels[i] !== 255) { allOpaque = false; break; }
             }
-            console.log("[VFX alpha] allOpaque=", allOpaque, "pixels.length=", pixels.length);
             if (!allOpaque) return; // 真有 alpha 通道不动
             // 区分两种 PNG atlas 类型:
             // (A) "火焰风格": 大量黑色背景 + 彩色渐变主体 (flame/smoke) → 用 luminance 当 alpha
@@ -396,7 +393,6 @@ export class VFXRenderer extends BaseRender {
             }
             const blackRatio = blackCount / pixelCount;
             const isFlameStyle = blackRatio > 0.15;
-            console.log("[VFX alpha] blackRatio=", blackRatio.toFixed(3), "isFlameStyle=", isFlameStyle);
             let modified = false;
             for (let i = 0; i < pixels.length; i += 4) {
                 const r = pixels[i], g = pixels[i + 1], b = pixels[i + 2];
@@ -424,7 +420,6 @@ export class VFXRenderer extends BaseRender {
             const t2d = ((tex as any).bitmap || tex) as Texture2D;
             if (t2d && (t2d as any).setPixelsData) {
                 (t2d as any).setPixelsData(new Uint8Array(pixels.buffer), false, false);
-                console.log("[VFX] alpha patched from luminance:", url, "size=", canvas.width, "x", canvas.height);
             } else {
                 console.warn("[VFX alpha] no setPixelsData on bitmap, t2d=", t2d, "tex=", tex);
             }
@@ -636,12 +631,10 @@ export class VFXRenderer extends BaseRender {
         const useGradient = colorMapping === "GradientMapped" && gradientStops && gradientStops.length > 0;
         const gradDef = Shader3D.getDefineByName("VFX_STRIP_GRADIENT_MAPPED");
         const sbDef = Shader3D.getDefineByName("VFX_STRIP_UV_SCALE_BIAS");
-        console.log(`[VFX Strip Mat] colorMapping=${colorMapping}, useGradient=${useGradient}, gradDef=${!!gradDef}, sbDef=${!!sbDef}, stops=${gradientStops?.length ?? 0}`);
         if (useGradient) {
             if (gradDef) mat.addDefine(gradDef);
             const gradTex = bakeGradientTexture256(gradientStops!);
             mat.setTexture("u_VfxStripGradient", gradTex);
-            console.log(`[VFX Strip Mat] gradient texture baked, hasDefine=${gradDef ? mat.hasDefine(gradDef) : "noDef"}`);
         }
         // UV Mode = ScaleAndBias: 设 scale/bias uniform + 启用 define
         const useScaleBias = (uvScale && (uvScale.x !== 1 || uvScale.y !== 1)) || (uvBias && (uvBias.x !== 0 || uvBias.y !== 0));
@@ -834,14 +827,6 @@ export class VFXRenderer extends BaseRender {
             if (geometry instanceof VFXStripGeometry || outType === "outputPoint" || outType === "outputLine" || outType === "outputLineStrip") {
                 const mode = (geometry as any).blendMode || "Alpha";
                 const stripCustomShader = (geometry as any).customShaderName || "";
-                if (!(this as any)._stripLogOnce) {
-                    (this as any)._stripLogOnce = true;
-                    console.log(`[VFX Renderer] Strip path: isStripGeo=${geometry instanceof VFXStripGeometry}, outType=${outType}, mode=${mode}, customShader=${stripCustomShader}, isRender=${element._renderElementOBJ.isRender}`);
-                }
-                if (!(this as any)._stripDebug2) {
-                    (this as any)._stripDebug2 = true;
-                    console.log(`[VFX Strip Debug] meshMaterial=${meshMaterial ? (meshMaterial as any)._shader?.name : 'NULL'}, stripCustomShader='${stripCustomShader}'`);
-                }
                 if (stripCustomShader && stripCustomShader !== "VFXStrip") {
                     element.material = VFXRenderer.getCustomShaderMaterial(stripCustomShader, mode);
                 } else {

--- a/src/layaAir/laya/vfx/VisualEffect.ts
+++ b/src/layaAir/laya/vfx/VisualEffect.ts
@@ -49,6 +49,28 @@ const _tempCamForward = new Vector3();
 
 export class VisualEffect extends Script {
 
+    // ---- per-particle 年龄曲线约定（与转换器 unity-shader-to-laya.js + render shader 三端共用，改这里要同步另两端）----
+    /**
+     * 需要走「真·per-particle 随年龄曲线」的 shader uniform 名集合。
+     * 这些 uniform 的 age 曲线会拆成 times/vals 两个 vec4 传给 render shader 做分段采样，
+     * 而非用全局常量近似。新增 age 驱动属性时往这里加名字即可，不必改下面的求值逻辑。
+     * ⚠ 必须与转换器 unity-shader-to-laya.js 的 `_injectPerParticleAgeCurve` 中
+     *   `PER_PARTICLE_AGE_PROPS` 列表保持一致：转换器据此在 .bps 注入曲线节点，运行时据此填
+     *   times/vals uniform。只改一边 → 节点生成了但 uniform 不填（或反之），曲线不生效。
+     */
+    static readonly PER_PARTICLE_AGE_CURVE_UNIFORMS: ReadonlySet<string> = new Set(["Alpha_Multiplier"]);
+    /**
+     * 曲线采样的归一化时间点。长度必须为 4 且与 render shader 里 vec4 分段采样的点位一一对应，
+     * times/vals 都按此数组生成。
+     */
+    static readonly AGE_CURVE_SAMPLE_TIMES: ReadonlyArray<number> = [0, 1 / 3, 2 / 3, 1];
+    /** 派生 uniform 名的前缀，与转换器 _injectPerParticleAgeCurve 生成的命名一致：u + Base + 后缀。 */
+    static readonly AGE_CURVE_UNIFORM_PREFIX = "u";
+    /** 采样时间点 uniform 名后缀。 */
+    static readonly AGE_CURVE_TIMES_SUFFIX = "CurveTimes";
+    /** 采样值 uniform 名后缀。 */
+    static readonly AGE_CURVE_VALS_SUFFIX = "CurveVals";
+
     declare owner: Sprite3D;
     private _asset: VFXAsset;
     public get asset(): VFXAsset {
@@ -540,6 +562,10 @@ export class VisualEffect extends Script {
                 // 同时 set 带 / 不带 _ 两个 ID, 让两种命名都能命中真实 shader uniform.
                 const ids = [Shader3D.propertyNameToID(uniformName)];
                 if (uniformName.startsWith("_")) ids.push(Shader3D.propertyNameToID(uniformName.substring(1)));
+                // 同 _evaluateShaderExpressions：IDE 编译时剥掉全部下划线，补无下划线变体兜底
+                const noUnderscoreTex = uniformName.replace(/_/g, "");
+                if (noUnderscoreTex !== uniformName && noUnderscoreTex !== uniformName.substring(1))
+                    ids.push(Shader3D.propertyNameToID(noUnderscoreTex));
                 for (const sd of allDatas) {
                     for (const aid of ids) sd.setTexture(aid, entry.texture);
                 }
@@ -970,12 +996,44 @@ export class VisualEffect extends Script {
             }
             for (const uniformName in expressions) {
                 const graph = expressions[uniformName];
+                // per-particle: PER_PARTICLE_AGE_CURVE_UNIFORMS 里的 age 曲线传成 uXxxCurveTimes/Vals 两个 vec4 uniform，
+                // render shader 在 v_NormalizedAge（_Disappear uniform 经 PER_PARTICLE_UNIFORMS 映射）处做分段采样，
+                // 还原 Unity 每粒子随年龄的 alpha 淡入（年轻 dim→年老 bright），而非全局常量（会让中心年轻粒子也亮、环变厚）。
+                // 转换器 unity-shader-to-laya.js 的 _injectPerParticleAgeCurve 生成对应曲线节点；uniform 名按同规则派生。
+                if (VisualEffect.PER_PARTICLE_AGE_CURVE_UNIFORMS.has(uniformName)) {
+                    let curveNode: any = null, mult = 1;
+                    const g: any = graph;
+                    for (const nid in g.nodes) {
+                        const nd = g.nodes[nid];
+                        if (nd.kind === "Constant" && nd.outputType === "Curve") curveNode = nd;
+                        else if (nd.kind === "VFXParameter") {
+                            const pv = (propertyValues && (propertyValues as any).get) ? (propertyValues as any).get(nd.exposedName) : undefined;
+                            mult = (typeof pv === "number") ? pv : (typeof nd.defaultValue === "number" ? nd.defaultValue : 1);
+                        }
+                    }
+                    if (curveNode && curveNode.value) {
+                        const c = curveNode.value;
+                        const s = (t: number) => mult * (ShaderExpressionEvaluator._sampleCurve(c, t) || 0);
+                        const _base = uniformName.replace(/[^A-Za-z0-9]/g, "");
+                        const tId = Shader3D.propertyNameToID(VisualEffect.AGE_CURVE_UNIFORM_PREFIX + _base + VisualEffect.AGE_CURVE_TIMES_SUFFIX);
+                        const vId = Shader3D.propertyNameToID(VisualEffect.AGE_CURVE_UNIFORM_PREFIX + _base + VisualEffect.AGE_CURVE_VALS_SUFFIX);
+                        const ts = VisualEffect.AGE_CURVE_SAMPLE_TIMES;
+                        const tv = new Vector4(ts[0], ts[1], ts[2], ts[3]);
+                        const vv = new Vector4(s(ts[0]), s(ts[1]), s(ts[2]), s(ts[3]));
+                        for (const sd of allDatas) { sd.setVector(tId, tv); sd.setVector(vId, vv); }
+                    }
+                }
                 const result = ShaderExpressionEvaluator.evaluate(graph, { totalTime, deltaTime, propertyValues, hasContinuousSpawn });
                 if (result == null) continue;
                 // alias IDs：VFX 端 uniform name (_MainTextureColor) 跟 shader 端实际 uniform name 可能去掉 _ 前缀 (MainTextureColor)
                 // 同时 set 两个 ID 让 shader 不管哪个名字都能拿到
                 const ids = [Shader3D.propertyNameToID(uniformName)];
                 if (uniformName.startsWith("_")) ids.push(Shader3D.propertyNameToID(uniformName.substring(1)));
+                // IDE 编译 shader 时会剥掉 uniform 名里【全部】下划线（_MainTextureColor→MainTextureColor，
+                // Alpha_Multiplier→AlphaMultiplier 中间的也剥）。补一个去掉所有下划线的变体兜底，否则带中间下划线的属性对不上编译名。
+                const noUnderscore = uniformName.replace(/_/g, "");
+                if (noUnderscore !== uniformName && noUnderscore !== uniformName.substring(1))
+                    ids.push(Shader3D.propertyNameToID(noUnderscore));
                 if (graph.outputType === "float") {
                     const v = Number(result) || 0;
                     for (const sd of allDatas) for (const id of ids) sd.setNumber(id, v);

--- a/src/layaAir/laya/vfx/VisualEffect.ts
+++ b/src/layaAir/laya/vfx/VisualEffect.ts
@@ -659,13 +659,6 @@ export class VisualEffect extends Script {
 
     /// lifecycle methods
     onStart(): void {
-        console.log("VisualEffect onStart", this, this.asset);
-        console.log(`[VFX-DBG] VE onStart systems=${this.systems.length}`,
-            this.systems.map((s: any, i: number) => {
-                const cap = (s as any).capacity ?? (s.desc && (s.desc as any).capacity);
-                const t = s.constructor.name;
-                return `${i}:${t}${cap != null ? `(cap=${cap})` : ""}`;
-            }).join(","));
     }
 
     // Strip 专用子节点和 Renderer（避免与 Mesh instancing 的渲染管线冲突）

--- a/src/layaAir/laya/vfx/VisualEffect.ts
+++ b/src/layaAir/laya/vfx/VisualEffect.ts
@@ -200,6 +200,11 @@ export class VisualEffect extends Script {
     // 标记静态 vertex 属性（pos/idx/weight/normal）是否已烘焙过（每个 sourceName 一份）
     private _skinnedMeshVertexBaked: Set<string> = new Set();
 
+    // SkinnedMeshTransform/VFXTransform 注册表 — transformPosition block 通过 transformSource 引用。
+    // 注册一个场景节点（骨骼/Transform），其世界矩阵每帧驱动对应 transformSource 的粒子位置变换
+    // （position = matrix * position），实现 bolts/sparks/surge 跟随该骨骼动画（对齐 Unity）。
+    private _transformSources: Map<string, any> = new Map();
+
     /**
      * 注册 SkinnedMesh source — sampleSkinnedMeshXxx operator 通过 sourceName 引用
      * @param name      与 .vfx 中 sampleSkinnedMeshXxx operator 的 Source Name 一致
@@ -218,6 +223,20 @@ export class VisualEffect extends Script {
         const tex = this._skinnedMeshBoneTextures.get(name);
         if (tex) tex.destroy();
         this._skinnedMeshBoneTextures.delete(name);
+    }
+
+    /**
+     * 注册 SkinnedMeshTransform/VFXTransform source — transformPosition block 通过 transformSource 引用。
+     * @param name  与 .vfx 中 Transform 暴露属性名一致（如 "SkinnedMeshTransform"）
+     * @param node  场景节点（骨骼/Transform），其世界矩阵每帧驱动粒子位置变换
+     */
+    setTransformSource(name: string, node: any): void {
+        this._transformSources.set(name, node);
+    }
+
+    /** 移除 TransformSource 注册 */
+    clearTransformSource(name: string): void {
+        this._transformSources.delete(name);
     }
 
     /**
@@ -1070,6 +1089,8 @@ export class VisualEffect extends Script {
 
         // Phase 0.6: SkinnedMesh texture 烘焙/刷新（首次烘焙静态 vertex 属性，每帧刷 bones 矩阵）
         this._updateSkinnedMeshTextures();
+        // Phase 0.7: SkinnedMeshTransform/VFXTransform — 每帧把注册骨骼/节点世界矩阵绑到粒子位置变换 uniform
+        this._updateTransformSources();
 
         // 计算 emitter 世界矩阵
         state.emitterWorldMatrix = this.owner.transform.worldMatrix;
@@ -1381,6 +1402,10 @@ export class VisualEffect extends Script {
             if (!textureUniforms || textureUniforms.length === 0) continue;
             const allDatas = system.getAllShaderDatas();
             for (const tu of textureUniforms) {
+                // transformSource 项是 Mat4 uniform（SkinnedMeshTransform/VFXTransform），不是纹理。
+                // 若在此 setTexture(whiteTexture)，会把该 uniform 槽注册成纹理 → _updateTransformSources
+                // 的 setMatrix4x4 往纹理上 cloneTo 崩（Cannot read 'set' of undefined）。必须跳过。
+                if ((tu as any).transformSource) continue;
                 const id = Shader3D.propertyNameToID(tu.uniformName);
                 // 空 texture fallback 到默认纹理，避免 compute shader bind group 读 null 崩溃
                 // （用户可通过 shaderData.setTexture 运行时覆盖）
@@ -1398,6 +1423,35 @@ export class VisualEffect extends Script {
                 for (const sd of allDatas) {
                     sd.setTexture(id, texture);
                 }
+            }
+        }
+    }
+
+    /**
+     * 每帧把注册的 TransformSource（骨骼/Transform 节点）世界矩阵绑到对应 transformPosition 的
+     * Mat4 uniform（u_VfxProp_VfxTransform_<name>）。transformPosition block 的 initialize compute
+     * 里 position = matrix * position，让 bolts/sparks/surge 跟随该骨骼动画（对齐 Unity 的 mul(uniform,...)）。
+     */
+    private _updateTransformSources(): void {
+        if (this._transformSources.size === 0) return;
+        const asset = this.asset;
+        if (!asset) return;
+        const descs = (asset as any).systems;
+        for (let i = 0; i < this.systems.length; i++) {
+            const system = this.systems[i];
+            const desc = descs[i];
+            if (!(system instanceof VFXParticleSystem)) continue;
+            if (!desc?.textureUniforms) continue;
+            for (const tu of desc.textureUniforms as any[]) {
+                if (!tu.transformSource) continue;
+                const node = this._transformSources.get(tu.transformSource);
+                if (!node) continue;
+                const tr = node.transform || (node.owner && node.owner.transform);
+                if (!tr) continue;
+                const id = Shader3D.propertyNameToID(tu.uniformName);
+                const wm = tr.worldMatrix;
+                for (const sd of system.getAllShaderDatas())
+                    sd.setMatrix4x4(id, wm);
             }
         }
     }

--- a/src/layaAir/laya/vfx/systems/VFXParticleSystem.ts
+++ b/src/layaAir/laya/vfx/systems/VFXParticleSystem.ts
@@ -761,7 +761,6 @@ export class VFXParticleSystem extends VFXSystem {
             // 包在 try-catch 中，确保 geometry 创建失败不会阻断后续的 Bounds 和 GPU Event 初始化
             try {
                 if (isStrip) {
-                    console.log(`[VFX] Creating StripGeometry: capacity=${capacity}, stripCap=${this.stripCapacity}, perStrip=${this.particlePerStripCount}, blend=${this.blendMode}`);
                     const stripParams = new VFXStripGeometryParams();
                     stripParams.capacity = capacity;
                     stripParams.stripVertexBuffer = this.renderBuffer;
@@ -779,7 +778,6 @@ export class VFXParticleSystem extends VFXSystem {
                     (this.geometry as any).stripGradientStops = this.stripGradientStops;
                     (this.geometry as any).stripTilingMode = this.stripTilingMode;
                     (this.geometry as any).stripPpsc = this.particlePerStripCount;
-                    console.log(`[VFX] StripGeometry created:`, this.geometry ? "OK" : "FAILED");
                 } else if (isPoint) {
                     const pointParams = new VFXPointGeometryParams();
                     pointParams.capacity = capacity;
@@ -1032,12 +1030,7 @@ export class VFXParticleSystem extends VFXSystem {
     /**
      * 阶段3: Output — 压缩输出到 RenderBuffer
      */
-    private _outputLogOnce = false;
     outputPhase(state: VFXState, cmd: ComputeCommandBuffer): void {
-        if (!this._outputLogOnce && this.isStripOutput) {
-            this._outputLogOnce = true;
-            console.log(`[VFX OutputPhase] type=${this.outputType}, hasShader=${!!this.outputShader}, hasAlive=${!!this.aliveListBufferRead}, hasRender=${!!this.renderBuffer}, hasIndirect=${!!this.indirectBuffer}, isStrip=${this.isStripOutput}, geometry=${this.geometry?.constructor?.name}`);
-        }
         if (this.outputType === "none" || !this.outputShader) return;
         if (!this.aliveListBufferRead || !this.renderBuffer || !this.indirectBuffer) return;
 

--- a/src/layaAir/laya/vfx/systems/VFXSpawnerTask.ts
+++ b/src/layaAir/laya/vfx/systems/VFXSpawnerTask.ts
@@ -99,10 +99,13 @@ export class VFXSpawnerSingleBurst extends VFXSpawnerTask {
     }
 
     internalInit(rand: Rand): void {
-        // ⚠ 不要 reset sleeping — Unity SingleBurst 整个 VFX 生命周期只 fire 一次 (含 Infinite loop 模式).
-        // 之前每个 newLoop 重置 sleeping=false 让 durationMode=Infinite + SingleBurst 每个 loop 重新 fire
-        // → 看起来 "粒子播放 2 次" (实际是无限次重 fire). UNI VFX1/2/3 都受影响.
-        // 只在 VFX 完整重置 (init / play) 时才重置 sleeping.
+        // internalInit 在 newLoop(每个 loop 开始)时被 VFXSpawnerTask.update 调用。这里重置 sleeping=false,
+        // 让【有限循环】(durationMode=Constant, loopDuration>0, loop 会周期性重启)的 SingleBurst 每个 loop 重新 fire,
+        // 对齐 Unity(有限 loop 的 Single Burst 每个 loop 触发一次)。BarrierVFX7 底圈脉冲依赖此行为。
+        // 为何不会重蹈旧 bug(Infinite + 无限重 fire): durationMode=Infinite → loopDuration=-1,
+        // VFXSpawnerState.endUpdate 对 currentMaximumDuration<0 不转换 loop 状态 → loop 永不重启 → newLoop 只第一次 true
+        // → Infinite 模式仍只 fire 一次。所以重置 sleeping 对 Infinite/Finite 两种都正确。
+        this.sleeping = false;
         this.nextTriggerTime = sampleRange(this.delay, rand);
         this.sampledCount = Math.round(sampleRange(this.count, rand));
     }


### PR DESCRIPTION
## 改动

VFX `setPositionMesh` 点云烘焙（`VFXAssetParser.ts`）支持**按 mesh 顶点缩放**：

- 新增 `_resolveMeshScale(rawScale, uuid)` + `MESH_CMUNIT_FALLBACK` 兜底表
- `bakeMeshSurfacePoints` / `bakeMeshVolumePoints`（及相关点云数据函数）增加可选 `scale` 参数，对采样点位置乘以缩放
- 调用点优先读转换器注入的数据驱动 `meshScale`；`.lvfx` 没带时，对已知 cm-unit mesh（Unity fileScale 未应用、顶点 100x，如 Ellen.fbx）兜底 0.01

## 解决的问题

cm-unit 的 mesh（如 Smoke DM 火焰发射面 Ellen.fbx）顶点是 cm 量级（米级 ×100），烘成点云后 100x 过大，粒子喷到屏幕外（看不到火焰）。之前引擎用硬编码 ×0.01 兜底，会错误缩小内置 mesh（如 Capsule swarm）。本改动改为数据驱动 + 仅对已知 cm-unit mesh 兜底。

## 说明

- 仅加 `meshScale` 串接，**不改动各分支既有的采样算法**（3.4 拆分版 / Master3.0 面积加权内联版各自保持）。
- 本分支沿用 VFX 系列的累积式结构（在前序 VFX PR 之上叠加），新增内容为顶部的 meshScale commit。
- TypeScript 转译检查通过。
