### PR TITLE
feat: VFX engine-sync + per-particle-shading + uni-align 统一 (rebase 到最新 LayaAir_3.4, 解决 #2250/#2248/#2240 合并冲突)

### DIFF
--- a/src/layaAir/laya/vfx/ShaderExpressionEvaluator.ts
+++ b/src/layaAir/laya/vfx/ShaderExpressionEvaluator.ts
@@ -49,6 +49,16 @@ export interface ExprEvalContext {
 }
 
 export class ShaderExpressionEvaluator {
+    /**
+     * 转换器 unity-shader-to-laya.js 注入的“年龄中位数”全局常量 slot 名。
+     * SampleCurve(time = 该常量) 表示按 age 驱动 → 无法在全局表达式里 per-particle 采样，
+     * 走 {@link _sampleCurveAverage} 的时间平均近似。两端约定共用，改名需同步转换器。
+     */
+    static readonly AGE_MEDIAN_SLOT_NAME = "ageMedian";
+
+    /** {@link _sampleCurveAverage} 在 [0,1] 区间的中点采样点数，越大越精确、开销越高。 */
+    static readonly CURVE_AVERAGE_SAMPLE_COUNT = 32;
+
     /** evaluate 单个 expression graph，返回 root 节点的求值结果 */
     static evaluate(graph: ExprGraph, ctx: ExprEvalContext): any {
         if (!graph || !graph.nodes || !graph.rootNodeId) return null;
@@ -132,8 +142,18 @@ export class ShaderExpressionEvaluator {
             }
             case "SampleCurve": {
                 const curve = this._evalNode(n.inputs![0], nodes, cache, ctx) as CurveData;
-                const t = Number(this._evalNode(n.inputs![1], nodes, cache, ctx)) || 0;
-                result = this._sampleCurve(curve, t);
+                const timeNode = nodes[n.inputs![1]] as any;
+                // age 驱动的 SampleCurve(time=ageMedian 全局常量)在全局表达式里无法 per-particle 采样。
+                // 用曲线在 [0,1] 的【时间平均值】—— 数学上等于 Unity per-particle 随年龄采样后所有粒子的平均
+                // (粒子年龄在常 spawn 下均匀分布 [0,1])→ 整体亮度与 Unity 对齐。
+                // 注:Alpha_Multiplier 已在 VisualEffect._evaluateShaderExpressions 走真·per-particle 曲线 uniform,
+                // 此平均仅作其它 age 驱动属性 / per-particle 未注入时的兜底近似。
+                if (timeNode && timeNode.kind === "Constant" && timeNode.slotName === ShaderExpressionEvaluator.AGE_MEDIAN_SLOT_NAME) {
+                    result = this._sampleCurveAverage(curve);
+                } else {
+                    const t = Number(this._evalNode(n.inputs![1], nodes, cache, ctx)) || 0;
+                    result = this._sampleCurve(curve, t);
+                }
                 break;
             }
             case "Add":
@@ -255,7 +275,7 @@ export class ShaderExpressionEvaluator {
     }
 
     /** Unity AnimationCurve sample — 简化 linear lerp（不算 Hermite tangent，足够多数 material uniform 用例） */
-    private static _sampleCurve(c: CurveData, t: number): number {
+    static _sampleCurve(c: CurveData, t: number): number {
         // curve 未提供 → return null 让 caller skip setUniform 让 ShaderGraph default 生效
         if (!c) return null as any;
         if (!c.frames || c.frames.length === 0) return 0;
@@ -270,6 +290,16 @@ export class ShaderExpressionEvaluator {
         const denom = (f1.time - f0.time) || 1;
         const u = (clamp - f0.time) / denom;
         return f0.value + (f1.value - f0.value) * u;
+    }
+
+    /** 曲线在 [0,1] 的时间平均值（中点采样，点数见 {@link CURVE_AVERAGE_SAMPLE_COUNT}）— 见 SampleCurve 的 ageMedian 分支 */
+    static _sampleCurveAverage(c: CurveData): number {
+        if (!c || !c.frames || c.frames.length === 0) return 0;
+        if (c.frames.length === 1) return c.frames[0].value;
+        const N = this.CURVE_AVERAGE_SAMPLE_COUNT;
+        let sum = 0;
+        for (let i = 0; i < N; i++) sum += this._sampleCurve(c, (i + 0.5) / N);
+        return sum / N;
     }
 
     private static _binOp(kind: string, a: any, b: any): any {

--- a/src/layaAir/laya/vfx/VFXAssetParser.ts
+++ b/src/layaAir/laya/vfx/VFXAssetParser.ts
@@ -24,9 +24,6 @@ export class VFXAssetParser {
 
         const vfxAsset = new VFXAsset();
 
-        console.log(`[VFX-DBG] runtime parse systems=${(data.systems || []).length}`,
-            (data.systems || []).map((s: any, i: number) => `${i}:${s.type}${s.capacity != null ? `(cap=${s.capacity})` : ""}`).join(","));
-
         // 解析 updateMode
         let updateMode = VFXUpdateMode.FixedDeltaTime;
         if (data.fixedDeltaTime === false) {

--- a/src/layaAir/laya/vfx/VFXAssetParser.ts
+++ b/src/layaAir/laya/vfx/VFXAssetParser.ts
@@ -735,34 +735,41 @@ export class VFXAssetParser {
  * 用于 sampleGradient operator 的 inline gradient 分支（textureLod(tex, vec2(t, 0.5), 0)）
  * 与 VisualEffect.bakeGradientTexture（Graph Property 用）算法一致但独立定义避免跨文件耦合
  */
+// float32 → float16 bits（渐变 HDR 烘焙用；R16G16B16A16=rgba16float 原始字节直传）
+const _f16ScratchF32 = new Float32Array(1);
+const _f16ScratchU32 = new Uint32Array(_f16ScratchF32.buffer);
+function _f32ToF16(v: number): number {
+    _f16ScratchF32[0] = v;
+    const bits = _f16ScratchU32[0];
+    const sign = (bits >> 16) & 0x8000;
+    const exp = ((bits >> 23) & 0xff) - 127 + 15;
+    const frac = bits & 0x7fffff;
+    if (exp <= 0) {
+        if (exp < -10) return sign;
+        const m = (frac | 0x800000) >> (1 - exp);
+        return sign | (m >> 13);
+    }
+    if (exp >= 31) return sign | 0x7c00;
+    return sign | (exp << 10) | (frac >> 13);
+}
+
 function bakeInlineGradientTexture(stops: { t: number; color: [number, number, number, number] }[]): Texture2D {
     const width = 256;
-    const data = new Uint8Array(width * 4);
+    const data = new Uint16Array(width * 4);
     const rawKeys = stops.length >= 2 ? stops : [
         { t: 0, color: [1, 1, 1, 1] as [number, number, number, number] },
         { t: 1, color: [1, 1, 1, 0] as [number, number, number, number] },
     ];
-    // Unity Gradient editor 用 HDR color picker 输出值 (e.g., 0,89.97,46.39) → 没 HDR pipeline 时需 clamp 到 [0,1]
-    // 之前 per-channel clamp 让所有三通道都 >1 的 HDR 颜色（如 (1.22, 5.66, 3.62) HDR teal）变成 (1,1,1) 纯白
-    // 丢失 chroma → TexIndexAdvanced Core Cube 这种 stop 该显示 teal 但 Laya 显示纯白
-    // 修：per-stop 用 max-channel 归一化保留 chroma 方向，仅 max>1 时缩放（max<=1 保留原值）
-    //   (1.22, 5.66, 3.62) max=5.66 → (0.216, 1.0, 0.640) 保留 teal-green chroma
-    //   (2.95, 0.012, 0.24) max=2.95 → (1.0, 0.004, 0.081) 保留 red chroma
-    // 副作用：失去 Unity HDR 强度信息（bloom glow 不可见），但 chroma 准确
-    const normalizeStop = (c: number[]): [number, number, number, number] => {
-        const r = Math.max(0, c[0]);
-        const g = Math.max(0, c[1]);
-        const b = Math.max(0, c[2]);
-        const a = Math.max(0, Math.min(1, c[3]));
-        const maxRGB = Math.max(r, g, b);
-        if (maxRGB > 1) {
-            return [r / maxRGB, g / maxRGB, b / maxRGB, a];
-        }
-        return [r, g, b, a];
-    };
+    // ⭐2026-06-11 HDR 直通：烘到 R16G16B16A16 半精度浮点纹理，不再 max-channel 归一化。
+    // 归一化是 LDR framebuffer 时代的 crutch——保了 chroma 但丢强度，让 Unity 的 HDR 红(23.97,0,0)
+    // 在 additive 下永远压不过低强度橙 → Buff 爆心橙白 vs Unity 饱和红的根因。
+    // 场景 enableHDR(浮点 framebuffer)下直通才是 Unity 语义(LDR 场景 clip 爆白同样是 Unity 行为)。
+    const sanitizeStop = (c: number[]): [number, number, number, number] => [
+        Math.max(0, c[0]), Math.max(0, c[1]), Math.max(0, c[2]), Math.max(0, Math.min(1, c[3])),
+    ];
     const keys = rawKeys.map(k => ({
         t: k.t,
-        color: normalizeStop(k.color),
+        color: sanitizeStop(k.color),
     }));
     for (let i = 0; i < width; i++) {
         const t = i / (width - 1);
@@ -776,12 +783,12 @@ function bakeInlineGradientTexture(stops: { t: number; color: [number, number, n
         const g = a.color[1] + (b.color[1] - a.color[1]) * u;
         const bB = a.color[2] + (b.color[2] - a.color[2]) * u;
         const aA = a.color[3] + (b.color[3] - a.color[3]) * u;
-        data[i * 4]     = Math.round(r * 255);
-        data[i * 4 + 1] = Math.round(g * 255);
-        data[i * 4 + 2] = Math.round(bB * 255);
-        data[i * 4 + 3] = Math.round(aA * 255);
+        data[i * 4]     = _f32ToF16(r);
+        data[i * 4 + 1] = _f32ToF16(g);
+        data[i * 4 + 2] = _f32ToF16(bB);
+        data[i * 4 + 3] = _f32ToF16(aA);
     }
-    const tex = new Texture2D(width, 1, TextureFormat.R8G8B8A8, false, false, false, false);
+    const tex = new Texture2D(width, 1, TextureFormat.R16G16B16A16, false, false, false, false);
     tex.setPixelsData(data, false, false);
     tex.wrapModeU = WrapMode.Clamp;
     tex.wrapModeV = WrapMode.Clamp;

--- a/src/layaAir/laya/vfx/VFXRenderer.ts
+++ b/src/layaAir/laya/vfx/VFXRenderer.ts
@@ -551,8 +551,13 @@ export class VFXRenderer extends BaseRender {
      * 反查到 res:// url 异步加载（每次只 kick off 一次），返回 VFXUnlit fallback；
      * .bps 加载完成后下一次 getCustomShaderMaterial 调用会命中已注册 shader。
      */
-    static getCustomShaderMaterial(shaderName: string, blendMode: string = "Alpha"): Material {
-        const key = `${shaderName}__${blendMode}`;
+    static getCustomShaderMaterial(shaderName: string, blendMode: string = "Alpha", instanceKey: string = ""): Material {
+        // instanceKey: per-system 材质实例标识。多个粒子系统共用同一 custom shader(如 UNI-Masked)时,
+        // 共享材质会让各 system 的 per-system uniform(shaderPropertyDefaults 的 _MaskTexture、
+        // per-particle 烘焙的 Alpha_Multiplier 年龄曲线/Disappear 曲线/颜色渐变)每帧互相覆盖
+        // (Barrier rings 的 mask/alpha 被 walls 覆盖 → 顶部亮环变暗的根因)。
+        // Unity 每个 output 是独立 material 实例,这里用 system 级 key 对齐。
+        const key = `${shaderName}__${blendMode}__${instanceKey}`;
         let mat = VFXRenderer._customShaderMaterialCache.get(key);
         if (mat) return mat;
 
@@ -576,7 +581,7 @@ export class VFXRenderer extends BaseRender {
                     .catch((err: any) => console.warn(`[VFX Renderer] custom shader '${shaderName}' load failed`, err));
             }
             // Shader 还没注册：返回 VFXUnlit fallback，不缓存（让下一帧重试）
-            return VFXRenderer.getCustomShaderMaterial("VFXUnlit", blendMode);
+            return VFXRenderer.getCustomShaderMaterial("VFXUnlit", blendMode, instanceKey);
         }
 
         mat = new Material();
@@ -924,7 +929,7 @@ export class VFXRenderer extends BaseRender {
 
                 // outputShaderGraphQuad 或用户指定了自定义 shader
                 if (customShaderName) {
-                    const mat = VFXRenderer.getCustomShaderMaterial(customShaderName, mode);
+                    const mat = VFXRenderer.getCustomShaderMaterial(customShaderName, mode, (geometry as any).matInstanceKey || "");
                     element.material = mat;
                     // (旧 P1 临时方案: 这里手动 mat.setColor u_AmbientColor / setFloat
                     // u_AmbientIntensity / u_ReflectionIntensity 给 fake IBL fallback 用.

--- a/src/layaAir/laya/vfx/VFXRenderer.ts
+++ b/src/layaAir/laya/vfx/VFXRenderer.ts
@@ -355,13 +355,12 @@ export class VFXRenderer extends BaseRender {
         VFXRenderer._patchedTextureUrls.add(url);
         console.log("[VFX alpha] start url=", url);
         try {
-            // 不能直接 fetch(res://...)，浏览器不认 res: scheme。
-            // 改走 Laya.loader.load(url, BUFFER) 拿 ArrayBuffer：
-            //   - Loader 内部把 res:// 解析成实际 IDE preview server URL (http://localhost:xxx/library/...)
-            //   - 同一 url 加载有 cache，不会触发二次实际下载
-            const buffer = await Laya.loader.load(url, Loader.BUFFER);
+            // ⚠不能用 loader.load(url, BUFFER)：同 url 已按 Texture 加载过时，资产缓存按 url 直接命中
+            // 返回 Texture 对象（请求类型被忽略）→ "non-ArrayBuffer: object"，alpha 修补静默失效。
+            // 改用 loader.fetch：内部走 AssetDb.resolveURL 解析 res://，纯下载字节不进资产缓存。
+            const buffer = await (Laya.loader as any).fetch(url, "arraybuffer");
             if (!buffer || !(buffer instanceof ArrayBuffer)) {
-                console.warn("[VFX alpha] loader returned non-ArrayBuffer:", typeof buffer);
+                console.warn("[VFX alpha] fetch returned non-ArrayBuffer:", typeof buffer);
                 return;
             }
             // 只处理 PNG (其它格式如 KTX/DDS 通常带正确 alpha)
@@ -551,8 +550,40 @@ export class VFXRenderer extends BaseRender {
      * 反查到 res:// url 异步加载（每次只 kick off 一次），返回 VFXUnlit fallback；
      * .bps 加载完成后下一次 getCustomShaderMaterial 调用会命中已注册 shader。
      */
-    static getCustomShaderMaterial(shaderName: string, blendMode: string = "Alpha"): Material {
-        const key = `${shaderName}__${blendMode}`;
+    /** mesh 顶点能力 → 材质 define 同步（COLOR=slot1 / UV=slot2 / TANGENT=slot4）。
+     *  WebGPU 要求 shader 引用的顶点槽必须出现在 VertexState；mesh 缺元素时必须关掉对应 define。 */
+    static _syncMeshAttrDefines(mat: Material, geometry: any): void {
+        try {
+            const mesh = geometry && (geometry._mesh || geometry.mesh);
+            if (!mesh || !mat) return;
+            const vb = mesh.vertexBuffer || mesh._vertexBuffer;
+            const decl = vb && vb.vertexDeclaration;
+            const elems = decl && (decl._vertexElements || decl.vertexElements);
+            if (!elems || !elems.length) return;
+            const usages = new Set<number>();
+            for (const e of elems) usages.add(e.elementUsage !== undefined ? e.elementUsage : e._elementUsage);
+            // 官方 mesh define 集合（MeshUtil.getMeshDefine 与 MeshRenderer 同源），加上手动 usage 双保险
+            let meshDefs: any[] | null = null;
+            try {
+                meshDefs = [];
+                MeshUtil.getMeshDefine(mesh, meshDefs as any);
+            } catch (e) { meshDefs = null; }
+            const sync = (defName: string, usage: number) => {
+                const def = Shader3D.getDefineByName(defName);
+                if (!def) return;
+                const has = meshDefs ? meshDefs.indexOf(def) >= 0 : usages.has(usage);
+                if (has || usages.has(usage)) mat.addDefine(def);
+                else mat.removeDefine(def);
+            };
+            sync("COLOR", 1);
+            sync("UV", 2);
+            sync("UV1", 7);
+            sync("TANGENT", 4);
+        } catch (e) { }
+    }
+
+    static getCustomShaderMaterial(shaderName: string, blendMode: string = "Alpha", variant: "instanced" | "strip" = "instanced"): Material {
+        const key = `${shaderName}__${blendMode}__${variant}`;
         let mat = VFXRenderer._customShaderMaterialCache.get(key);
         if (mat) return mat;
 
@@ -576,15 +607,25 @@ export class VFXRenderer extends BaseRender {
                     .catch((err: any) => console.warn(`[VFX Renderer] custom shader '${shaderName}' load failed`, err));
             }
             // Shader 还没注册：返回 VFXUnlit fallback，不缓存（让下一帧重试）
-            return VFXRenderer.getCustomShaderMaterial("VFXUnlit", blendMode);
+            return VFXRenderer.getCustomShaderMaterial("VFXUnlit", blendMode, variant);
         }
 
         mat = new Material();
         mat.setShaderName(shaderName);
         // 蓝图 shader 启 supportVFX 后用 VFX_INSTANCED define 选 vfxTransformVertex 分支
         // (普通 mesh 用 shader 时此 define 关，VS 走原始 path)。
-        const vfxDef = Shader3D.getDefineByName("VFX_INSTANCED");
-        if (vfxDef) mat.addDefine(vfxDef);
+        // ⚠ strip 变体绝不能加 VFX_INSTANCED：strip 几何是普通顶点流(a_Position/a_Color/a_Texcoord0/a_Normal)
+        //   没有实例属性 a_AttrScale/a_AttrColor 等 → p.scale 读 0 → 顶点全缩到 pivot 退化不可见且零报错
+        //   (Buff VFX4 UNI-Masked 丝带不显示根因)。strip 的粒子色走标准 a_Color → vertex.vertexColor 通道。
+        if (variant !== "strip") {
+            const vfxDef = Shader3D.getDefineByName("VFX_INSTANCED");
+            if (vfxDef) mat.addDefine(vfxDef);
+        } else {
+            // strip 顶点流自带 a_Texcoord0，但 UV define 通常由 Mesh 顶点声明自动推导——strip 几何
+            // 不是 Mesh 不走那条路，必须显式开，否则 Vertex 结构无 texCoord0 字段（SG 纹理采样退化到 (0,0) 单点）
+            const uvDef = Shader3D.getDefineByName("UV");
+            if (uvDef) mat.addDefine(uvDef);
+        }
         // 同步强制开 COLOR define：让蓝图 #ifdef COLOR 路径启用，FS 端 pixel.vertexColor
         // 能拿到 vfxTransformVertex 写入的 p.color (instance a_AttrColor)。
         // 不强制的话 Laya 按 mesh 是否有顶点色决定 COLOR，让粒子色全链路断 → 蓝图算
@@ -767,12 +808,12 @@ export class VFXRenderer extends BaseRender {
         if (!supportedCompute)
             return;
 
-        const shaderData = this._baseRenderNode.shaderData;
-
-        // 更新 mesh defines: 先清除旧的，再添加所有 geometry 的
+        // ⭐不再把各 mesh 的能力 define 并集到【节点级】shaderData（原 addMeshDefines）：
+        // 多 mesh 能力不同时（实心 mesh 有色/切线 + 内置 quad 无），节点级并集会让无色/无切线
+        // 元素的 shader 变体强制引用缺失顶点槽 → WebGPU CreateRenderPipeline 失败（Detonation 根因）。
+        // mesh define 现由 _syncMeshAttrDefines 按【系统材质实例】精确管理（onAwake 预同步+每帧幂等）。
         for (const geo of this._geometries) {
             if (geo instanceof VFXGeometry) {
-                addMeshDefines(geo.mesh, shaderData);
                 // 跑 mesh smooth: 让相邻 face 共享 vertex normal → 消除 fragment shading 跳变三角形
                 // alternating; vc smooth 让区域边界 baseColor 过渡柔和.
                 VFXRenderer.smoothMeshNormals(geo.mesh);
@@ -843,7 +884,7 @@ export class VFXRenderer extends BaseRender {
                     console.log(`[VFX Strip Debug] meshMaterial=${meshMaterial ? (meshMaterial as any)._shader?.name : 'NULL'}, stripCustomShader='${stripCustomShader}'`);
                 }
                 if (stripCustomShader && stripCustomShader !== "VFXStrip") {
-                    element.material = VFXRenderer.getCustomShaderMaterial(stripCustomShader, mode);
+                    element.material = VFXRenderer.getCustomShaderMaterial(stripCustomShader, mode, "strip");
                 } else {
                     const stripMainTex = ((geometry as any).mainTexture as string) || "";
                     const stripColorMapping = ((geometry as any).stripColorMapping as string) || "Default";
@@ -886,6 +927,11 @@ export class VFXRenderer extends BaseRender {
                 // outputShaderGraphQuad 或用户指定了自定义 shader
                 if (customShaderName) {
                     const mat = VFXRenderer.getCustomShaderMaterial(customShaderName, mode);
+                    // mesh 顶点能力 → define 同步：WebGPU 严格校验 shader 引用的顶点槽必须在 VertexState 里，
+                    // mesh 缺 color/tangent 元素时不关 define 会 CreateRenderPipeline 失败（Detonation 根因）。
+                    // ⚠依赖 per-system 材质实例（bundle 的 matInstanceKey 参数，本源尚缺需提交前补齐），
+                    // 共享材质下不同 mesh 的系统会互相覆盖 define。
+                    VFXRenderer._syncMeshAttrDefines(mat, geometry);
                     element.material = mat;
                     // (旧 P1 临时方案: 这里手动 mat.setColor u_AmbientColor / setFloat
                     // u_AmbientIntensity / u_ReflectionIntensity 给 fake IBL fallback 用.

--- a/src/layaAir/laya/vfx/VFXRenderer.ts
+++ b/src/layaAir/laya/vfx/VFXRenderer.ts
@@ -601,6 +601,45 @@ export class VFXRenderer extends BaseRender {
     }
 
     /**
+     * 基础 mesh 纹理材质：无 shadergraph(.bps)时,用内置 VFXUnlit + 绑定 MainTexture 到 u_AlbedoTexture。
+     * 对齐 Unity —— Output Mesh 自带 Main Texture,默认材质即可显示纹理,不依赖 Shader Graph。
+     * 按 (blendMode, 纹理 uuid, uvMode, flipbook) 缓存,避免共享材质被不同纹理互相覆盖。
+     */
+    static getMeshTexturedMaterial(blendMode: string = "Alpha", mainTextureUuid: string = "", uvMode: string = "Default", flipbookSize: Vector2 = null): Material {
+        // IDE Texture2D 字段存裸 assetId,转换器存 res://uuid —— 统一补前缀
+        if (mainTextureUuid && mainTextureUuid.indexOf("://") < 0)
+            mainTextureUuid = "res://" + mainTextureUuid;
+        const fbKey = flipbookSize ? `${flipbookSize.x}x${flipbookSize.y}` : "";
+        const key = `__meshtex__${blendMode}__${mainTextureUuid}__${uvMode}__${fbKey}`;
+        let mat = VFXRenderer._customShaderMaterialCache.get(key);
+        if (mat) return mat;
+        const shader = Shader3D.find("VFXUnlit");
+        if (!shader) {
+            console.error("[VFX Renderer] built-in 'VFXUnlit' shader not registered");
+            return null as any;
+        }
+        mat = new Material();
+        mat.setShaderName("VFXUnlit");
+        const vfxDef = Shader3D.getDefineByName("VFX_INSTANCED");
+        if (vfxDef) mat.addDefine(vfxDef);
+        const colorDef = Shader3D.getDefineByName("COLOR");
+        if (colorDef) mat.addDefine(colorDef);
+        mat.setColor("u_Color", new Color(1, 1, 1, 1));
+        mat.setTexture("u_AlbedoTexture", VFXRenderer.getDefaultDotTexture());
+        mat.renderQueue = 3000;
+        mat.cull = RenderState.CULL_NONE;
+        applyBlendMode(mat, blendMode);
+        applyFlipbook(mat, uvMode, flipbookSize);
+        VFXRenderer._customShaderMaterialCache.set(key, mat);
+        if (mainTextureUuid) {
+            VFXRenderer._tryLoadTextureOnce(mainTextureUuid, tex => {
+                if (mat) mat.setTexture("u_AlbedoTexture", tex);
+            });
+        }
+        return mat;
+    }
+
+    /**
      * 按 blendMode 获取/创建 strip 材质（缓存共享）
      * blendMode: "Alpha" | "Additive" | "Premultiplied" | "Opaque"
      *
@@ -952,8 +991,13 @@ export class VFXRenderer extends BaseRender {
                 else if (!meshMaterial && outType === "outputBillboard") {
                     element.material = VFXRenderer.getBillboardMaterial(mode);
                 } else if (!meshMaterial) {
-                    // outputMesh / outputStaticMesh 等：自动创建 VFXUnlit 默认材质
-                    element.material = VFXRenderer.getCustomShaderMaterial("VFXUnlit", mode);
+                    // 无 shadergraph(.bps)材质的 mesh 输出:有 MainTexture 时用基础 VFXUnlit + 绑纹理(对齐 Unity Output Mesh 自带 Main Texture),否则纯默认材质
+                    const meshMainTex = (geometry as any).mainTexture as string || "";
+                    if (meshMainTex) {
+                        element.material = VFXRenderer.getMeshTexturedMaterial(mode, meshMainTex, (geometry as any).uvMode || "Default", (geometry as any).flipbookSize);
+                    } else {
+                        element.material = VFXRenderer.getCustomShaderMaterial("VFXUnlit", mode);
+                    }
                 } else {
                     if (meshMaterial) {
                         applyBlendMode(meshMaterial, mode);
@@ -975,6 +1019,23 @@ export class VFXRenderer extends BaseRender {
                             if (!existing) {
                                 meshMaterial.setTexture("u_AlbedoTexture", VFXRenderer.getDefaultDotTexture());
                             }
+                        }
+                    }
+                    // mesh 输出(shadergraph 或基础):把 Output Mesh 的 MainTexture 字段直接绑到渲染材质。
+                    // 对齐 Unity —— Main Texture 字段驱动纹理,不依赖 shaderName/shadergraph 属性绑定(shaderName 常被 IDE 留空)。
+                    // 绑多个 sampler 名覆盖 .bps(MainTexture/_MainTexture)和基础材质(u_AlbedoTexture)。
+                    if (meshMaterial && outType !== "outputBillboard") {
+                        let meshFieldTex = (geometry as any).mainTexture as string;
+                        if (meshFieldTex && meshFieldTex.indexOf("://") < 0)
+                            meshFieldTex = "res://" + meshFieldTex;
+                        if (meshFieldTex) {
+                            VFXRenderer._tryLoadTextureOnce(meshFieldTex, tex => {
+                                if (tex) {
+                                    meshMaterial.setTexture("MainTexture", tex);
+                                    meshMaterial.setTexture("_MainTexture", tex);
+                                    meshMaterial.setTexture("u_AlbedoTexture", tex);
+                                }
+                            });
                         }
                     }
                     // Soft Particle / Flipbook / SubpixelAA

--- a/src/layaAir/laya/vfx/VisualEffect.ts
+++ b/src/layaAir/laya/vfx/VisualEffect.ts
@@ -49,6 +49,28 @@ const _tempCamForward = new Vector3();
 
 export class VisualEffect extends Script {
 
+    // ---- per-particle 年龄曲线约定（与转换器 unity-shader-to-laya.js + render shader 三端共用，改这里要同步另两端）----
+    /**
+     * 需要走「真·per-particle 随年龄曲线」的 shader uniform 名集合。
+     * 这些 uniform 的 age 曲线会拆成 times/vals 两个 vec4 传给 render shader 做分段采样，
+     * 而非用全局常量近似。新增 age 驱动属性时往这里加名字即可，不必改下面的求值逻辑。
+     * ⚠ 必须与转换器 unity-shader-to-laya.js 的 `_injectPerParticleAgeCurve` 中
+     *   `PER_PARTICLE_AGE_PROPS` 列表保持一致：转换器据此在 .bps 注入曲线节点，运行时据此填
+     *   times/vals uniform。只改一边 → 节点生成了但 uniform 不填（或反之），曲线不生效。
+     */
+    static readonly PER_PARTICLE_AGE_CURVE_UNIFORMS: ReadonlySet<string> = new Set(["Alpha_Multiplier"]);
+    /**
+     * 曲线采样的归一化时间点。长度必须为 4 且与 render shader 里 vec4 分段采样的点位一一对应，
+     * times/vals 都按此数组生成。
+     */
+    static readonly AGE_CURVE_SAMPLE_TIMES: ReadonlyArray<number> = [0, 1 / 3, 2 / 3, 1];
+    /** 派生 uniform 名的前缀，与转换器 _injectPerParticleAgeCurve 生成的命名一致：u + Base + 后缀。 */
+    static readonly AGE_CURVE_UNIFORM_PREFIX = "u";
+    /** 采样时间点 uniform 名后缀。 */
+    static readonly AGE_CURVE_TIMES_SUFFIX = "CurveTimes";
+    /** 采样值 uniform 名后缀。 */
+    static readonly AGE_CURVE_VALS_SUFFIX = "CurveVals";
+
     declare owner: Sprite3D;
     private _asset: VFXAsset;
     public get asset(): VFXAsset {
@@ -540,6 +562,10 @@ export class VisualEffect extends Script {
                 // 同时 set 带 / 不带 _ 两个 ID, 让两种命名都能命中真实 shader uniform.
                 const ids = [Shader3D.propertyNameToID(uniformName)];
                 if (uniformName.startsWith("_")) ids.push(Shader3D.propertyNameToID(uniformName.substring(1)));
+                // 同 _evaluateShaderExpressions：IDE 编译时剥掉全部下划线，补无下划线变体兜底
+                const noUnderscoreTex = uniformName.replace(/_/g, "");
+                if (noUnderscoreTex !== uniformName && noUnderscoreTex !== uniformName.substring(1))
+                    ids.push(Shader3D.propertyNameToID(noUnderscoreTex));
                 for (const sd of allDatas) {
                     for (const aid of ids) sd.setTexture(aid, entry.texture);
                 }
@@ -970,12 +996,44 @@ export class VisualEffect extends Script {
             }
             for (const uniformName in expressions) {
                 const graph = expressions[uniformName];
+                // per-particle: PER_PARTICLE_AGE_CURVE_UNIFORMS 里的 age 曲线传成 uXxxCurveTimes/Vals 两个 vec4 uniform，
+                // render shader 在 v_NormalizedAge（_Disappear uniform 经 PER_PARTICLE_UNIFORMS 映射）处做分段采样，
+                // 还原 Unity 每粒子随年龄的 alpha 淡入（年轻 dim→年老 bright），而非全局常量（会让中心年轻粒子也亮、环变厚）。
+                // 转换器 unity-shader-to-laya.js 的 _injectPerParticleAgeCurve 生成对应曲线节点；uniform 名按同规则派生。
+                if (VisualEffect.PER_PARTICLE_AGE_CURVE_UNIFORMS.has(uniformName)) {
+                    let curveNode: any = null, mult = 1;
+                    const g: any = graph;
+                    for (const nid in g.nodes) {
+                        const nd = g.nodes[nid];
+                        if (nd.kind === "Constant" && nd.outputType === "Curve") curveNode = nd;
+                        else if (nd.kind === "VFXParameter") {
+                            const pv = (propertyValues && (propertyValues as any).get) ? (propertyValues as any).get(nd.exposedName) : undefined;
+                            mult = (typeof pv === "number") ? pv : (typeof nd.defaultValue === "number" ? nd.defaultValue : 1);
+                        }
+                    }
+                    if (curveNode && curveNode.value) {
+                        const c = curveNode.value;
+                        const s = (t: number) => mult * (ShaderExpressionEvaluator._sampleCurve(c, t) || 0);
+                        const _base = uniformName.replace(/[^A-Za-z0-9]/g, "");
+                        const tId = Shader3D.propertyNameToID(VisualEffect.AGE_CURVE_UNIFORM_PREFIX + _base + VisualEffect.AGE_CURVE_TIMES_SUFFIX);
+                        const vId = Shader3D.propertyNameToID(VisualEffect.AGE_CURVE_UNIFORM_PREFIX + _base + VisualEffect.AGE_CURVE_VALS_SUFFIX);
+                        const ts = VisualEffect.AGE_CURVE_SAMPLE_TIMES;
+                        const tv = new Vector4(ts[0], ts[1], ts[2], ts[3]);
+                        const vv = new Vector4(s(ts[0]), s(ts[1]), s(ts[2]), s(ts[3]));
+                        for (const sd of allDatas) { sd.setVector(tId, tv); sd.setVector(vId, vv); }
+                    }
+                }
                 const result = ShaderExpressionEvaluator.evaluate(graph, { totalTime, deltaTime, propertyValues, hasContinuousSpawn });
                 if (result == null) continue;
                 // alias IDs：VFX 端 uniform name (_MainTextureColor) 跟 shader 端实际 uniform name 可能去掉 _ 前缀 (MainTextureColor)
                 // 同时 set 两个 ID 让 shader 不管哪个名字都能拿到
                 const ids = [Shader3D.propertyNameToID(uniformName)];
                 if (uniformName.startsWith("_")) ids.push(Shader3D.propertyNameToID(uniformName.substring(1)));
+                // IDE 编译 shader 时会剥掉 uniform 名里【全部】下划线（_MainTextureColor→MainTextureColor，
+                // Alpha_Multiplier→AlphaMultiplier 中间的也剥）。补一个去掉所有下划线的变体兜底，否则带中间下划线的属性对不上编译名。
+                const noUnderscore = uniformName.replace(/_/g, "");
+                if (noUnderscore !== uniformName && noUnderscore !== uniformName.substring(1))
+                    ids.push(Shader3D.propertyNameToID(noUnderscore));
                 if (graph.outputType === "float") {
                     const v = Number(result) || 0;
                     for (const sd of allDatas) for (const id of ids) sd.setNumber(id, v);

--- a/src/layaAir/laya/vfx/VisualEffect.ts
+++ b/src/layaAir/laya/vfx/VisualEffect.ts
@@ -72,6 +72,20 @@ export class VisualEffect extends Script {
     /** 采样值 uniform 名后缀。 */
     static readonly AGE_CURVE_VALS_SUFFIX = "CurveVals";
 
+    /**
+     * per-particle 颜色渐变 uniform 集合（.laya.vfx shaderPropertyExpressions 的 key）。
+     * Unity SG 里这些 uniform = SampleGradient(gradient, age) 按【每粒子年龄】采样；Laya material uniform
+     * 是 per-system 一份（evaluator 用 ageMedian=0.5 固定采样）→ 所有粒子同色（单色锐丝/顶环不亮/无混色层次）。
+     * 这里把 gradient 烘成 4-stop uniform（u_VfxColorGradTimes/C0..C3 + Enable），render shader（ShaderBuild
+     * supportVFX 注入的 vfxSampleColorGradient）按 v_NormalizedAge 分段采样还原 per-particle 颜色。
+     * ⚠ 必须与 LayaPro ShaderBuild.ts 的 per-particle color gradient 注入段 uniform 命名保持一致。
+     */
+    static readonly PER_PARTICLE_COLOR_GRADIENT_UNIFORMS: ReadonlySet<string> = new Set(["_MainTextureColor"]);
+    /** per-particle 颜色渐变 uniform 名（与 ShaderBuild 注入的 shader 端一致）。 */
+    static readonly COLOR_GRAD_ENABLE_UNIFORM = "u_VfxColorGradEnable";
+    static readonly COLOR_GRAD_TIMES_UNIFORM = "u_VfxColorGradTimes";
+    static readonly COLOR_GRAD_COLOR_UNIFORMS: ReadonlyArray<string> = ["u_VfxColorGradC0", "u_VfxColorGradC1", "u_VfxColorGradC2", "u_VfxColorGradC3"];
+
     declare owner: Sprite3D;
     private _asset: VFXAsset;
     public get asset(): VFXAsset {
@@ -553,7 +567,7 @@ export class VisualEffect extends Script {
             const customShaderName = (sys as any).customShaderName as string;
             const blendMode = (sys as any).blendMode as string || "Alpha";
             if (customShaderName) {
-                const mat = VFXRenderer.getCustomShaderMaterial(customShaderName, blendMode);
+                const mat = VFXRenderer.getCustomShaderMaterial(customShaderName, blendMode, (sys as any).matInstanceKey || "");
                 if (mat && mat.shaderData && allDatas.indexOf(mat.shaderData) === -1) allDatas.push(mat.shaderData);
             }
             for (const uniformName in defaults) {
@@ -642,12 +656,6 @@ export class VisualEffect extends Script {
     /// lifecycle methods
     onStart(): void {
         console.log("VisualEffect onStart", this, this.asset);
-        console.log(`[VFX-DBG] VE onStart systems=${this.systems.length}`,
-            this.systems.map((s: any, i: number) => {
-                const cap = (s as any).capacity ?? (s.desc && (s.desc as any).capacity);
-                const t = s.constructor.name;
-                return `${i}:${t}${cap != null ? `(cap=${cap})` : ""}`;
-            }).join(","));
     }
 
     // Strip 专用子节点和 Renderer（避免与 Mesh instancing 的渲染管线冲突）
@@ -992,7 +1000,7 @@ export class VisualEffect extends Script {
             const customShaderName = (sys as any).customShaderName as string;
             const blendMode = (sys as any).blendMode as string || "Alpha";
             if (customShaderName) {
-                const mat = VFXRenderer.getCustomShaderMaterial(customShaderName, blendMode);
+                const mat = VFXRenderer.getCustomShaderMaterial(customShaderName, blendMode, (sys as any).matInstanceKey || "");
                 if (mat && mat.shaderData && allDatas.indexOf(mat.shaderData) === -1) allDatas.push(mat.shaderData);
             }
             for (const uniformName in expressions) {
@@ -1022,6 +1030,76 @@ export class VisualEffect extends Script {
                         const tv = new Vector4(ts[0], ts[1], ts[2], ts[3]);
                         const vv = new Vector4(s(ts[0]), s(ts[1]), s(ts[2]), s(ts[3]));
                         for (const sd of allDatas) { sd.setVector(tId, tv); sd.setVector(vId, vv); }
+                    }
+                }
+                // per-particle Disappear 曲线 shaping: _Disappear = SampleCurve(curve, ageMedian) 时把 V 形曲线
+                // 4 关键点烘进 u_VfxDisTimes/Vals + Enable=1,render shader(ShaderBuild 注入的 vfxDisappearShape)
+                // 按 v_NormalizedAge 分段采样 → 还原 Unity 出生 fade-in + 死亡 fade-out
+                // (纯线性 v_NormalizedAge 让新生粒子立即全显 → Barrier walls 顶部亮环;老年慢淡 → 底部长尾)。
+                if (uniformName === "_Disappear" || uniformName === "Disappear") {
+                    const g: any = graph;
+                    const root = g.nodes && g.nodes[g.rootNodeId];
+                    if (root && root.kind === "SampleCurve" && root.inputs && root.inputs.length > 0) {
+                        const cnode = g.nodes[root.inputs[0]];
+                        const curve = cnode && cnode.kind === "Constant" ? cnode.value : null;
+                        if (curve && Array.isArray(curve.frames) && curve.frames.length > 0) {
+                            // 曲线原生关键帧 ≤4 个用原生 t(完整还原 V 形拐点),>4 均匀重采样
+                            let times = curve.frames.map((f: any) => Number(f.time) || 0).sort((a: number, b: number) => a - b);
+                            if (times.length > 4) times = [0, 1 / 3, 2 / 3, 1];
+                            while (times.length < 4) times.push(times[times.length - 1] ?? 1);
+                            const sc = (t: number) => ShaderExpressionEvaluator._sampleCurve(curve, t) || 0;
+                            const eId = Shader3D.propertyNameToID("u_VfxDisCurveEnable");
+                            const tId3 = Shader3D.propertyNameToID("u_VfxDisTimes");
+                            const vId3 = Shader3D.propertyNameToID("u_VfxDisVals");
+                            const tv3 = new Vector4(times[0], times[1], times[2], times[3]);
+                            const vv3 = new Vector4(sc(times[0]), sc(times[1]), sc(times[2]), sc(times[3]));
+                            for (const sd of allDatas) { sd.setNumber(eId, 1); sd.setVector(tId3, tv3); sd.setVector(vId3, vv3); }
+                        }
+                    }
+                }
+                // per-particle 颜色渐变: _MainTextureColor = SampleGradient(gradient, ageMedian) 时把 gradient
+                // 烘成 4-stop uniform(u_VfxColorGradTimes/C0..C3 + Enable=1),render shader(ShaderBuild supportVFX
+                // 注入的 vfxSampleColorGradient)按 v_NormalizedAge 分段采样 → 每粒子随年龄变色(新生亮青/老金棕),
+                // 而非全局 ageMedian 单色。未命中时 Enable 保持默认 0,shader 走原 uniform 路径,其它 VFX 零影响。
+                if (VisualEffect.PER_PARTICLE_COLOR_GRADIENT_UNIFORMS.has(uniformName)) {
+                    const g: any = graph;
+                    const root = g.nodes && g.nodes[g.rootNodeId];
+                    if (root && root.kind === "SampleGradient" && root.inputs && root.inputs.length > 0) {
+                        const gnode = g.nodes[root.inputs[0]];
+                        let grad: any = null;
+                        if (gnode && gnode.kind === "VFXParameter") {
+                            const pv: any = (propertyValues && gnode.exposedName) ? propertyValues.get(gnode.exposedName) : null;
+                            if (pv && pv.rawGradientStops && pv.rawGradientStops.length > 0) {
+                                grad = { __layaGradientStops: pv.rawGradientStops };
+                            } else if (gnode.defaultValue && (gnode.defaultValue.colorKeys || gnode.defaultValue.alphaKeys)) {
+                                grad = gnode.defaultValue;
+                            }
+                        }
+                        if (grad) {
+                            // 采样时间点: gradient 原生关键 t ≤4 个时用原生(完整还原陡变,如 Barrier ColorOverLife
+                            // 的 0/0.1/0.75/1),>4 个退化为均匀 4 点重采样
+                            const tSet = new Set<number>();
+                            if (grad.__layaGradientStops) {
+                                for (const s of grad.__layaGradientStops) tSet.add(Number(s.t) || 0);
+                            } else {
+                                for (const k of grad.colorKeys || []) tSet.add(Number(k.time) || 0);
+                                for (const k of grad.alphaKeys || []) tSet.add(Number(k.time) || 0);
+                            }
+                            let times = [...tSet].sort((a, b) => a - b);
+                            if (times.length > 4) times = [0, 1 / 3, 2 / 3, 1];
+                            while (times.length < 4) times.push(times[times.length - 1] ?? 1);
+                            const sampler = (ShaderExpressionEvaluator as any)._sampleGradient.bind(ShaderExpressionEvaluator);
+                            const eId = Shader3D.propertyNameToID(VisualEffect.COLOR_GRAD_ENABLE_UNIFORM);
+                            const tId2 = Shader3D.propertyNameToID(VisualEffect.COLOR_GRAD_TIMES_UNIFORM);
+                            const tv2 = new Vector4(times[0], times[1], times[2], times[3]);
+                            for (const sd of allDatas) { sd.setNumber(eId, 1); sd.setVector(tId2, tv2); }
+                            for (let ci = 0; ci < 4; ci++) {
+                                const col = sampler(grad, times[ci]) || { r: 1, g: 1, b: 1, a: 1 };
+                                const cId = Shader3D.propertyNameToID(VisualEffect.COLOR_GRAD_COLOR_UNIFORMS[ci]);
+                                const cv = new Vector4(col.r, col.g, col.b, col.a);
+                                for (const sd of allDatas) sd.setVector(cId, cv);
+                            }
+                        }
                     }
                 }
                 const result = ShaderExpressionEvaluator.evaluate(graph, { totalTime, deltaTime, propertyValues, hasContinuousSpawn });

--- a/src/layaAir/laya/vfx/VisualEffect.ts
+++ b/src/layaAir/laya/vfx/VisualEffect.ts
@@ -100,6 +100,8 @@ export class VisualEffect extends Script {
         return this._initialEvent;
     }
     public set initialEvent(value: string) {
+        // 空值回退资产默认（再退 OnPlay）：场景里序列化空字符串时避免派发空事件名 → 整个特效静默不播
+        if (!value) value = (this._asset && this._asset.initialEventName) || "OnPlay";
         this._initialEvent = value;
         this.initialEventID = Shader3D.propertyNameToID(this._initialEvent);
     }
@@ -530,7 +532,9 @@ export class VisualEffect extends Script {
             const customShaderName = (sys as any).customShaderName as string;
             const blendMode = (sys as any).blendMode as string || "Alpha";
             if (customShaderName) {
-                const mat = VFXRenderer.getCustomShaderMaterial(customShaderName, blendMode);
+                // strip 输出用无 VFX_INSTANCED 的材质变体（与 VFXRenderer 渲染用同一实例，defaults 才能生效）
+                const variant = VisualEffect._matVariantOf(sys);
+                const mat = VFXRenderer.getCustomShaderMaterial(customShaderName, blendMode, variant);
                 if (mat && mat.shaderData && allDatas.indexOf(mat.shaderData) === -1) allDatas.push(mat.shaderData);
             }
             for (const uniformName in defaults) {
@@ -612,6 +616,13 @@ export class VisualEffect extends Script {
         this.initialEvent = "OnPlay";
     }
 
+    /** strip 族输出（普通顶点流几何）→ 自定义 shader 材质取 "strip" 变体（无 VFX_INSTANCED）；其它取实例化变体 */
+    private static _matVariantOf(sys: any): "instanced" | "strip" {
+        const t = sys.outputType as string;
+        return (t === "outputTrail" || t === "outputParticleStripSGQuad" || t === "outputPoint" || t === "outputLine" || t === "outputLineStrip")
+            ? "strip" : "instanced";
+    }
+
     /// lifecycle methods
     onStart(): void {
         console.log("VisualEffect onStart", this, this.asset);
@@ -641,6 +652,17 @@ export class VisualEffect extends Script {
         const isNonMeshOutput = (t: string) => t === "outputTrail" || t === "outputParticleStripSGQuad" || t === "outputPoint" || t === "outputLine";
         let hasStrip = false;
         let hasMesh = false;
+        // ⭐define 同步必须在首帧渲染前完成：渲染元素的 shader 实例按"首次编译时的 define 集合"缓存，
+        // 之后材质 define 变更不触发重编译（失效管线被无限复用）。这里在任何 draw 之前按 mesh 顶点能力定型。
+        // ⚠依赖 per-system 材质实例（bundle 的 matInstanceKey，本源尚缺需提交前补齐）。
+        for (let system of this.systems) {
+            const sysAny = system as any;
+            if (system instanceof VFXParticleSystem && sysAny.geometry && sysAny.customShaderName
+                && !isNonMeshOutput(sysAny.outputType)) {
+                const _m = VFXRenderer.getCustomShaderMaterial(sysAny.customShaderName, sysAny.blendMode || "Alpha");
+                VFXRenderer._syncMeshAttrDefines(_m, sysAny.geometry);
+            }
+        }
         for (let system of this.systems) {
             if (system instanceof VFXParticleSystem && system.geometry) {
                 if (isNonMeshOutput(system.outputType)) {
@@ -888,7 +910,10 @@ export class VisualEffect extends Script {
     }
 
     processInitialize(evt: VFXEvent, state: VFXState) {
-
+        // Initialize 事件在 asset setter(initAssetData)时刻入队，但场景反序列化是先 asset 后 initialEvent，
+        // 入队时捕获的 id 永远是 asset 默认值，组件 Inspector 设置的 initialEvent 被吞掉。
+        // 处理时刻(首帧 simulate)重新解析当前 initialEventID 让组件 override 生效。
+        evt.id = this.initialEventID;
         this.processEvent(evt, state);
 
         this.asset.prewarmDeltaTime;
@@ -965,7 +990,9 @@ export class VisualEffect extends Script {
             const customShaderName = (sys as any).customShaderName as string;
             const blendMode = (sys as any).blendMode as string || "Alpha";
             if (customShaderName) {
-                const mat = VFXRenderer.getCustomShaderMaterial(customShaderName, blendMode);
+                // strip 输出用无 VFX_INSTANCED 的材质变体（与 VFXRenderer 渲染用同一实例，表达式 uniform 才能生效）
+                const variant = VisualEffect._matVariantOf(sys);
+                const mat = VFXRenderer.getCustomShaderMaterial(customShaderName, blendMode, variant);
                 if (mat && mat.shaderData && allDatas.indexOf(mat.shaderData) === -1) allDatas.push(mat.shaderData);
             }
             for (const uniformName in expressions) {
@@ -1442,31 +1469,41 @@ export class VisualEffect extends Script {
  * 按关键帧烘焙 256×1 RGBA8 Gradient Texture2D
  * 用于 sampleGradient 在 VFX shader 里 textureLod(tex, vec2(t, 0.5), 0) 采样
  */
+// float32 → float16 bits（渐变 HDR 烘焙用；R16G16B16A16=rgba16float 原始字节直传）
+const _veF16F32 = new Float32Array(1);
+const _veF16U32 = new Uint32Array(_veF16F32.buffer);
+function _veF32ToF16(v: number): number {
+    _veF16F32[0] = v;
+    const bits = _veF16U32[0];
+    const sign = (bits >> 16) & 0x8000;
+    const exp = ((bits >> 23) & 0xff) - 127 + 15;
+    const frac = bits & 0x7fffff;
+    if (exp <= 0) {
+        if (exp < -10) return sign;
+        const m = (frac | 0x800000) >> (1 - exp);
+        return sign | (m >> 13);
+    }
+    if (exp >= 31) return sign | 0x7c00;
+    return sign | (exp << 10) | (frac >> 13);
+}
+
 function bakeGradientTexture(stops: { t: number; color: [number, number, number, number] }[]): Texture2D {
     const width = 256;
-    const data = new Uint8Array(width * 4);
+    const data = new Uint16Array(width * 4);
 
     // 保底至少两个关键帧
     const rawKeys = stops.length >= 2 ? stops : [
         { t: 0, color: [1, 1, 1, 1] as [number, number, number, number] },
         { t: 1, color: [1, 1, 1, 0] as [number, number, number, number] },
     ];
-    // Unity HDR color picker 让 gradient stops 含 >1 值；之前 per-channel clamp 让 (1.22, 5.66, 3.62) 全 >1
-    // 的 HDR teal 变成 (1,1,1) 纯白丢 chroma。修：per-stop max-normalize 保留 chroma 方向
-    const normalizeStop = (c: number[]): [number, number, number, number] => {
-        const r = Math.max(0, c[0]);
-        const g = Math.max(0, c[1]);
-        const b = Math.max(0, c[2]);
-        const a = Math.max(0, Math.min(1, c[3]));
-        const maxRGB = Math.max(r, g, b);
-        if (maxRGB > 1) {
-            return [r / maxRGB, g / maxRGB, b / maxRGB, a];
-        }
-        return [r, g, b, a];
-    };
+    // ⭐2026-06-11 HDR 直通：烘到 R16G16B16A16 半精度浮点，不再 max-normalize（LDR 时代 crutch，
+    // 保 chroma 丢强度 → Unity HDR 红压不过低强度橙）。enableHDR 场景下直通才是 Unity 语义。
+    const sanitizeStop = (c: number[]): [number, number, number, number] => [
+        Math.max(0, c[0]), Math.max(0, c[1]), Math.max(0, c[2]), Math.max(0, Math.min(1, c[3])),
+    ];
     const keys = rawKeys.map(k => ({
         t: k.t,
-        color: normalizeStop(k.color),
+        color: sanitizeStop(k.color),
     }));
 
     for (let i = 0; i < width; i++) {
@@ -1486,13 +1523,13 @@ function bakeGradientTexture(stops: { t: number; color: [number, number, number,
         const g = a.color[1] + (b.color[1] - a.color[1]) * u;
         const bB = a.color[2] + (b.color[2] - a.color[2]) * u;
         const aA = a.color[3] + (b.color[3] - a.color[3]) * u;
-        data[i * 4] = Math.round(r * 255);
-        data[i * 4 + 1] = Math.round(g * 255);
-        data[i * 4 + 2] = Math.round(bB * 255);
-        data[i * 4 + 3] = Math.round(aA * 255);
+        data[i * 4] = _veF32ToF16(r);
+        data[i * 4 + 1] = _veF32ToF16(g);
+        data[i * 4 + 2] = _veF32ToF16(bB);
+        data[i * 4 + 3] = _veF32ToF16(aA);
     }
 
-    const tex = new Texture2D(width, 1, TextureFormat.R8G8B8A8, false, false, false, false);
+    const tex = new Texture2D(width, 1, TextureFormat.R16G16B16A16, false, false, false, false);
     tex.setPixelsData(data, false, false);
     tex.wrapModeU = WrapMode.Clamp;
     tex.wrapModeV = WrapMode.Clamp;

--- a/src/layaAir/laya/vfx/VisualEffect.ts
+++ b/src/layaAir/laya/vfx/VisualEffect.ts
@@ -46,6 +46,7 @@ import { Laya } from "../../Laya";
 
 const globalRand = new Rand((Math.random() * 0xFFFFFFFF) >>> 0);
 const _tempCamForward = new Vector3();
+const _tempCamUp = new Vector3();
 
 export class VisualEffect extends Script {
 
@@ -1149,9 +1150,10 @@ export class VisualEffect extends Script {
             const camTransform = cameraModuleData.transform;
             const cameraWorldPos = camTransform.position;
             camTransform.getForward(_tempCamForward);
+            camTransform.getUp(_tempCamUp);   // 相机 up 轴(世界空间)→ LookAtPosition/Line orient 用它做 twist(对齐 Unity GetVFXToViewRotMatrix()[1])
             for (let system of this.systems) {
                 if (system instanceof VFXParticleSystem) {
-                    system.setOrientCamera(this.cmd, cameraWorldPos, _tempCamForward);
+                    system.setOrientCamera(this.cmd, cameraWorldPos, _tempCamForward, _tempCamUp);
                 }
             }
         }

--- a/src/layaAir/laya/vfx/shader/BlueprintPixelVertexVFX.glsl
+++ b/src/layaAir/laya/vfx/shader/BlueprintPixelVertexVFX.glsl
@@ -29,12 +29,13 @@
     //   下面所有 a_AttrPosition 等 attribute 引用完全从源码消失，GLSL→SPIR-V 编译器不会保留
     //   未使用 in 变量声明，WebGPU pipeline 创建不会要求绑定 instance buffer。
     //   不加 #ifdef 包裹时函数定义体保留 attribute 引用，依赖编译器 DCE 行为不可靠。
-    #ifdef VFX_INSTANCED
-
 // Per-particle data 通过 varying 传 fragment shader,
 // 让 ShaderGraph 内部用 uniform Float (如 MaskFlipbookIndex) 的 property 能改成 per-particle value.
 // ShaderBuild post-process 把 FS 内 uniform name `MaskFlipbookIndex` 等替换成 `v_TexIndex`.
 // 转换器 init context 加 setAttribute(texIndex, Random(0, range)) 让 GPU 每粒子写 unique value 到 a_AttrScale.w.
+// ⭐声明在 #ifdef VFX_INSTANCED 之外：FS 的 per-particle 替换是无条件文本替换，strip 材质变体
+//   (VFX_INSTANCED off，粒子属性走顶点流而非实例 buffer) 下声明若被剥掉而引用仍在 → 编译炸。
+//   非实例分支由 ShaderBuild 注入的 #else 写默认值（v_TexIndex=0/v_NormalizedAge=0/v_MainTexRand=0）。
 varying float v_TexIndex;
 
 // per-particle ageOverLifetime: 让 SG Disappear/Lifetime/Age 等 uniform 走 per-particle 路径
@@ -42,6 +43,8 @@ varying float v_TexIndex;
 // 直接 0→1 linear 跟随粒子 age, 不是 sampleCurve V 形 (粒子生 visible/老化 fade-out, 没 fade-in 阶段)
 // 完整 curve sample 路径后续优化 (vertex 端 sample 256x1 curve texture)
 varying float v_NormalizedAge;
+
+    #ifdef VFX_INSTANCED
 
 struct VFXParticle {
     vec3 position;

--- a/src/layaAir/laya/vfx/systems/VFXParticleSystem.ts
+++ b/src/layaAir/laya/vfx/systems/VFXParticleSystem.ts
@@ -203,6 +203,12 @@ export class VFXParticleSystem extends VFXSystem {
     // 混合模式 — 对齐 Unity VFX Graph BlendMode
     blendMode: import("../VFXAsset").VFXBlendMode = "Alpha" as any;
 
+    private static _matUidCounter = 0;
+    /** per-system 材质实例 key:custom shader 材质若按 shaderName+blendMode 全局共享,
+     *  各 system 的 per-system uniform(_MaskTexture/alpha 年龄曲线/Disappear 曲线/颜色渐变)会互相覆盖。
+     *  对齐 Unity 每 output 独立 material 实例。 */
+    readonly matInstanceKey: string = "s" + (VFXParticleSystem._matUidCounter++);
+
     // Soft Particle 淡出距离（eye 空间单位，0 = 关闭）
     softParticleFade: number = 0;
 
@@ -849,6 +855,7 @@ export class VFXParticleSystem extends VFXSystem {
                     (this.geometry as any).subpixelAA = this.subpixelAA;
                     (this.geometry as any).customShaderName = this.customShaderName;
                 }
+                if (this.geometry) (this.geometry as any).matInstanceKey = this.matInstanceKey;
             } catch (e) {
                 console.warn("VFXParticleSystem: geometry creation failed, compute pipeline will still run.", e);
             }

--- a/src/layaAir/laya/vfx/systems/VFXParticleSystem.ts
+++ b/src/layaAir/laya/vfx/systems/VFXParticleSystem.ts
@@ -71,6 +71,7 @@ let ID: {
     u_VfxInvViewProjection: number;
     u_OrientCameraPos: number;
     u_OrientCameraDir: number;
+    u_OrientCameraUp: number;
     u_ParticlePerStrip: number;
     u_StripCapacity: number;
     StripDataBuffer: number;
@@ -113,6 +114,7 @@ export function ensureIDs(): void {
         u_VfxInvViewProjection: Shader3D.propertyNameToID("u_VfxInvViewProjection"),
         u_OrientCameraPos: Shader3D.propertyNameToID("u_OrientCameraPos"),
         u_OrientCameraDir: Shader3D.propertyNameToID("u_OrientCameraDir"),
+        u_OrientCameraUp: Shader3D.propertyNameToID("u_OrientCameraUp"),
         u_ParticlePerStrip: Shader3D.propertyNameToID("u_ParticlePerStrip"),
         u_StripCapacity: Shader3D.propertyNameToID("u_StripCapacity"),
         // SpawnState
@@ -628,10 +630,11 @@ export class VFXParticleSystem extends VFXSystem {
     /**
      * 通过 cmd 设置当前渲染相机的位置和朝向到 output shader
      */
-    setOrientCamera(cmd: ComputeCommandBuffer, cameraWorldPos: Vector3, cameraForward: Vector3): void {
+    setOrientCamera(cmd: ComputeCommandBuffer, cameraWorldPos: Vector3, cameraForward: Vector3, cameraUp: Vector3): void {
         for (const sd of this.outputDatas) {
             cmd.addSetShaderDataCommand(sd, ID.u_OrientCameraPos, ShaderDataType.Vector3, cameraWorldPos);
             cmd.addSetShaderDataCommand(sd, ID.u_OrientCameraDir, ShaderDataType.Vector3, cameraForward);
+            cmd.addSetShaderDataCommand(sd, ID.u_OrientCameraUp, ShaderDataType.Vector3, cameraUp);
         }
         // Multi-Output: extra outputDatas 也需要 orient camera 数据,
         // 不然 extra orient block 算出 (0,0,0) 假相机位置 → quaternion 错 → 粒子 quad 朝怪方向 / size collapse → 不可见
@@ -640,6 +643,7 @@ export class VFXParticleSystem extends VFXSystem {
             if (esd) {
                 cmd.addSetShaderDataCommand(esd, ID.u_OrientCameraPos, ShaderDataType.Vector3, cameraWorldPos);
                 cmd.addSetShaderDataCommand(esd, ID.u_OrientCameraDir, ShaderDataType.Vector3, cameraForward);
+                cmd.addSetShaderDataCommand(esd, ID.u_OrientCameraUp, ShaderDataType.Vector3, cameraUp);
             }
         }
     }

--- a/src/layaAir/laya/vfx/systems/VFXSpawnerTask.ts
+++ b/src/layaAir/laya/vfx/systems/VFXSpawnerTask.ts
@@ -99,10 +99,13 @@ export class VFXSpawnerSingleBurst extends VFXSpawnerTask {
     }
 
     internalInit(rand: Rand): void {
-        // ⚠ 不要 reset sleeping — Unity SingleBurst 整个 VFX 生命周期只 fire 一次 (含 Infinite loop 模式).
-        // 之前每个 newLoop 重置 sleeping=false 让 durationMode=Infinite + SingleBurst 每个 loop 重新 fire
-        // → 看起来 "粒子播放 2 次" (实际是无限次重 fire). UNI VFX1/2/3 都受影响.
-        // 只在 VFX 完整重置 (init / play) 时才重置 sleeping.
+        // internalInit 在 newLoop(每个 loop 开始)时被 VFXSpawnerTask.update 调用。这里重置 sleeping=false,
+        // 让【有限循环】(durationMode=Constant, loopDuration>0, loop 会周期性重启)的 SingleBurst 每个 loop 重新 fire,
+        // 对齐 Unity(有限 loop 的 Single Burst 每个 loop 触发一次)。BarrierVFX7 底圈脉冲依赖此行为。
+        // 为何不会重蹈旧 bug(Infinite + 无限重 fire): durationMode=Infinite → loopDuration=-1,
+        // VFXSpawnerState.endUpdate 对 currentMaximumDuration<0 不转换 loop 状态 → loop 永不重启 → newLoop 只第一次 true
+        // → Infinite 模式仍只 fire 一次。所以重置 sleeping 对 Infinite/Finite 两种都正确。
+        this.sleeping = false;
         this.nextTriggerTime = sampleRange(this.delay, rand);
         this.sampledCount = Math.round(sampleRange(this.count, rand));
     }


### PR DESCRIPTION
## 背景

原三个 VFX PR 因主干先合并了 materialize / transformposition / mesh-scale 而产生合并冲突，无法直接合并：

- #2250 `feat/vfx-engine-sync-3.4`
- #2248 `feat/vfx-per-particle-shading-3.4`（已包含 #2240 `feat/vfx-uni-align-3.4` 的提交）
- #2240 `feat/vfx-uni-align-3.4`

本 PR 把这三者**统一 rebase 到最新 `LayaAir_3.4`**（基线为 #2307 合并后），解决冲突后一次性提交，**可替代并关闭上述三个 PR**。

## 合并的特性

- **engine-sync**：HDR 渐变半精度直通 + initialEvent 重解析 + `_syncMeshAttrDefines`（mesh 顶点能力 → 材质 define 同步，修复 mesh 缺 COLOR/TANGENT 顶点元素时 WebGPU CreateRenderPipeline 失败）
- **per-particle-shading**：per-particle 颜色/Disappear 曲线烘焙 + `matInstanceKey` per-system 材质实例（多系统共用 custom shader 时各自独立材质，避免 uniform/define 互相覆盖）
- **uni-align**：mesh 输出纹理绑定 + orient camera-up（`u_OrientCameraUp`）+ per-particle age-curve alpha

## 冲突解决要点

engine-sync 与 per-particle-shading 各自改了 `VFXRenderer.getCustomShaderMaterial` 签名（前者加 `variant`，后者加 `instanceKey`）。已合并为**四参数** `getCustomShaderMaterial(shaderName, blendMode, instanceKey, variant)`，cache key = `shaderName__blendMode__instanceKey__variant`，并同步更新全部调用点（strip 输出传 `(shader, mode, matInstanceKey, "strip")`）。VisualEffect 的 onStart 调试 log 按主干（日志清理版）保留删除。

## 验证

- `node scripts/buildEngine.mjs`（vfx bundle）编译通过，无报错
- 编译产物与线上工作 bundle 对齐：`_syncMeshAttrDefines` / 四参数 `getCustomShaderMaterial` / `matInstanceKey` / `getMeshTexturedMaterial` / `u_OrientCameraUp` / `PER_PARTICLE_AGE_CURVE` 均已包含

> 注：资源 URL 相对解析（发布包 lvfx 依赖 404 修复）为另一独立改动，不在本 PR 范围。

Supersedes #2250, #2248, #2240.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
