### PR TITLE
fix: skip destroyed struct and stale render element in 2D render pass（2D 渲染跳过已销毁 struct 与失效 render element，修复 GList 虚拟滚动崩溃）

### DIFF
--- a/src/layaAir/laya/RenderDriver/RenderModuleData/WebModuleData/2D/WebRender2DPass.ts
+++ b/src/layaAir/laya/RenderDriver/RenderModuleData/WebModuleData/2D/WebRender2DPass.ts
@@ -166,7 +166,9 @@ export class WebRender2DPass implements IRender2DPass {
 
    cullAndSort(context2D: IRenderContext2D, struct: WebRenderStruct2D): void {
       if (
-         !struct.enabled
+         !struct
+         || struct.destroyed        // 已销毁 struct 若仍残留在树里, 跳过其及子树(原始 globalAlpha/globalRenderData 崩溃点兜底)
+         || !struct.enabled
          || struct.globalAlpha < 0.01
          || this._mask === struct
       )
@@ -242,6 +244,9 @@ export class WebRender2DPass implements IRender2DPass {
       let success = this._initRenderProcess(context, renderTime);
       if (!success) return;
 
+      // 本帧有内容暂不可用(如 mask subStruct 未就绪)时置 true, 末尾据此保持 repaint 以便下帧重试
+      let deferRepaint = false;
+
       if (this.repaint) {
          // if (true) {
          this._structs.reset();
@@ -262,9 +267,15 @@ export class WebRender2DPass implements IRender2DPass {
 
          if (this._mask) {
             let renderMask = this._mask.subStruct;
-            renderMask._handleInterData();
-            renderMask.renderUpdate(context);
-            context.drawRenderElementOne(renderMask.renderElements[0]);
+            // mask 的 subStruct 可能尚未就绪(undefined)或已销毁：本帧跳过合成, 避免崩溃
+            if (renderMask && !renderMask.destroyed) {
+               renderMask._handleInterData();
+               renderMask.renderUpdate(context);
+               context.drawRenderElementOne(renderMask.renderElements[0]);
+            } else {
+               // mask 未就绪/已失效: 本帧跳过, 保持 repaint 下帧重试(否则会进入非重绘快路径, mask 永不再合成)
+               deferRepaint = true;
+            }
          }
 
          // 处理后期处理
@@ -272,20 +283,32 @@ export class WebRender2DPass implements IRender2DPass {
             this.postProcess.apply();
          }
       } else {
+         let stale = false;
          this._structs.indice.forEach(index => {
             let list = this._structs.lists.get(index);
             for (let i = 0, cnt = list.length; i < cnt; i++) {
                let struct = list.elements[i];
+               // 缓存里残留已销毁/失效的 struct(孤儿): 说明 _renderElements 也脏了
+               if (!struct || struct.destroyed) {
+                  stale = true;
+                  continue;
+               }
                struct._handleInterData();
                struct.renderUpdate(context);
             }
          });
 
+         if (stale) {
+            // 本帧不画脏的 _renderElements(避免画到已销毁元素在 shader 编译时崩), 强制下帧重建
+            this.repaint = true;
+            return;
+         }
+
          WebRender2DPass.uploadBuffer();
          context.drawRenderElementList(this._renderElements);
       }
 
-      this.repaint = false;
+      this.repaint = deferRepaint;
    }
 
    private fillRenderElements(): void {

--- a/src/layaAir/laya/RenderDriver/RenderModuleData/WebModuleData/2D/WebRenderStruct2D.ts
+++ b/src/layaAir/laya/RenderDriver/RenderModuleData/WebModuleData/2D/WebRenderStruct2D.ts
@@ -237,6 +237,9 @@ export class WebRenderStruct2D implements IRenderStruct2D {
    /** 是否启动 */
    enabled: boolean = true;
 
+   /** @internal 已销毁标记：destroy 后仍可能残留在某个 pass 的 _structs 缓存里, 渲染遍历据此跳过 */
+   destroyed: boolean = false;
+
    //渲染数据
    isRenderStruct: boolean = false;
 
@@ -740,6 +743,12 @@ export class WebRenderStruct2D implements IRenderStruct2D {
    removeChild(child: WebRenderStruct2D): void {
       const index = this.children.indexOf(child);
       if (index !== -1) {
+         // 摘除前拿到子节点当前所在 pass(带 cacheAs 的父其子渲染在父的 subpass, 不是 this.pass), 标记其重绘:
+         // 让该 pass 的 _structs/_renderElements 缓存重建, 不再残留对这个(随后可能被销毁的)子 struct 的引用,
+         // 避免 else 快路径复用到已销毁 struct 的元素而在 _handleInterData / shader 编译时崩溃
+         let childPass = child.pass;
+         if (childPass) childPass.repaint = true;
+
          child.parent = null;
          this.children.splice(index, 1);
 
@@ -771,6 +780,7 @@ export class WebRenderStruct2D implements IRenderStruct2D {
    }
 
    destroy(): void {
+      this.destroyed = true;
       this._clipInfo = null;
       this._currentData = null;
       this._parentData = null;

--- a/src/layaAir/laya/RenderDriver/WebGLDriver/2DRenderPass/WebGLPrimitiveRenderElement2D.ts
+++ b/src/layaAir/laya/RenderDriver/WebGLDriver/2DRenderPass/WebGLPrimitiveRenderElement2D.ts
@@ -84,6 +84,10 @@ export class WebGLPrimitiveRenderElement2D extends WebGLRenderElement2D implemen
 
 
     override _render(context: WebglRenderContext2D) {
+        // 未就绪/已回收的元素(owner/subShader/缓存条目缺失, 常见于池化元素残留在 pass 的 _renderElements 里):
+        // 跳过, 避免 this.owner.getClipInfo() 等对 null 取属性崩溃(等 pass 重绘拿到有效元素再画)
+        if (!this.owner || !this._subShader || !this._curCacheEntry) return;
+
         let inss = this._curCacheEntry.shaderInss;
         let count = inss.length;
 

--- a/src/layaAir/laya/RenderDriver/WebGLDriver/2DRenderPass/WebGLRenderElement2D.ts
+++ b/src/layaAir/laya/RenderDriver/WebGLDriver/2DRenderPass/WebGLRenderElement2D.ts
@@ -185,6 +185,10 @@ export class WebGLRenderElement2D implements IRenderElement2D {
     }
 
     _prepare(context: WebglRenderContext2D) {
+        // 元素未就绪(subShader 未配置): 常见于池化元素被回收/复用后仍残留在某 pass 的 _renderElements 缓存里,
+        // 此时跳过, 避免 _compileShader 读 this._subShader._passes 崩溃(等 pass 重绘拿到有效元素再画)
+        if (!this._subShader) return;
+
         this.globalShaderData = this.owner && this.owner._globalShaderData as WebGLShaderData;
 
         let entry = this._getOrCreateCacheEntry(context);
@@ -204,6 +208,9 @@ export class WebGLRenderElement2D implements IRenderElement2D {
     }
 
     _render(context: WebglRenderContext2D) {
+        // 未就绪/未编译的元素(subShader 空或无缓存条目): 跳过, 与 _prepare 的守卫配套
+        if (!this._subShader || !this._curCacheEntry) return;
+
         // 非 Primitive 元素打断快速路径链
         context._prevTypeKey = -1;
         context._prevTextureKey = -1;


### PR DESCRIPTION
## 问题
打开带 fairygui `GList` 滚动组件的界面、或虚拟列表频繁滚动/回收/销毁重建 item 时，2D 渲染路径出现多处空指针崩溃，例如：
- `Cannot read properties of null (reading 'globalAlpha' / 'globalRenderData')` at `WebRender2DPass.cullAndSort`
- `Cannot read properties of undefined (reading '_handleInterData')` at `WebRender2DPass.fowardRender`
- `Cannot read properties of null (reading 'clipInfo' / '_passes' / 'getClipInfo')` at 渲染元素 `_compileShader` / `_render`

## 根因
虚拟滚动在极端 churn 下会频繁 **移除+销毁子节点 / 回收 render element**。被销毁的 `WebRenderStruct2D` 及被回收的 render element **仍残留在所属 pass 的 `_structs` / `_renderElements` 缓存中**；当该 pass 处于「非重绘快路径」时复用这些脏缓存，遍历/绘制到已失效对象 → 读到 null 字段崩溃。核心是**结构/元素被销毁回收后，pass 缓存未被正确失效**。

## 修复
**根因层**（`WebRenderStruct2D`）：
- 新增 `destroyed` 标记，`destroy()` 置位；
- `removeChild()` 在摘除前捕获子节点**真实所在的 pass**（带 cacheAs/mask 的父，其子渲染在父的 subpass，而非父自身 pass）并标记其 `repaint`，让缓存重建、不残留对被移除子 struct 的引用。

**Pass 层**（`WebRender2DPass`）：
- `cullAndSort` 入口跳过已销毁 struct（原始 `globalAlpha` 崩溃点兜底）；
- `fowardRender` mask 分支：subStruct 未就绪/已失效时本帧跳过合成，并保持 `repaint` 下帧重试；
- `fowardRender` 非重绘分支：发现 `_structs` 缓存含已销毁 struct 时，本帧不绘制脏的 `_renderElements` 并强制下帧重建。

**渲染元素兜底层**（`WebGLRenderElement2D` / `WebGLPrimitiveRenderElement2D`）：
- `_prepare` / `_render` 跳过未就绪/已回收的元素（`subShader` / `owner` / `_curCacheEntry` 为空），避免绘制到失效元素崩溃。

## 验证
在基于 3.4 引擎的工程中用同事提供的必现压力用例复现并验证：1000 项虚拟滚动 GList，每帧疯狂滚动 + `itemRenderer` 里销毁重建子节点 + 反复切 `cacheAs`/`mask`，并每帧递归校验渲染 struct 树父子一致性。
- 修复前：数十帧内即崩（多处不同空指针）。
- 修复后：连续跑满 **5000 帧无崩溃、无 struct 错位、0 报错**。

经独立代码审查复核：`removeChild` 取 pass 时机正确、`destroyed` 免复位假设成立（`createRenderStruct2D` 无对象池）、元素级守卫不会误伤正常元素、`stale` 提前 return 跳过 `uploadBuffer` 无副作用。

本 PR 仅含共享层 + WebGL 驱动改动，不涉及子模块；WebGPU 驱动的同类元素级守卫将另行补充。

🤖 Generated with [Claude Code](https://claude.com/claude-code)