### PR TITLE
fix(forum-55473): skip drawArrays when trail has no active segments to avoid WebGL warning

### DIFF
--- a/src/layaAir/laya/trail/trailCommon/RenderFeatureComman/Trail/TrailGeometry.ts
+++ b/src/layaAir/laya/trail/trailCommon/RenderFeatureComman/Trail/TrailGeometry.ts
@@ -425,7 +425,9 @@ export class TrailGeometry {
         this._geometryElementOBj.clearRenderParams();
         var start: number = this._activeIndex * 2;
         var count: number = this._endIndex * 2 - start;
-        this._geometryElementOBj.setDrawArrayParams(start, count);
+        if (count > 0) {
+            this._geometryElementOBj.setDrawArrayParams(start, count);
+        }
     }
 
     /**


### PR DESCRIPTION
修复论坛反馈 https://ask.layaair.com/d/55473-trailwen-ti