### PR TITLE
fix: unwrap Filter shell in PostProcess2D.addEffect to avoid effectInit crash（PostProcess2D.addEffect 兼容直接传入 Filter 外壳，自动解包避免 effectInit 报错）

### DIFF
--- a/src/layaAir/laya/display/PostProcess2D.ts
+++ b/src/layaAir/laya/display/PostProcess2D.ts
@@ -1,4 +1,5 @@
 import { EventDispatcher } from "../events/EventDispatcher";
+import { Filter } from "../filters/Filter";
 import { LayaGL } from "../layagl/LayaGL";
 import { Vector2 } from "../maths/Vector2";
 import { ShaderData } from "../RenderDriver/DriverDesign/RenderDevice/ShaderData";
@@ -155,6 +156,11 @@ export class PostProcess2D extends EventDispatcher {
     * @param effect 要添加的后期处理效果。
     */
    addEffect<T extends PostProcess2DEffect>(effect: T): T | null {
+      // 兼容旧用法：允许直接传入 ColorFilter/GlowFilter/BlurFilter 等 Filter 外壳，自动解包为真正的 effect
+      if (effect instanceof Filter) {
+         effect = effect.getEffect() as unknown as T;
+      }
+
       if (effect.destroyed) {
          console.error("the target effect is destroyed", effect);
          return null;


### PR DESCRIPTION
## 问题
开发者反馈：直接调用 `PostProcess2D.addEffect(filter)` 或 `postProcess.effects = [filter]` 时报错 `TypeError: effect.effectInit is not a function`。

## 原因
LayaAir 3.4 中 `ColorFilter` / `GlowFilter` / `BlurFilter` 只是 `Filter` 外壳，真正的 `PostProcess2DEffect` 需要通过 `filter.getEffect()` 取出（内部 `_effect2D`）。`Filter` 基类没有 `effectInit` / `destroyed` / `singleton` 等 `PostProcess2DEffect` 成员。h5game 旧代码直接把 `Filter` 塞进 `postProcess.effects` / `addEffect`，到 3.4 就会在 `addEffect` 内部调用 `effect.effectInit(this)` 时抛异常。`effects` setter 内部也逐个走 `addEffect`，同样中招。

## 修复
在 `PostProcess2D.addEffect` 入口做一次兼容解包：入参是 `Filter` 时自动取 `getEffect()`。`addEffect` 是唯一收敛点，`effects` setter 一并覆盖；`Sprite.filters` 本就传 `getEffect()` 的正确路径，`instanceof Filter` 为 false 原样通过，幂等无副作用。

```ts
addEffect<T extends PostProcess2DEffect>(effect: T): T | null {
   if (effect instanceof Filter) {
      effect = effect.getEffect() as unknown as T;
   }
   ...
}
```

## 验证
在基于 3.4 引擎的 WxWebGPU 工程中复现并验证：
- 修复前：`addEffect(filter)` 与 `effects=[filter]` 两条路径均抛 `effect.effectInit is not a function`。
- 修复后：两条路径均正常，且去饱和的 `ColorFilter` 真正生效（测试色块变灰），说明 effect 被正确解包并进入渲染管线。

仅改动一个文件 `src/layaAir/laya/display/PostProcess2D.ts`，不涉及子模块。

🤖 Generated with [Claude Code](https://claude.com/claude-code)