### PR TITLE
fix: ImageRenderer listens to texture reload at runtime, not only in editor（ImageRenderer 运行时也监听纹理 reload 事件，修复 GLoader 纹理重载后不刷新的显示丢失/黑图）

### DIFF
--- a/src/layaAir/laya/ui2/ImageRenderer.ts
+++ b/src/layaAir/laya/ui2/ImageRenderer.ts
@@ -1,4 +1,3 @@
-import { NodeFlags } from "../Const";
 import { Draw9GridTextureCmd } from "../display/cmd/Draw9GridTextureCmd";
 import { DrawTextureCmd } from "../display/cmd/DrawTextureCmd";
 import { DrawTrianglesCmd } from "../display/cmd/DrawTrianglesCmd";
@@ -25,8 +24,7 @@ export class ImageRenderer {
 
     destroy() {
         if (this._tex) {
-            if (this._owner._getBit(NodeFlags.EDITING_NODE))
-                this._tex.off("reload", this, this.onTextureReload);
+            this._tex.off("reload", this, this.onTextureReload);
             this._tex = null;
         }
         if (this._drawCmd) {
@@ -36,13 +34,12 @@ export class ImageRenderer {
     }
 
     setTexture(value: Texture) {
-        if (this._tex && this._owner._getBit(NodeFlags.EDITING_NODE))
+        if (this._tex)
             this._tex.off("reload", this, this.onTextureReload);
 
         this._tex = value;
         if (value) {
-            if (this._owner._getBit(NodeFlags.EDITING_NODE))
-                value.on("reload", this, this.onTextureReload);
+            value.on("reload", this, this.onTextureReload);
 
             this.createCmd();
         }


### PR DESCRIPTION
## 问题
开发者反馈：使用 ui2 的 `GLoader` 加载图片，运行一段时间后出现图片显示丢失/黑图/错误。

## 原因
ui2 的 `GLoader`/`GImage` 使用 `ImageRenderer` 渲染纹理。`ImageRenderer` **只在编辑器（`EDITING_NODE`）里监听纹理的 `"reload"` 事件，运行时不监听**。

而引擎的内存管理会在运行时释放纹理 bitmap（标记 `obsolute`），下次用到再按需重载。重载时 `TextureLoader.wrapTex2D` 会复用同一个 `Texture` 对象、`setTo` 换上新 bitmap，然后派发 `tex.event("reload")` 通知使用方重画。老 UI 系统的 `AutoBitmap` 是**无条件**监听该事件的，所以老的 `GImage` 会响应刷新；新 ui2 的 `ImageRenderer` 把监听 gate 到了编辑器，运行时收不到通知 → GLoader 的 graphics 不 repaint → 停留在纹理被释放时的那一帧（黑图/残缺）。属于「新 UI 系统」引入的回归。

## 修复
将 `ImageRenderer` 对纹理 `"reload"` 的监听改为**无条件注册/注销**（去掉 `EDITING_NODE` 判断），与老 UI 的 `AutoBitmap` 行为对齐；顺带移除因此不再使用的 `NodeFlags` import。

```ts
setTexture(value: Texture) {
    if (this._tex)
        this._tex.off("reload", this, this.onTextureReload);
    this._tex = value;
    if (value) {
        value.on("reload", this, this.onTextureReload);   // 运行时也监听
        this.createCmd();
    }
    ...
}
```

## 验证
在基于 3.4 引擎的 WxWebGPU 工程中写了确定性复现：4 个 GLoader 各加载一张图 → 释放全部纹理 bitmap → 重新 load 触发 `"reload"`。用一个直接挂在纹理上的探针证明 reload 确实派发（4/4），再看 GLoader 是否响应（`onTextureReload` 会再派发一次 `Event.LOADED`）。
- 修复前：探针 4/4 派发，但 GLoader LOADED 次数停在 `1,1,1,1`（0/4 响应）。
- 修复后：探针 4/4 派发，GLoader LOADED 次数变为 `2,2,2,2`（4/4 响应并刷新）。

仅改动一个文件 `src/layaAir/laya/ui2/ImageRenderer.ts`，不涉及子模块。

🤖 Generated with [Claude Code](https://claude.com/claude-code)