### PR TITLE
修正 KTX 纹理丢失 sRGB 信息

### DIFF
--- a/src/layaAir/laya/loaders/TextureLoader.ts
+++ b/src/layaAir/laya/loaders/TextureLoader.ts
@@ -103,6 +103,15 @@ export class Texture2DLoader implements IResourceLoader {
             propertyParams = task.options.propertyParams;
         }
 
+        const applyTextureCubeProperties = (texture: BaseTexture) => {
+            if (!propertyParams)
+                return;
+            texture.wrapModeU = propertyParams.wrapModeU;
+            texture.wrapModeV = propertyParams.wrapModeV;
+            texture.filterMode = propertyParams.filterMode;
+            texture.anisoLevel = propertyParams.anisoLevel;
+        };
+
         let compress = compressedFormats.indexOf(ext) != -1 ? ext : null;
         if (compress != null) {
             return task.loader.fetch(url, "arraybuffer", task.progress.createCallback(), task.options).then(data => {
@@ -118,8 +127,10 @@ export class Texture2DLoader implements IResourceLoader {
                             let cls = ClassUtils.getClass("TextureCube");
                             if (cls) {
                                 let srgb = constructParams ? !!constructParams[5] : false;
-                                let tc = new cls(ddsInfo.width, ddsInfo.format, ddsInfo.mipmapCount > 1, srgb);
+                                let premultiplyAlpha = propertyParams ? propertyParams.premultiplyAlpha : false;
+                                let tc = new cls(ddsInfo.width, ddsInfo.format, ddsInfo.mipmapCount > 1, srgb, premultiplyAlpha);
                                 tc.setDDSData(ddsInfo);
+                                applyTextureCubeProperties(tc);
                                 tex = tc;
                             }
                             else {
@@ -138,8 +149,10 @@ export class Texture2DLoader implements IResourceLoader {
                             let cls = ClassUtils.getClass("TextureCube");
                             if (cls) {
                                 let sRGB = constructParams ? !!constructParams[5] : ktxInfo.sRGB;
-                                let tc = new cls(ktxInfo.width, ktxInfo.format, ktxInfo.mipmapCount > 1, sRGB);
+                                let premultiplyAlpha = propertyParams ? propertyParams.premultiplyAlpha : false;
+                                let tc = new cls(ktxInfo.width, ktxInfo.format, ktxInfo.mipmapCount > 1, sRGB, premultiplyAlpha);
                                 tc.setKTXData(ktxInfo);
+                                applyTextureCubeProperties(tc);
                                 tex = tc;
                             }
                             else

--- a/src/layaAir/laya/loaders/TextureLoader.ts
+++ b/src/layaAir/laya/loaders/TextureLoader.ts
@@ -137,7 +137,8 @@ export class Texture2DLoader implements IResourceLoader {
                             //这里在core模块，不能直接引用d3里的TextureCube
                             let cls = ClassUtils.getClass("TextureCube");
                             if (cls) {
-                                let tc = new cls(ktxInfo.width, ktxInfo.format, ktxInfo.mipmapCount > 1, ktxInfo.sRGB);
+                                let sRGB = constructParams ? !!constructParams[5] : ktxInfo.sRGB;
+                                let tc = new cls(ktxInfo.width, ktxInfo.format, ktxInfo.mipmapCount > 1, sRGB);
                                 tc.setKTXData(ktxInfo);
                                 tex = tc;
                             }

--- a/src/layaAir/laya/resource/Texture2D.ts
+++ b/src/layaAir/laya/resource/Texture2D.ts
@@ -252,7 +252,8 @@ export class Texture2D extends BaseTexture {
     static _parseKTX(data: ArrayBuffer, propertyParams: TexturePropertyParams = null, constructParams: TextureConstructParams = null) {
         let ktxInfo = KTXTextureInfo.getKTXTextureInfo(data);
 
-        let texture = new Texture2D(ktxInfo.width, ktxInfo.height, ktxInfo.format, ktxInfo.mipmapCount > 1, false, ktxInfo.sRGB);
+        let sRGB = constructParams ? !!constructParams[5] : ktxInfo.sRGB;
+        let texture = new Texture2D(ktxInfo.width, ktxInfo.height, ktxInfo.format, ktxInfo.mipmapCount > 1, false, sRGB);
 
         texture.setKTXData(ktxInfo);
         if (propertyParams){
@@ -436,4 +437,4 @@ export class Texture2D extends BaseTexture {
             if (propertyParams.anisoLevel != null) this.anisoLevel = propertyParams.anisoLevel;
         }
     }
-}
+}


### PR DESCRIPTION
- 修复 KTX 纹理 sRGB 配置丢失问题
- 补齐 DDS/KTX 立方体纹理的 wrapMode、filterMode、anisoLevel 和 pma 配置。