### PR TITLE
fix(forum-55440): Spine additive blend mode alpha double-multiplication when premultiplied alpha is enabled

### DIFF
--- a/src/layaAir/laya/spine/material/SpineShaderInit.ts
+++ b/src/layaAir/laya/spine/material/SpineShaderInit.ts
@@ -51,9 +51,9 @@ export class SpineShaderInit {
      */
     static SetSpineBlendMode(value: number, mat: Material, premultipliedAlpha = true) {
         switch (value) {
-            case 1: //Additive 
+            case 1: //Additive
                 mat.blend = RenderState.BLEND_ENABLE_ALL;
-                mat.blendSrc = RenderState.BLENDPARAM_SRC_ALPHA;
+                mat.blendSrc = premultipliedAlpha ? RenderState.BLENDPARAM_ONE : RenderState.BLENDPARAM_SRC_ALPHA;
                 mat.blendDst = RenderState.BLENDPARAM_ONE;
                 break;
             case 3: //Screen


### PR DESCRIPTION
修复论坛反馈 https://ask.layaair.com/d/55440-3dchang-jing-xia-de-she-zhi-liao-xiang-jia-de-spinezi-yuan-alphadu-ming-xian-geng-di-yu-spinebian-ji-qi-de