### PR TITLE
fix(forum-55473): skip drawArrays when trail has no active segments to avoid WebGL warning

### DIFF
--- a/src/layaAir/laya/d3/core/trail/TrailGeometry.ts
+++ b/src/layaAir/laya/d3/core/trail/TrailGeometry.ts
@@ -432,7 +432,9 @@ export class TrailGeometry extends GeometryElement {
 		this.clearRenderParams();
 		var start: number = this._activeIndex * 2;
 		var count: number = this._endIndex * 2 - start;
-		this.setDrawArrayParams(start, count);
+		if (count > 0) {
+			this.setDrawArrayParams(start, count);
+		}
 	}
 
 	/**


### PR DESCRIPTION
修复论坛反馈 https://ask.layaair.com/d/55473-trailwen-ti