### PR TITLE
chore(vfx): 清理引擎 VFX 注释与日志（Master3.0）

### DIFF
--- a/src/layaAir/laya/vfx/ShaderExpressionEvaluator.ts
+++ b/src/layaAir/laya/vfx/ShaderExpressionEvaluator.ts
@@ -3,7 +3,7 @@ import { Vector4 } from "../maths/Vector4";
 /**
  * VFX → ShaderGraph 之间 operator chain 的 runtime evaluator。
  *
- * Unity VFX Graph 中 OutputContext 的 shader uniform（如 _MainTextureColor）可以接到
+ * OutputContext 的 shader uniform（如 _MainTextureColor）可以接到
  * operator chain（SampleGradient/SampleCurve/Math 等），每帧求值后写到 material。
  * 转换器把这些 chain 序列化到 .lvfx 的 shaderPropertyExpressions，runtime 这里 evaluate。
  *
@@ -112,7 +112,7 @@ export class ShaderExpressionEvaluator {
                     : Math.min(ctx.totalTime, 1);
                 break;
             case "Random": {
-                // Unity 端 Random(min, max, seed) 是 per-particle random, Laya material uniform 是 per-system 一份不能 per-particle.
+                // 源引擎端 Random(min, max, seed) 是 per-particle random, Laya material uniform 是 per-system 一份不能 per-particle.
                 // 之前写死 result=0.5 完全 ignore inputs 让 _MaskFlipbookIndex Random(0,3) 永远 0.5 而不是 0~3 范围
                 // 改成读 min/max input + 用 totalTime+seed-based deterministic random 让每帧动画 (frame 切换 mask flipbook)
                 const min = Number(this._evalNode(n.inputs![0], nodes, cache, ctx)) || 0;
@@ -198,7 +198,7 @@ export class ShaderExpressionEvaluator {
     }
 
     /** Gradient sample lerp — 支持两种格式：
-     *  Unity {colorKeys:[{color,time}], alphaKeys:[{alpha,time}]}
+     *  源格式 {colorKeys:[{color,time}], alphaKeys:[{alpha,time}]}
      *  Laya  {__layaGradientStops:[{time,r,g,b,a}]} (color+alpha 同 stop)
      */
     private static _sampleGradient(g: any, t: number): { r: number; g: number; b: number; a: number } | null {
@@ -226,7 +226,7 @@ export class ShaderExpressionEvaluator {
                 a: c0[3] + (c1[3] - c0[3]) * u,
             };
         }
-        // Unity 格式
+        // 源格式
         if (!g.colorKeys || g.colorKeys.length === 0) return { r: 1, g: 1, b: 1, a: 1 };
         const keys = g.colorKeys;
         const aKeys = g.alphaKeys || [{ alpha: 1, time: 0 }];
@@ -254,7 +254,7 @@ export class ShaderExpressionEvaluator {
         return { r, g: g_, b, a };
     }
 
