### PR TITLE
fix: guard null texture and destroyed bitmap in Texture.recoverBitmap under Loader stress（修复压测Loader加载时Texture.recoverBitmap的null崩溃）

### DIFF
--- a/src/layaAir/laya/resource/Texture.ts
+++ b/src/layaAir/laya/resource/Texture.ts
@@ -569,10 +569,11 @@ export class Texture extends Resource {
      * @param callback 位图恢复后调用的可选回调函数。
      */
     recoverBitmap(callback?: () => void): void {
-        var url = this._bitmap.url;
+        var url = this._bitmap?.url;
         if (!this._destroyed && (!this._bitmap || this._bitmap.destroyed) && url) {
             ILaya.loader.load(url, "image").then((tex: Texture) => {
-                this.bitmap = tex.bitmap;
+                if (!this._destroyed && tex && tex.bitmap)
+                    this.bitmap = tex.bitmap;
                 callback && callback();
             });
         }


### PR DESCRIPTION
## 问题现象
压测 Loader 加载时，`Laya.Texture.recoverBitmap` 报 `TypeError: Cannot read properties of null (reading 'bitmap')`，必现。

## 根因
`Texture.recoverBitmap` 在位图被回收后异步重新加载贴图。压测场景下资源被并发销毁/加载失败时，`ILaya.loader.load(url, "image")` 会按官方语义 resolve 为 `null`（加载失败即返回 null）。原代码直接 `this.bitmap = tex.bitmap`，`tex` 为 null 时读取 `.bitmap` 崩溃。此外 `.then` 回调是异步的，回来时 `this` 可能已被销毁。

## 修复
`src/layaAir/laya/resource/Texture.ts` 的 `recoverBitmap`：
- 回调中增加 `tex && tex.bitmap` 判空，并重判 `!this._destroyed`，避免给已销毁 Texture 赋值；
- `var url = this._bitmap.url` 改为可选链 `this._bitmap?.url`（条件本身已考虑 `_bitmap` 为 null，此处提前读取存在同类隐患）。

改动为纯内部判空，无 API/签名变化。

## 验证
用必现 demo（br3.4.0 压测场景）验证：原版引擎必现崩溃，替换为修复版引擎后不再报错；回退原版再次必现，确认为本修复生效。

🤖 Generated with [Claude Code](https://claude.com/claude-code)