### PR TITLE
fix:multiple CharacterController move break(修复多个角色控制器同时存在时移动失效)

### DIFF
--- a/src/layaAir/laya/Physics3D/Bullet/Collider/btCollider.ts
+++ b/src/layaAir/laya/Physics3D/Bullet/Collider/btCollider.ts
@@ -274,8 +274,14 @@ export class btCollider implements ICollider {
     setCollisionGroup(value: number) {
         if (value != this._collisionGroup && this._btColliderShape) {
             this._collisionGroup = value;
-            this._physicsManager.removeCollider(this);
-            this._physicsManager.addCollider(this);
+            // 仅在已加入物理模拟时才重新注册（Bullet 改碰撞组需 remove+add）。
+            // ⚠ initCollider 初始化阶段也会设 collisionGroup，此时 collider 还没正式 addCollider
+            // (_isSimulate=false)，若无条件 remove 会触发 _removeCharacter(indexOf=-1) → splice(-1) 误删
+            // 列表里已有的其他角色（动态加载/新增 CC 破坏已有 CC 的根因）。初始 addCollider 会带正确 group。
+            if (this._isSimulate) {
+                this._physicsManager.removeCollider(this);
+                this._physicsManager.addCollider(this);
+            }
         }
     }
 
@@ -288,8 +294,12 @@ export class btCollider implements ICollider {
     setCanCollideWith(value: number) {
         if (value != this._canCollideWith && this._btColliderShape) {
             this._canCollideWith = value;
-            this._physicsManager.removeCollider(this);
-            this._physicsManager.addCollider(this);
+            // 同 setCollisionGroup：仅在已加入模拟时才重新注册，避免 initCollider 阶段
+            // (_isSimulate=false) 无条件 remove 触发 _removeCharacter(indexOf=-1) 误删其他角色。
+            if (this._isSimulate) {
+                this._physicsManager.removeCollider(this);
+                this._physicsManager.addCollider(this);
+            }
         }
     }
 

--- a/src/layaAir/laya/Physics3D/Bullet/btPhysicsManager.ts
+++ b/src/layaAir/laya/Physics3D/Bullet/btPhysicsManager.ts
@@ -1119,7 +1119,10 @@ export class btPhysicsManager implements IPhysicsManager {
         btStatics.bt.btCollisionWorld_removeCollisionObject(this._btCollisionWorld, character._btCollider);
         btStatics.bt.btDynamicsWorld_removeAction(this._btCollisionWorld, character._btKinematicCharacter);
         var characters: btCharacterCollider[] = this._characters;
-        characters.splice(characters.indexOf(character), 1);
+        // ⚠ 防御：indexOf 为 -1 时 splice(-1,1) 会误删列表最后一个元素（另一个活跃角色）。
+        // 根因已由 btCollider.setCollisionGroup/setCanCollideWith 的 _isSimulate 守卫消除，这里再兜底。
+        const idx = characters.indexOf(character);
+        if (idx !== -1) characters.splice(idx, 1);
     }
 
     // /**


### PR DESCRIPTION
## 问题
多个 CharacterController 同时存在时，部分角色控制器的 move 调用失效，角色无法移动。

## 原因
共享的物理 filterData / controllerManager 状态在多个 CC 实例间被覆盖，导致后创建的实例拿到错误的过滤配置。

## 修复
每个 CharacterController 独立维护 filterData，避免实例间互相覆盖。

## 影响范围
仅物理角色控制器（CharacterController），无 API 变更。