-    /** Unity AnimationCurve sample — 简化 linear lerp（不算 Hermite tangent，足够多数 material uniform 用例） */
+    /** AnimationCurve sample — 简化 linear lerp（不算 Hermite tangent，足够多数 material uniform 用例） */
     private static _sampleCurve(c: CurveData, t: number): number {
         // curve 未提供 → return null 让 caller skip setUniform 让 ShaderGraph default 生效
         if (!c) return null as any;

--- a/src/layaAir/laya/vfx/VFXAsset.ts
+++ b/src/layaAir/laya/vfx/VFXAsset.ts
@@ -69,7 +69,7 @@ export class VFXSpawnerSetEventAttributeTaskDesc implements VFXSpawnerTaskDesc {
     value: [number, number, number, number] = [0, 0, 0, 0];
     fromLoopIndex: boolean = false;
     loopIndexModulo: number = 0;
-    // Unity Add(spawnState.loopDuration, spawnState.delayAfterLoop) → src.lifetime 模式
+    // Add(spawnState.loopDuration, spawnState.delayAfterLoop) → src.lifetime 模式
     fromSpawnStateLoop: boolean = false;
 }
 
@@ -87,7 +87,7 @@ export interface VFXGPUEventInput {
 }
 
 /**
- * Output Event 描述（CPU readback 通知，对齐 Unity VFXOutputEvent）
+ * Output Event 描述（CPU readback 通知，对齐 VFXOutputEvent）
  * 每个 outputEvent context 对应 update shader 中一份 OutputEventBuffer_<eventIdx>
  * Runtime 每帧 readback，按 eventName 派发到 VisualEffect.outputEventReceived 回调
  */
@@ -129,7 +129,7 @@ interface VFXSystemDesc {
 
 /**
  * VFXStaticMeshSystem 描述：渲染单个 mesh，不跑 particle simulation
- * Unity VFXStaticMeshOutput 对齐 — mesh 跟随 owner transform，material 由用户提供
+ * VFXStaticMeshOutput 对齐 — mesh 跟随 owner transform，material 由用户提供
  * bindings: setStaticMeshAttr block 收集到的 graph driven 绑定
  *   target: "position" | "rotation" | "scale" | "color"
  *   source: "inline" → value 是静态值 / "property" → name 引用 effect graph property
@@ -205,7 +205,7 @@ export class VFXParticleSystemDesc implements VFXSystemDesc {
     // Soft Particle 淡出距离（eye 空间单位，0 = 关闭）
     softParticleFade: number = 0;
 
-    // Flipbook 帧动画图集模式（对齐 Unity VFX Graph Output Context UV Mode）
+    // Flipbook 帧动画图集模式（对齐 Output Context UV Mode）
     // "Default" | "Flipbook" | "FlipbookBlend"
     uvMode: string = "Default";
     // Flipbook atlas 的列数/行数（cols, rows），启用 Flipbook 时用
@@ -213,13 +213,13 @@ export class VFXParticleSystemDesc implements VFXSystemDesc {
     // Flipbook 模式专用 atlas 资源（res:// uuid），runtime 加载后设到 BillboardMaterial.u_AlbedoTexture
     mainTexture: string = "";
 
-    // Subpixel AA 开关（对齐 Unity subpixelAA block）
+    // Subpixel AA 开关（对齐 subpixelAA block）
     subpixelAA: boolean = false;
 
     // 自定义 Shader 名（outputShaderGraphQuad 使用，空 = 默认 VFXUnlit）
     customShaderName: string = "";
 
-    // Billboard procedural 配置（对齐 Unity VFXPlanarPrimitiveOutput）
+    // Billboard procedural 配置（对齐 VFXPlanarPrimitiveOutput）
     // 空 = 走旧 mesh 路径（createQuad）兼容现有 VFX；
     // "Quad" / "Triangle" / "Octagon" = 走 VFXBillboardGeometry + gl_VertexID procedural
     billboardPrimitive: string = "";
@@ -228,12 +228,12 @@ export class VFXParticleSystemDesc implements VFXSystemDesc {
     // Octagon 裁角因子 [0, 0.5]，运行时可通过 property 系统动态调整
     billboardCropFactor: number = 0.146;
 
-    // Alpha Clipping (Unity VFXPlanarPrimitiveOutput useAlphaClipping):
+    // Alpha Clipping (VFXPlanarPrimitiveOutput useAlphaClipping):
     // 让 atlas mask 字符 (alpha<threshold 时 fragment discard)，背景方块透明
     useAlphaClipping: boolean = false;
     alphaThreshold: number = 0.5;
 
-    // Strip output 专属字段（对齐 Unity Output Trail）
+    // Strip output 专属字段（对齐 Output Trail）
     stripColorMapping: string = "Default";   // "Default" | "GradientMapped"
     stripUvScale: { x: number, y: number } = { x: 1, y: 1 };
     stripUvBias: { x: number, y: number } = { x: 0, y: 0 };
@@ -253,7 +253,7 @@ export class VFXParticleSystemDesc implements VFXSystemDesc {
     // 运行时通过 VisualEffect.setBuffer(name, buffer) 公开 API 绑定
     bufferUniforms: Array<{ uniformName: string; propertyName: string }> = [];
 
-    // Output Event 描述（CPU readback 通知，对齐 Unity VFXOutputEvent）
+    // Output Event 描述（CPU readback 通知，对齐 VFXOutputEvent）
     outputEvents: Array<VFXOutputEventDesc> = [];
 }
 

--- a/src/layaAir/laya/vfx/VFXAssetParser.ts
+++ b/src/layaAir/laya/vfx/VFXAssetParser.ts
@@ -24,9 +24,6 @@ export class VFXAssetParser {
 
         const vfxAsset = new VFXAsset();
 
-        console.log(`[VFX-DBG] runtime parse systems=${(data.systems || []).length}`,
-            (data.systems || []).map((s: any, i: number) => `${i}:${s.type}${s.capacity != null ? `(cap=${s.capacity})` : ""}`).join(","));
-
         // 解析 updateMode
         let updateMode = VFXUpdateMode.FixedDeltaTime;
         if (data.fixedDeltaTime === false) {
@@ -135,12 +132,12 @@ export class VFXAssetParser {
                     desc.outputType = sys.outputType || "outputMesh";
                     desc.particlePerStripCount = sys.particlePerStripCount ?? 128;
                     desc.stripCapacity = sys.stripCapacity ?? 1;
-                    // Billboard procedural：对齐 Unity VFXPlanarPrimitiveOutput，编译器写入 primitive/vertexCount/cropFactor
+                    // Billboard procedural：对齐 VFXPlanarPrimitiveOutput，编译器写入 primitive/vertexCount/cropFactor
                     desc.billboardPrimitive = (sys.billboardPrimitive as string) || "";
                     desc.billboardVertexCount = Number(sys.billboardVertexCount) || 0;
                     desc.distortionMode = (sys.distortionMode as string) || "Procedural";
                     desc.billboardCropFactor = Number(sys.billboardCropFactor ?? 0.146);
-                    // Alpha Clipping (Unity VFXPlanarPrimitiveOutput useAlphaClipping)
+                    // Alpha Clipping (VFXPlanarPrimitiveOutput useAlphaClipping)
                     (desc as any).useAlphaClipping = !!sys.useAlphaClipping;
                     (desc as any).alphaThreshold = Number(sys.alphaThreshold ?? 0.5);
 
@@ -164,7 +161,7 @@ export class VFXAssetParser {
                         desc.softParticleFade = sys.softParticleFade;
                     }
 
-                    // 解析 Flipbook UV Mode + 图集尺寸（对齐 Unity VFX Output UV Mode）
+                    // 解析 Flipbook UV Mode + 图集尺寸（对齐 Output UV Mode）
                     if (typeof sys.uvMode === "string") desc.uvMode = sys.uvMode;
                     if (Array.isArray(sys.flipbookSize)) {
                         desc.flipbookSize = new Vector2(
@@ -187,7 +184,7 @@ export class VFXAssetParser {
                         const shaderUrl: string = sys.customShaderRes;
                         loadPromises.push(
                             (Laya.loader.load(shaderUrl) as Promise<any>).then(
-                                () => { console.log(`[VFX Parser] preloaded custom shader '${sys.customShaderName}' from ${shaderUrl}`); },
+                                () => { },
                                 (err: any) => { console.warn(`[VFX Parser] failed preloading custom shader '${sys.customShaderName}' from ${shaderUrl}`, err); }
                             )
                         );
@@ -223,7 +220,7 @@ export class VFXAssetParser {
                         (desc as any).shaderPropertyExpressions = sys.shaderPropertyExpressions;
                     }
 
-                    // Strip 专属字段（对齐 Unity Output Trail）
+                    // Strip 专属字段（对齐 Output Trail）
                     if (typeof sys.colorMapping === "string") desc.stripColorMapping = sys.colorMapping;
                     if (typeof sys.tilingMode === "string") (desc as any).tilingMode = sys.tilingMode;
                     if (sys.uvScale && typeof sys.uvScale === "object") {
@@ -232,7 +229,7 @@ export class VFXAssetParser {
                     if (sys.uvBias && typeof sys.uvBias === "object") {
                         desc.stripUvBias = { x: Number(sys.uvBias.x ?? 0), y: Number(sys.uvBias.y ?? 0) };
                     }
-                    // gradient: Unity 格式 colorKeys+alphaKeys → 合并成 Laya stops 格式 (跟 sampleGradient 一致)
+                    // gradient: 源引擎格式 colorKeys+alphaKeys → 合并成 Laya stops 格式 (跟 sampleGradient 一致)
                     if (sys.gradient && typeof sys.gradient === "object" && Array.isArray(sys.gradient.colorKeys)) {
                         const gck = sys.gradient.colorKeys, gak = sys.gradient.alphaKeys || [];
                         const allTimes = new Set<number>();
@@ -326,8 +323,8 @@ export class VFXAssetParser {
                         // outputShaderGraphQuad / Billboard / Point / Line 无显式 mesh：用内置 Quad
                         return PrimitiveMesh.createQuad(1, 1);
                     };
-                    // builtin: 前缀表示 Unity 内置 primitive mesh（converter 检测 guid=0000-e000+fileID 后写入）
-                    // 直接用 PrimitiveMesh.createXxx 创建对齐尺寸（Unity 内置 Sphere/Cube 都是 1m，Plane 是 10m，Quad 1m）
+                    // builtin: 前缀表示内置 primitive mesh（converter 检测 guid=0000-e000+fileID 后写入）
+                    // 直接用 PrimitiveMesh.createXxx 创建对齐尺寸（内置 Sphere/Cube 都是 1m，Plane 是 10m，Quad 1m）
                     const buildBuiltinMesh = (name: string): Mesh | null => {
                         switch (name) {
                             case "Sphere":   return PrimitiveMesh.createSphere(0.5, 12, 12);
@@ -426,9 +423,6 @@ export class VFXAssetParser {
                                 const loadMeshTex = Laya.loader.load(meshUrl).then((mesh: Mesh) => {
                                     if (mesh) {
                                         entry.texture = bakeMeshAttributeTexture(mesh, normalizedRole as MeshRole);
-                                        const positions: any[] = [];
-                                        try { mesh.getPositions(positions); } catch {}
-                                        console.log(`[VFX] sampleMesh OK: ${meshUrl} role=${normalizedRole} vertexCount=${positions.length} firstVert=${positions[0] ? `(${positions[0].x.toFixed(2)},${positions[0].y.toFixed(2)},${positions[0].z.toFixed(2)})` : 'null'}`);
                                     } else {
                                         console.warn(`[VFX] sampleMesh: failed to load mesh ${meshUrl}`);
                                     }
@@ -497,7 +491,7 @@ export class VFXAssetParser {
                                 const exShaderUrl: string = eo.customShaderRes;
                                 loadPromises.push(
                                     (Laya.loader.load(exShaderUrl) as Promise<any>).then(
-                                        () => { console.log(`[VFX Parser] preloaded extra custom shader '${eo.customShaderName}' from ${exShaderUrl}`); },
+                                        () => { },
                                         (err: any) => { console.warn(`[VFX Parser] failed preloading extra custom shader '${eo.customShaderName}' from ${exShaderUrl}`, err); }
                                     )
                                 );
@@ -655,7 +649,7 @@ export class VFXAssetParser {
                     }
                     case VFXPropertyType.Texture2D: {
                         // Texture2D property: d 是 string "res://uuid" 或 array ["res://uuid"] (转换器统一输出后者)
-                        // Unity VFX exposed prop 跟 ShaderGraph 内 shader uniform 是双命名空间，OutputContext 含 binding；
+                        // VFX exposed prop 跟 ShaderGraph 内 shader uniform 是双命名空间，OutputContext 含 binding；
                         // 这里只 load 资源存到 desc.texture，setTexture 绑定 shader uniform 在 VisualEffect.onStart 用 binding 名做
                         let url: string | null = null;
                         if (Array.isArray(d) && typeof d[0] === "string") url = d[0];
@@ -728,7 +722,7 @@ export class VFXAssetParser {
 /**
  * 把 Mesh 顶点的 position 打包成 RGBA32F Texture2D（宽 = 顶点数 / 高 = 1）。
  * setPositionMesh block 在 compute shader 里通过 texelFetch(tex, ivec2(i, 0), 0) 取点。
- * 对齐 Unity VFX Graph 的 Point Cache 方案。
+ * 对齐 Point Cache 方案。
  */
 /**
  * 按关键帧烘焙 256×1 RGBA8 Gradient Texture2D
@@ -742,13 +736,13 @@ function bakeInlineGradientTexture(stops: { t: number; color: [number, number, n
         { t: 0, color: [1, 1, 1, 1] as [number, number, number, number] },
         { t: 1, color: [1, 1, 1, 0] as [number, number, number, number] },
     ];
-    // Unity Gradient editor 用 HDR color picker 输出值 (e.g., 0,89.97,46.39) → 没 HDR pipeline 时需 clamp 到 [0,1]
+    // HDR 颜色选择器输出值 (e.g., 0,89.97,46.39) → 没 HDR pipeline 时需 clamp 到 [0,1]
     // 之前 per-channel clamp 让所有三通道都 >1 的 HDR 颜色（如 (1.22, 5.66, 3.62) HDR teal）变成 (1,1,1) 纯白
     // 丢失 chroma → TexIndexAdvanced Core Cube 这种 stop 该显示 teal 但 Laya 显示纯白
     // 修：per-stop 用 max-channel 归一化保留 chroma 方向，仅 max>1 时缩放（max<=1 保留原值）
     //   (1.22, 5.66, 3.62) max=5.66 → (0.216, 1.0, 0.640) 保留 teal-green chroma
     //   (2.95, 0.012, 0.24) max=2.95 → (1.0, 0.004, 0.081) 保留 red chroma
-    // 副作用：失去 Unity HDR 强度信息（bloom glow 不可见），但 chroma 准确
+    // 副作用：失去 HDR 强度信息（bloom glow 不可见），但 chroma 准确
     const normalizeStop = (c: number[]): [number, number, number, number] => {
         const r = Math.max(0, c[0]);
         const g = Math.max(0, c[1]);
@@ -998,7 +992,7 @@ export function bakeSkinnedMeshBonesTexture(renderer: any, existingTex: Texture2
         } else {
             boneWorld.cloneTo(tmpMtx);
         }
-        // GLSL mat4 是 column-major，elements 已是 column-major（同 Three / Unity）
+        // GLSL mat4 是 column-major，elements 已是 column-major（同 Three）
         const e = tmpMtx.elements;
         const off = i * 16;
         for (let k = 0; k < 16; k++) data[off + k] = e[k];

--- a/src/layaAir/laya/vfx/VFXBillboardGeometry.ts
+++ b/src/layaAir/laya/vfx/VFXBillboardGeometry.ts
@@ -12,7 +12,7 @@ import { VertexElement } from "../renders/VertexElement";
 import { VertexElementFormat } from "../renders/VertexElementFormat";
 import { BufferState } from "../webgl/utils/BufferState";
 /**
- * VFXBillboardGeometry — 对齐 Unity VFXPlanarPrimitiveOutput
+ * VFXBillboardGeometry — 对齐 VFXPlanarPrimitiveOutput
  *
  * Procedural billboard 渲染：不依赖 mesh 资源，vertex shader 根据 gl_VertexID
  * 生成 Quad(6)/Triangle(3)/Octagon(18) 的顶点。配合 per-particle instance buffer。

--- a/src/layaAir/laya/vfx/VFXLineStripGeometry.ts
+++ b/src/layaAir/laya/vfx/VFXLineStripGeometry.ts
@@ -11,7 +11,7 @@ import { VertexElementFormat } from "../renders/VertexElementFormat";
 import { BufferState } from "../webgl/utils/BufferState";
 /**
  * VFXLineStripGeometry — Output LineStrip 渲染几何
- * 对齐 Unity VFXLineStripOutput
+ * 对齐 VFXLineStripOutput
  *
  * 每粒子 1 vertex（同 VFXPointGeometry layout，48 bytes）：
  *   [0] xyz=position, w=size (size 不使用，但保持 layout 兼容)

--- a/src/layaAir/laya/vfx/VFXRenderer.ts
+++ b/src/layaAir/laya/vfx/VFXRenderer.ts
@@ -43,7 +43,7 @@ export class VFXRenderer extends BaseRender {
     private static _defaultDotTexture: Texture2D | null = null;
 
     /**
-     * 程序生成 DefaultDot 软圆纹理（对齐 Unity VFX Graph DefaultParticle.png）
+     * 程序生成 DefaultDot 软圆纹理（对齐 DefaultParticle.png）
      * 64×64 白色软圆，alpha 为距中心的平滑衰减
      */
     static getDefaultDotTexture(): Texture2D {
@@ -110,7 +110,7 @@ export class VFXRenderer extends BaseRender {
     private static _smoothedNormalMeshIds: Set<number> = new Set();
 
     /**
-     * 给 mesh 跑 smooth normal: Unity .fbx import 默认 split vertex by hard edge + smooth normal
+     * 给 mesh 跑 smooth normal: 源引擎 .fbx import 默认 split vertex by hard edge + smooth normal
      * 平均化, 让相邻 face 共享 normal → shading 平滑无 alternating. Laya .fbx import 没这步,
      * 让蓝图 PBR shader 算 SurfaceShading 时邻接 face normal 不一致 → fragment shading 跳变 →
      * 三角形 alternating striping (image 56 蜡池区现象). 这里 weld by position + 平均 normal 复用
@@ -214,7 +214,7 @@ export class VFXRenderer extends BaseRender {
     /**
      * 给 mesh 跑 Laplacian vertex color smooth: 蓝图 ShaderGraph 用 mesh 顶点色驱动多区域选色
      * (e.g. SG_Candle 用 vc.g 分饰圈/蜡池/dripping), per-vertex 颜色直接 dump 显示三角形渐变.
-     * Unity 端因为有 bloom + AA + tonemap 视觉融合, Laya 简单 lighting 直接暴露相邻三角形色差.
+     * 源引擎端因为有 bloom + AA + tonemap 视觉融合, Laya 简单 lighting 直接暴露相邻三角形色差.
      * 这里对相邻 vertex (共三角形) 颜色做加权平均, 减少 striping 同时保留大尺度 region 差异.
      * 只 smooth r/g/a 通道 (b 通道在 vertex shader vfxTransformVertex 阶段 override 给 per-particle).
      */
@@ -329,10 +329,10 @@ export class VFXRenderer extends BaseRender {
         Laya.loader.load(url).then(async (tex: BaseTexture) => {
             if (tex) {
                 // PNG RGB-only atlas (e.g. TX_Flipbook_example.png 白数字 + 橙/cyan 方块底,
-                // colorType=2 无 alpha channel) 走 alpha blend 时方块底色全显示. Unity 端默认 Particles
-                // shader Color Mapping Default = color * tex, PNG no alpha → tex.a=1 → Unity 端实际行为不明,
+                // colorType=2 无 alpha channel) 走 alpha blend 时方块底色全显示. 源引擎端默认 Particles
+                // shader Color Mapping Default = color * tex, PNG no alpha → tex.a=1 → 源引擎端实际行为不明,
                 // 但 visually 蜡烛场景方块透明跟数字白显示. 这里跑 saturation 检测把彩色像素 alpha 设 0,
-                // 灰度像素保留 luminance, 让 atlas 视觉对齐 Unity (背景透明). 检测条件:
+                // 灰度像素保留 luminance, 让 atlas 视觉对齐源引擎 (背景透明). 检测条件:
                 // 所有 pixel alpha 都是 255 (PNG 无 alpha 让 IDE import 自动填 1) 才跑.
                 await VFXRenderer._patchTextureAlphaFromLuminance(tex, url);
                 VFXRenderer._atlasTextureCache.set(url, tex);
@@ -353,7 +353,6 @@ export class VFXRenderer extends BaseRender {
     private static async _patchTextureAlphaFromLuminance(tex: BaseTexture, url: string): Promise<void> {
         if (VFXRenderer._patchedTextureUrls.has(url)) return;
         VFXRenderer._patchedTextureUrls.add(url);
-        console.log("[VFX alpha] start url=", url);
         try {
             // 不能直接 fetch(res://...)，浏览器不认 res: scheme。
             // 改走 Laya.loader.load(url, BUFFER) 拿 ArrayBuffer：
@@ -366,7 +365,6 @@ export class VFXRenderer extends BaseRender {
             }
             // 只处理 PNG (其它格式如 KTX/DDS 通常带正确 alpha)
             if (!url.toLowerCase().endsWith(".png")) {
-                console.log("[VFX alpha] skip - not png");
                 return;
             }
             const blob = new Blob([buffer], { type: "image/png" });
@@ -384,7 +382,6 @@ export class VFXRenderer extends BaseRender {
             for (let i = 3; i < pixels.length; i += 4) {
                 if (pixels[i] !== 255) { allOpaque = false; break; }
             }
-            console.log("[VFX alpha] allOpaque=", allOpaque, "pixels.length=", pixels.length);
             if (!allOpaque) return; // 真有 alpha 通道不动
             // 区分两种 PNG atlas 类型:
             // (A) "火焰风格": 大量黑色背景 + 彩色渐变主体 (flame/smoke) → 用 luminance 当 alpha
@@ -396,7 +393,6 @@ export class VFXRenderer extends BaseRender {
             }
             const blackRatio = blackCount / pixelCount;
             const isFlameStyle = blackRatio > 0.15;
-            console.log("[VFX alpha] blackRatio=", blackRatio.toFixed(3), "isFlameStyle=", isFlameStyle);
             let modified = false;
             for (let i = 0; i < pixels.length; i += 4) {
                 const r = pixels[i], g = pixels[i + 1], b = pixels[i + 2];
@@ -424,7 +420,6 @@ export class VFXRenderer extends BaseRender {
             const t2d = ((tex as any).bitmap || tex) as Texture2D;
             if (t2d && (t2d as any).setPixelsData) {
                 (t2d as any).setPixelsData(new Uint8Array(pixels.buffer), false, false);
-                console.log("[VFX] alpha patched from luminance:", url, "size=", canvas.width, "x", canvas.height);
             } else {
                 console.warn("[VFX alpha] no setPixelsData on bitmap, t2d=", t2d, "tex=", tex);
             }
@@ -434,7 +429,7 @@ export class VFXRenderer extends BaseRender {
     }
 
     /**
-     * 对齐 Unity VFXPlanarPrimitiveOutput：procedural billboard（用 gl_VertexID 生成顶点）
+     * 对齐 VFXPlanarPrimitiveOutput：procedural billboard（用 gl_VertexID 生成顶点）
      * primitive: "Quad" / "Triangle" / "Octagon"
      * cropFactor: Octagon 专用裁角因子 [0, 0.5]
      * mainTextureUuid / uvMode / fbW / fbH 加入 cache key —— Multi-Output 同一 system 多 output ctx
@@ -483,11 +478,11 @@ export class VFXRenderer extends BaseRender {
         return mat;
     }
 
-    /** Distortion procedural material 缓存（Unity VFXDistortion 对齐） */
+    /** Distortion procedural material 缓存（VFXDistortion 对齐） */
     private static _distortionMaterialCache: Map<string, Material> = new Map();
 
     /**
-     * 对齐 Unity VFXDistortion：采样 u_CameraOpaqueTexture 做 UV 偏移
+     * 对齐 VFXDistortion：采样 u_CameraOpaqueTexture 做 UV 偏移
      * mode: "Procedural"（径向透镜）/ "NormalMap"（用 u_AlbedoTexture 的 RG 当法线）
      * distortionStrength: UV 偏移乘法因子 [0, 1]
      * Camera 必须启用 opaqueTexture 才能看到效果
@@ -516,11 +511,11 @@ export class VFXRenderer extends BaseRender {
         return mat;
     }
 
-    /** Cube procedural material 缓存（Unity VFXBasicCubeOutput 对齐） */
+    /** Cube procedural material 缓存（VFXBasicCubeOutput 对齐） */
     private static _cubeProceduralCache: Map<string, Material> = new Map();
 
     /**
-     * 对齐 Unity VFXBasicCubeOutput：3D cube 粒子（6 面，带简易 Lambert 光照）
+     * 对齐 VFXBasicCubeOutput：3D cube 粒子（6 面，带简易 Lambert 光照）
      */
     static getCubeProceduralMaterial(blendMode: string = "Alpha"): Material | null {
         let mat = VFXRenderer._cubeProceduralCache.get(blendMode);
@@ -572,7 +567,7 @@ export class VFXRenderer extends BaseRender {
                     : (Laya as any).AssetDb?.inst?.shaderName_to_URL_async?.(shaderName)
                         .then((u: string) => u ? Laya.loader.load(u) : null);
                 Promise.resolve(loadPromise)
-                    .then(() => console.log(`[VFX Renderer] custom shader '${shaderName}' loaded (url=${url})`))
+                    .then(() => { })
                     .catch((err: any) => console.warn(`[VFX Renderer] custom shader '${shaderName}' load failed`, err));
             }
             // Shader 还没注册：返回 VFXUnlit fallback，不缓存（让下一帧重试）
@@ -636,12 +631,10 @@ export class VFXRenderer extends BaseRender {
         const useGradient = colorMapping === "GradientMapped" && gradientStops && gradientStops.length > 0;
         const gradDef = Shader3D.getDefineByName("VFX_STRIP_GRADIENT_MAPPED");
         const sbDef = Shader3D.getDefineByName("VFX_STRIP_UV_SCALE_BIAS");
-        console.log(`[VFX Strip Mat] colorMapping=${colorMapping}, useGradient=${useGradient}, gradDef=${!!gradDef}, sbDef=${!!sbDef}, stops=${gradientStops?.length ?? 0}`);
         if (useGradient) {
             if (gradDef) mat.addDefine(gradDef);
             const gradTex = bakeGradientTexture256(gradientStops!);
             mat.setTexture("u_VfxStripGradient", gradTex);
-            console.log(`[VFX Strip Mat] gradient texture baked, hasDefine=${gradDef ? mat.hasDefine(gradDef) : "noDef"}`);
         }
         // UV Mode = ScaleAndBias: 设 scale/bias uniform + 启用 define
         const useScaleBias = (uvScale && (uvScale.x !== 1 || uvScale.y !== 1)) || (uvBias && (uvBias.x !== 0 || uvBias.y !== 0));
@@ -834,14 +827,6 @@ export class VFXRenderer extends BaseRender {
             if (geometry instanceof VFXStripGeometry || outType === "outputPoint" || outType === "outputLine" || outType === "outputLineStrip") {
                 const mode = (geometry as any).blendMode || "Alpha";
                 const stripCustomShader = (geometry as any).customShaderName || "";
-                if (!(this as any)._stripLogOnce) {
-                    (this as any)._stripLogOnce = true;
-                    console.log(`[VFX Renderer] Strip path: isStripGeo=${geometry instanceof VFXStripGeometry}, outType=${outType}, mode=${mode}, customShader=${stripCustomShader}, isRender=${element._renderElementOBJ.isRender}`);
-                }
-                if (!(this as any)._stripDebug2) {
-                    (this as any)._stripDebug2 = true;
-                    console.log(`[VFX Strip Debug] meshMaterial=${meshMaterial ? (meshMaterial as any)._shader?.name : 'NULL'}, stripCustomShader='${stripCustomShader}'`);
-                }
                 if (stripCustomShader && stripCustomShader !== "VFXStrip") {
                     element.material = VFXRenderer.getCustomShaderMaterial(stripCustomShader, mode);
                 } else {
@@ -892,19 +877,19 @@ export class VFXRenderer extends BaseRender {
                     // 现在 _onEnable + _renderUpdate 接通真 reflection probe block bind,
                     // 引擎自动 push u_IBLTex / u_AmbientColor 等真值, 不需要手动 set.)
                 }
-                // Cube procedural（Unity VFXBasicCubeOutput 对齐）
+                // Cube procedural（VFXBasicCubeOutput 对齐）
                 else if (outType === "outputCube") {
                     const cubeMat = VFXRenderer.getCubeProceduralMaterial(mode);
                     if (cubeMat) element.material = cubeMat;
                 }
-                // Distortion（Unity VFXDistortion 对齐）
+                // Distortion（VFXDistortion 对齐）
                 else if (outType === "outputDistortion") {
                     const dMode = (geometry as any).distortionMode || "Procedural";
                     const dStrength = (geometry as any).cropFactor ?? 0.05; // 复用 cropFactor 字段传 strength
                     const dMat = VFXRenderer.getDistortionMaterial(dMode, mode, dStrength);
                     if (dMat) element.material = dMat;
                 }
-                // Billboard procedural（Unity VFXPlanarPrimitive 对齐）
+                // Billboard procedural（VFXPlanarPrimitive 对齐）
                 else if (isBillboardProcedural) {
                     const cropF = (geometry as any).cropFactor ?? 0.146;
                     // cache key 包含 mainTexture+uvMode+flipbookSize，让 multi-output 各 ctx 独立 material
@@ -936,7 +921,7 @@ export class VFXRenderer extends BaseRender {
                         const softFade = (geometry as any).softParticleFade || 0;
                         applySoftParticle(bbMat, softFade);
                         applySubpixelAA(bbMat, !!(geometry as any).subpixelAA);
-                        // Alpha Clipping (Unity VFXPlanarPrimitiveOutput useAlphaClipping)
+                        // Alpha Clipping (VFXPlanarPrimitiveOutput useAlphaClipping)
                         // atlas mask 字符用：alpha<threshold 时 fragment discard，atlas 背景方块消失
                         const useAlphaClip = !!(geometry as any).useAlphaClipping;
                         const alphaThresh = Number((geometry as any).alphaThreshold ?? 0.5);
@@ -1015,7 +1000,7 @@ export class VFXRenderer extends BaseRender {
 }
 
 /**
- * 按 blendMode 配置材质的 blend 状态（对齐 Unity VFX BlendMode 枚举）
+ * 按 blendMode 配置材质的 blend 状态（对齐 BlendMode 枚举）
  *   Alpha         = (SrcAlpha, OneMinusSrcAlpha)   — 普通半透明
  *   Additive      = (SrcAlpha, One)                — 发光/火花叠加
  *   Premultiplied = (One,      OneMinusSrcAlpha)   — 预乘 alpha
@@ -1032,7 +1017,7 @@ function bakeGradientTexture256(stops: { t: number; color: [number, number, numb
         sorted.push({ t: 1, color: [1, 1, 1, 0] });
     }
     const W = 256;
-    // 用 R32G32B32A32 float 格式保留 HDR (Unity gradient 末端 r=g=b=16)
+    // 用 R32G32B32A32 float 格式保留 HDR (源引擎 gradient 末端 r=g=b=16)
     const floats = new Float32Array(W * 4);
     for (let i = 0; i < W; i++) {
         const t = i / (W - 1);
@@ -1112,7 +1097,7 @@ function applySoftParticle(mat: Material, softFade: number): void {
 
 /**
  * 按 uvMode 开启/关闭 Flipbook / FlipbookBlend defines，并设置 u_FlipbookSize
- * 对齐 Unity VFX Output Context UV Mode（Default / Flipbook / FlipbookBlend）
+ * 对齐 Output Context UV Mode（Default / Flipbook / FlipbookBlend）
  */
 function applyFlipbook(mat: Material, uvMode: string, flipbookSize: Vector2): void {
     const defFB = Shader3D.getDefineByName("FLIPBOOK");

--- a/src/layaAir/laya/vfx/VisualEffect.ts
+++ b/src/layaAir/laya/vfx/VisualEffect.ts
@@ -136,7 +136,7 @@ export class VisualEffect extends Script {
     state: VFXState = new VFXState();
 
     /**
-     * Output Event 回调（对齐 Unity VFXOutputEventArgs）
+     * Output Event 回调（对齐 VFXOutputEventArgs）
      *
      * 当 triggerEvent block 路由到 outputEvent context 且触发条件满足时，
      * 每一条触发都会异步回调一次（typically 1-2 帧延迟 due to GPU readback）。
@@ -166,7 +166,7 @@ export class VisualEffect extends Script {
         size: number;
     }) => void) | null = null;
 
-    // CustomSpawn 回调注册表 — Unity VFXSpawnerCustomWrapper 对齐
+    // CustomSpawn 回调注册表 — VFXSpawnerCustomWrapper 对齐
     // 用 customSpawn block 的 Callback Name 索引到对应回调
     private _customSpawnCallbacks: Map<string, IVFXCustomSpawnCallback> = new Map();
 
@@ -343,12 +343,12 @@ export class VisualEffect extends Script {
                     (particleSystem as any).shaderPropertyDefaults = (particleDesc as any).shaderPropertyDefaults || null;
                     // ShaderGraph property expression chains（每帧 evaluate 写 shader uniform，参 ShaderExpressionEvaluator）
                     (particleSystem as any).shaderPropertyExpressions = (particleDesc as any).shaderPropertyExpressions || null;
-                    // Billboard procedural 配置（对齐 Unity VFXPlanarPrimitiveOutput）
+                    // Billboard procedural 配置（对齐 VFXPlanarPrimitiveOutput）
                     particleSystem.billboardPrimitive = particleDesc.billboardPrimitive;
                     particleSystem.billboardVertexCount = particleDesc.billboardVertexCount;
                     particleSystem.distortionMode = particleDesc.distortionMode || "Procedural";
                     particleSystem.billboardCropFactor = particleDesc.billboardCropFactor;
-                    // Alpha Clipping (Unity VFXPlanarPrimitiveOutput useAlphaClipping)
+                    // Alpha Clipping (VFXPlanarPrimitiveOutput useAlphaClipping)
                     particleSystem.useAlphaClipping = (particleDesc as any).useAlphaClipping || false;
                     particleSystem.alphaThreshold = (particleDesc as any).alphaThreshold ?? 0.5;
                     // Strip 专属字段
@@ -536,7 +536,7 @@ export class VisualEffect extends Script {
             for (const uniformName in defaults) {
                 const entry = defaults[uniformName];
                 if (!entry || !entry.texture) continue;
-                // Unity 端 shader uniform 用 _MainTexture 带下划线, 但 Laya .bps 编译后 uniform name 不带下划线 (MainTexture).
+                // 源引擎端 shader uniform 用 _MainTexture 带下划线, 但 Laya .bps 编译后 uniform name 不带下划线 (MainTexture).
                 // 同时 set 带 / 不带 _ 两个 ID, 让两种命名都能命中真实 shader uniform.
                 const ids = [Shader3D.propertyNameToID(uniformName)];
                 if (uniformName.startsWith("_")) ids.push(Shader3D.propertyNameToID(uniformName.substring(1)));
@@ -614,13 +614,6 @@ export class VisualEffect extends Script {
 
     /// lifecycle methods
     onStart(): void {
-        console.log("VisualEffect onStart", this, this.asset);
-        console.log(`[VFX-DBG] VE onStart systems=${this.systems.length}`,
-            this.systems.map((s: any, i: number) => {
-                const cap = (s as any).capacity ?? (s.desc && (s.desc as any).capacity);
-                const t = s.constructor.name;
-                return `${i}:${t}${cap != null ? `(cap=${cap})` : ""}`;
-            }).join(","));
     }
 
     // Strip 专用子节点和 Renderer（避免与 Mesh instancing 的渲染管线冲突）
@@ -782,8 +775,6 @@ export class VisualEffect extends Script {
         this.frameTime.deltaTime = MathUtil.clamp(currentDeltaTime, 0, maxDeltaTime);
         this.frameTime.unscaledFixedDeltaTime = this.frameTime.unscaledTimeStepCount * fixedTimeStep;
         this.frameTime.unscaledDeltaTime = MathUtil.clamp(currentUnscaledDeltaTime, 0.0, maxDeltaTime);
-
-        // console.log(`VisualEffect onUpdate deltaTime:${this.frameTime.deltaTime.toFixed(4)} fixedDeltaTime:${this.frameTime.fixedDeltaTime.toFixed(4)} timeStepCount:${this.frameTime.timeStepCount}`);
 
         // update state
         let currentUnscaledVfxDeltaTime = 0;
@@ -1451,7 +1442,7 @@ function bakeGradientTexture(stops: { t: number; color: [number, number, number,
         { t: 0, color: [1, 1, 1, 1] as [number, number, number, number] },
         { t: 1, color: [1, 1, 1, 0] as [number, number, number, number] },
     ];
-    // Unity HDR color picker 让 gradient stops 含 >1 值；之前 per-channel clamp 让 (1.22, 5.66, 3.62) 全 >1
+    // HDR 颜色选择器 让 gradient stops 含 >1 值；之前 per-channel clamp 让 (1.22, 5.66, 3.62) 全 >1
     // 的 HDR teal 变成 (1,1,1) 纯白丢 chroma。修：per-stop max-normalize 保留 chroma 方向
     const normalizeStop = (c: number[]): [number, number, number, number] => {
         const r = Math.max(0, c[0]);

--- a/src/layaAir/laya/vfx/systems/VFXParticleSystem.ts
+++ b/src/layaAir/laya/vfx/systems/VFXParticleSystem.ts
@@ -50,7 +50,7 @@ let ID: {
     u_LoopIndex: number;
     u_EventCount: number;
     u_MaxSpawnCount: number;
-    // SpawnState operator (Unity SpawnState.cs 对齐) — Initialize stage uniforms
+    // SpawnState operator (SpawnState 对齐) — Initialize stage uniforms
     u_NewLoop: number;
     u_LoopState: number;
     u_SpawnCount: number;
@@ -198,13 +198,13 @@ export class VFXParticleSystem extends VFXSystem {
     particlePerStripCount: number = 128;
     stripCapacity: number = 1;
 
-    // 混合模式 — 对齐 Unity VFX Graph BlendMode
+    // 混合模式 — 对齐 BlendMode
     blendMode: import("../VFXAsset").VFXBlendMode = "Alpha" as any;
 
     // Soft Particle 淡出距离（eye 空间单位，0 = 关闭）
     softParticleFade: number = 0;
 
-    // Flipbook UV 模式 + 图集尺寸（对齐 Unity Output Context UV Mode）
+    // Flipbook UV 模式 + 图集尺寸（对齐 Output Context UV Mode）
     uvMode: string = "Default";
     flipbookSize: Vector2 = new Vector2(4, 4);
     // Flipbook atlas 资源（res:// uuid），uvMode != Default 时由 runtime 加载到 BillboardMaterial.u_AlbedoTexture
@@ -213,7 +213,7 @@ export class VFXParticleSystem extends VFXSystem {
     // Subpixel AA 开关
     subpixelAA: boolean = false;
 
-    // Strip output 专属字段（对齐 Unity Output Trail）
+    // Strip output 专属字段（对齐 Output Trail）
     stripColorMapping: string = "Default";   // "Default" | "GradientMapped"
     stripUvScale: { x: number, y: number } = { x: 1, y: 1 };
     stripUvBias: { x: number, y: number } = { x: 0, y: 0 };
@@ -223,7 +223,7 @@ export class VFXParticleSystem extends VFXSystem {
     // 自定义 Shader 名（空 = VFXUnlit）
     customShaderName: string = "";
 
-    // Billboard procedural 配置（对齐 Unity VFXPlanarPrimitiveOutput）
+    // Billboard procedural 配置（对齐 VFXPlanarPrimitiveOutput）
     // 空 = 走旧 mesh 路径；"Quad"/"Triangle"/"Octagon" = VFXBillboardGeometry
     billboardPrimitive: string = "";
     billboardVertexCount: number = 0;
@@ -255,7 +255,7 @@ export class VFXParticleSystem extends VFXSystem {
     spawnedCount: number = 0;
     eventCount: number = 0;
 
-    /** 本系统历史上已成功 Initialize 的粒子总数（用于 spawnIndex / particleId 与 Unity 对齐） */
+    /** 本系统历史上已成功 Initialize 的粒子总数（用于 spawnIndex / particleId 与源引擎对齐） */
     private _cumulativeSpawnTotal: number = 0;
 
     maxEventsPerFrame: number = 32;
@@ -671,7 +671,7 @@ export class VFXParticleSystem extends VFXSystem {
 
         // Strip: StripDataBuffer (5 uint per strip) for ring buffer tracking
         // Layout: [firstIndex, nextIndex, snapFirst, snapNext, minAlive(hi16)|maxAlive(lo16)]
-        // Matches Unity: firstIndex, nextIndex, prevNextIndex, minAlive, maxAlive
+        // 对齐: firstIndex, nextIndex, prevNextIndex, minAlive, maxAlive
         if (this.isStripOutput) {
             const stripCount = this.stripCapacity;
             const stripDataSize = stripCount * 5 * 4; // 5 uint per strip
@@ -761,7 +761,6 @@ export class VFXParticleSystem extends VFXSystem {
             // 包在 try-catch 中，确保 geometry 创建失败不会阻断后续的 Bounds 和 GPU Event 初始化
             try {
                 if (isStrip) {
-                    console.log(`[VFX] Creating StripGeometry: capacity=${capacity}, stripCap=${this.stripCapacity}, perStrip=${this.particlePerStripCount}, blend=${this.blendMode}`);
                     const stripParams = new VFXStripGeometryParams();
                     stripParams.capacity = capacity;
                     stripParams.stripVertexBuffer = this.renderBuffer;
@@ -779,7 +778,6 @@ export class VFXParticleSystem extends VFXSystem {
                     (this.geometry as any).stripGradientStops = this.stripGradientStops;
                     (this.geometry as any).stripTilingMode = this.stripTilingMode;
                     (this.geometry as any).stripPpsc = this.particlePerStripCount;
-                    console.log(`[VFX] StripGeometry created:`, this.geometry ? "OK" : "FAILED");
                 } else if (isPoint) {
                     const pointParams = new VFXPointGeometryParams();
                     pointParams.capacity = capacity;
@@ -805,7 +803,7 @@ export class VFXParticleSystem extends VFXSystem {
                     (this.geometry as any).blendMode = this.blendMode;
                     (this.geometry as any).outputType = this.outputType;
                 } else if (isBillboardProc) {
-                    // 对齐 Unity VFXPlanarPrimitiveOutput：DrawArrayIndirect + gl_VertexID 生成顶点
+                    // 对齐 VFXPlanarPrimitiveOutput：DrawArrayIndirect + gl_VertexID 生成顶点
                     const bbParams = new VFXBillboardGeometryParams();
                     bbParams.capacity = capacity;
                     bbParams.vertexCount = this.billboardVertexCount;
@@ -1032,12 +1030,7 @@ export class VFXParticleSystem extends VFXSystem {
     /**
      * 阶段3: Output — 压缩输出到 RenderBuffer
      */
-    private _outputLogOnce = false;
     outputPhase(state: VFXState, cmd: ComputeCommandBuffer): void {
-        if (!this._outputLogOnce && this.isStripOutput) {
-            this._outputLogOnce = true;
-            console.log(`[VFX OutputPhase] type=${this.outputType}, hasShader=${!!this.outputShader}, hasAlive=${!!this.aliveListBufferRead}, hasRender=${!!this.renderBuffer}, hasIndirect=${!!this.indirectBuffer}, isStrip=${this.isStripOutput}, geometry=${this.geometry?.constructor?.name}`);
-        }
         if (this.outputType === "none" || !this.outputShader) return;
         if (!this.aliveListBufferRead || !this.renderBuffer || !this.indirectBuffer) return;
 
@@ -1172,7 +1165,7 @@ export class VFXParticleSystem extends VFXSystem {
         shaderData.setInt(ID.u_TotalSpawnedCount, this._cumulativeSpawnTotal);
         shaderData.setInt(ID.u_SpawnedCount, sc);
         shaderData.setInt(ID.u_EventCount, this.eventCount);
-        // 传递 LoopIndex + SpawnState 全套（Unity SpawnState.cs 对齐）
+        // 传递 LoopIndex + SpawnState 全套（SpawnState 对齐）
         if (this.spawnerSystems.length > 0) {
             const spawner = this.effect.systems[this.spawnerSystems[0]] as VFXSpawnerSystem;
             if (spawner) {

--- a/src/layaAir/laya/vfx/systems/VFXSpawnerSystem.ts
+++ b/src/layaAir/laya/vfx/systems/VFXSpawnerSystem.ts
@@ -53,9 +53,9 @@ export class VFXSpawnerSystem extends VFXSystem {
         {
             const buffer = attrDesc.createBuffer();
             this.eventAttribute.initBuffer(buffer);
-            // 给关键 attribute 设 Unity 风格 default：粒子 setAttribute(lifetime, source=Source)
+            // 给关键 attribute 设源引擎风格 default：粒子 setAttribute(lifetime, source=Source)
             // 但 spawn event 没 setSpawnEventAttribute(lifetime) 时，src.lifetime=0 让粒子瞬死。
-            // Unity 默认 lifetime=1，保持一致避免 sample 默认配置不可见。
+            // 源引擎默认 lifetime=1，保持一致避免 sample 默认配置不可见。
             if (attrDesc.hasAttribute("lifetime")) {
                 this.eventAttribute.setFloat("lifetime", 1);
             }

--- a/src/layaAir/laya/vfx/systems/VFXSpawnerTask.ts
+++ b/src/layaAir/laya/vfx/systems/VFXSpawnerTask.ts
@@ -78,7 +78,7 @@ export class VFXSpawnerSingleBurst extends VFXSpawnerTask {
     // 循环开始后到首次爆发的延迟时间（x=min, y=max），单位：秒
     delay: Vector2 = new Vector2();
 
-    // 当为 true 时，burst count = spawnerState.loopIndex % countModulo（对齐 Unity VFX LoopIndex → burst count 连接）
+    // 当为 true 时，burst count = spawnerState.loopIndex % countModulo（对齐 LoopIndex → burst count 连接）
     countFromLoopIndex: boolean = false;
     countModulo: number = 0;
 
@@ -94,12 +94,12 @@ export class VFXSpawnerSingleBurst extends VFXSpawnerTask {
 
     play(): void {
         // VFX onPlay (stop → play / asset re-import) 应该让 SingleBurst 重新 fire 一次
-        // (跟 Unity 行为一致：每次 onPlay 视为一次新 VFX 生命周期)
+        // (与源引擎行为一致：每次 onPlay 视为一次新 VFX 生命周期)
         this.sleeping = false;
     }
 
     internalInit(rand: Rand): void {
-        // ⚠ 不要 reset sleeping — Unity SingleBurst 整个 VFX 生命周期只 fire 一次 (含 Infinite loop 模式).
+        // ⚠ 不要 reset sleeping — SingleBurst 整个 VFX 生命周期只 fire 一次 (含 Infinite loop 模式).
         // 之前每个 newLoop 重置 sleeping=false 让 durationMode=Infinite + SingleBurst 每个 loop 重新 fire
         // → 看起来 "粒子播放 2 次" (实际是无限次重 fire). UNI VFX1/2/3 都受影响.
         // 只在 VFX 完整重置 (init / play) 时才重置 sleeping.
@@ -120,7 +120,7 @@ export class VFXSpawnerSingleBurst extends VFXSpawnerTask {
 
         this.sleeping = true;
         if (this.countFromLoopIndex) {
-            // Unity Modulo(loopIndex, N) → count 语义：loop 0 spawn 0 颗，loop 1 spawn 1 颗，... loop N-1 spawn N-1 颗，loop N 又 0 颗循环。
+            // Modulo(loopIndex, N) → count 语义：loop 0 spawn 0 颗，loop 1 spawn 1 颗，... loop N-1 spawn N-1 颗，loop N 又 0 颗循环。
             // 之前写 `idx + 1` 让 loop 0 就 spawn 1 颗 texIndex=0 → 数字 atlas 起点错位（看到 "0" 而非 "1"）。
             const idx = this.countModulo > 0 ? (spawnerState.loopIndex % this.countModulo) : spawnerState.loopIndex;
             spawnerState.spawnCount += idx;
@@ -209,7 +209,7 @@ export class VFXSpawnerCustomWrapper extends VFXSpawnerTask {
     release(): void { }
 }
 
-// 写 spawn event attribute（对齐 Unity VFXSpawnerSetAttribute）
+// 写 spawn event attribute（对齐 VFXSpawnerSetAttribute）
 // 每帧把固定值或 loopIndex(%N) 写入 spawnerState.eventAttribute，
 // 让粒子 Initialize 阶段 setAttribute(attr, source=Source) 能读到。
 // 这是 Strip / GPU Event 链上 stripIndex / texIndex / lifetime 等正确分配的关键
@@ -219,7 +219,7 @@ export class VFXSpawnerSetEventAttribute extends VFXSpawnerTask {
     value: [number, number, number, number] = [0, 0, 0, 0];
     fromLoopIndex: boolean = false;
     loopIndexModulo: number = 0;
-    // Unity SpawnContext 模式：lifetime ← Add(spawnState.loopDuration, spawnState.delayAfterLoop)
+    // SpawnContext 模式：lifetime ← Add(spawnState.loopDuration, spawnState.delayAfterLoop)
     // runtime 时用 spawnerState.loopDuration + delayAfterLoop 当 lifetime 值
     fromSpawnStateLoop: boolean = false;
 

--- a/src/layaAir/laya/vfx/systems/VFXStaticMeshSystem.ts
+++ b/src/layaAir/laya/vfx/systems/VFXStaticMeshSystem.ts
@@ -12,7 +12,7 @@ import { Material } from "../../resource/Material";
 import { Laya } from "../../../Laya";
 
 /**
- * Unity VFXStaticMeshOutput 对齐：渲染单个 mesh，不跑 particle simulation
+ * VFXStaticMeshOutput 对齐：渲染单个 mesh，不跑 particle simulation
  * - 在 owner（VisualEffect 节点）下创建子 Sprite3D + MeshFilter + MeshRenderer
  * - 子节点 transform 默认 identity（mesh 跟随 owner 世界 transform）
  * - material 由 .vfx props 提供 UUID，runtime 异步加载；未指定 / 加载失败 fallback unlit material


### PR DESCRIPTION
## 背景
整理引擎 VFX 运行时源码（`src/layaAir/laya/vfx/`）的注释与日志。

## 改动
- **去 Unity 字样**：移除注释中的 "Unity" 关键字，仅改注释文本、保留技术含义（如「对齐 Unity VFXPlanarPrimitiveOutput」→「对齐 VFXPlanarPrimitiveOutput」）。
- **清理日志**：移除开发期遗留的调试/成功 `console.log`（自定义 shader 预加载/加载成功、解析统计、alpha/strip 调试追踪等）及注释掉的死 log，并删除仅为这些调试日志服务的一次性守卫变量与临时采集。
- **保留诊断**：全部 `console.warn` / `console.error` 失败诊断原样保留。

## 安全性
纯注释与日志改动，不涉及任何逻辑、标识符、字段或类型变更。全部改动文件经 TypeScript `transpileModule` 语法校验通过（0 语法错误）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
