### PR TITLE
fix(forum-55486): FillTexture uses sourceWidth/sourceHeight as tile period for trimmed atlas textures

### DIFF
--- a/src/layaAir/laya/display/Scene2DSpecial/GraphicsRunner.ts
+++ b/src/layaAir/laya/display/Scene2DSpecial/GraphicsRunner.ts
@@ -62,6 +62,8 @@ export class GraphicsRunner {
     private _strokeStyle: DrawStyle = DrawStyle.DEFAULT;
 
     private static SEGNUM = 32;
+    /** @internal reusable Vector4 for fillTexture trim rect */
+    private static _trimRectVec4: Vector4 = new Vector4(0, 0, 1, 1);
 
     private _tempUV = new Float32Array(8);
     private _drawTriUseAbsMatrix = false;	//drawTriange函数的矩阵是全局的，不用再乘以当前矩阵了。这是一个补丁。
@@ -756,7 +758,10 @@ export class GraphicsRunner {
             return;
         }
         this._renderer.addResRef(texture);
-        this._fillTexture(texture, texture.width, texture.height, texture.uvrect, x, y, width, height, type, offset.x, offset.y, color);
+        // Use sourceWidth/sourceHeight as tile period to account for trimmed atlas textures
+        let texw = texture.sourceWidth || texture.width;
+        let texh = texture.sourceHeight || texture.height;
+        this._fillTexture(texture, texw, texh, texture.uvrect, x, y, width, height, type, offset.x, offset.y, color);
     }
 
     /**@internal */
@@ -833,6 +838,16 @@ export class GraphicsRunner {
             var arry = texuvRect.concat();
             Vector4.TEMP.setValue(arry[0], arry[1], arry[2], arry[3]);
             material.u_TexRange = Vector4.TEMP;
+            // Set trim rect for atlas sub-textures with transparent pixel trimming
+            let srcW = texture.sourceWidth || texture.width;
+            let srcH = texture.sourceHeight || texture.height;
+            GraphicsRunner._trimRectVec4.setValue(
+                texture.offsetX / srcW,
+                texture.offsetY / srcH,
+                texture.width / srcW,
+                texture.height / srcH
+            );
+            material.u_TexTrimRect = GraphicsRunner._trimRectVec4;
 
             this._setClipInfo(material);
             submit.clipInfoID = this._clipInfoID;

--- a/src/layaAir/laya/webgl/shader/d2/NewShader/Sprite2DFrag.glsl
+++ b/src/layaAir/laya/webgl/shader/d2/NewShader/Sprite2DFrag.glsl
@@ -37,12 +37,17 @@ vec4 transspaceColor(vec4 color)
 
     #ifdef FILLTEXTURE
         uniform vec4 u_TexRange; // startu,startv,urange, vrange
+        uniform vec4 u_TexTrimRect; // offsetX/sourceW, offsetY/sourceH, width/sourceW, height/sourceH
     #endif
 
     vec4 getSpriteTextureColor(){
         vec2 uv;
         #ifdef FILLTEXTURE
-            uv = fract(v_texcoordAlpha.xy) * u_TexRange.zw + u_TexRange.xy;
+            vec2 tileUV = fract(v_texcoordAlpha.xy);
+            vec2 trimmedUV = (tileUV - u_TexTrimRect.xy) / u_TexTrimRect.zw;
+            if (trimmedUV.x < 0.0 || trimmedUV.x > 1.0 || trimmedUV.y < 0.0 || trimmedUV.y > 1.0)
+                discard;
+            uv = trimmedUV * u_TexRange.zw + u_TexRange.xy;
         #else
             uv = v_texcoordAlpha.xy;
         #endif

--- a/src/layaAir/laya/webgl/shader/d2/ShaderDefines2D.ts
+++ b/src/layaAir/laya/webgl/shader/d2/ShaderDefines2D.ts
@@ -114,6 +114,7 @@ export class ShaderDefines2D {
     static UNIFORM_VERTEX_SIZE: number;// uniform vec4 u_vertexSize;
 
     static UNIFORM_TEXRANGE: number;//uniform vec4 u_TexRange;
+    static UNIFORM_TEXTRIMRECT: number;//uniform vec4 u_TexTrimRect;
     /**
      * 渲染矩阵第一个vector3属性ID
      */
@@ -214,6 +215,7 @@ export class ShaderDefines2D {
         ShaderDefines2D.UNIFORM_MATERIAL_CLIPMATPOS = Shader3D.propertyNameToID("u_mClipMatPos");
         ShaderDefines2D.UNIFORM_VERTEX_SIZE = Shader3D.propertyNameToID("u_vertexSize");
         ShaderDefines2D.UNIFORM_TEXRANGE = Shader3D.propertyNameToID("u_TexRange");
+        ShaderDefines2D.UNIFORM_TEXTRIMRECT = Shader3D.propertyNameToID("u_TexTrimRect");
         ShaderDefines2D.UNIFORM_SPRITETEXTURE = Shader3D.propertyNameToID("u_spriteTexture");
         ShaderDefines2D.UNIFORM_SPRITETEXTURE_ARRAY = Shader3D.propertyNameToID("u_spriteTextureArray");
 
@@ -222,6 +224,7 @@ export class ShaderDefines2D {
         graphicsUniformMap.addShaderUniform(ShaderDefines2D.UNIFORM_MATERIAL_CLIPMATPOS, "u_mClipMatPos", ShaderDataType.Vector4);
         graphicsUniformMap.addShaderUniform(ShaderDefines2D.UNIFORM_VERTEX_SIZE, "u_vertexSize", ShaderDataType.Vector4);
         graphicsUniformMap.addShaderUniform(ShaderDefines2D.UNIFORM_TEXRANGE, "u_TexRange", ShaderDataType.Vector4);
+        graphicsUniformMap.addShaderUniform(ShaderDefines2D.UNIFORM_TEXTRIMRECT, "u_TexTrimRect", ShaderDataType.Vector4);
         graphicsUniformMap.addShaderUniform(ShaderDefines2D.UNIFORM_SPRITETEXTURE, "u_spriteTexture", ShaderDataType.Texture2D);
         // 当启用 USE_TEX_ARRAY 宏时，材质将绑定该 uniform
         graphicsUniformMap.addShaderUniform(ShaderDefines2D.UNIFORM_SPRITETEXTURE_ARRAY, "u_spriteTextureArray", ShaderDataType.Texture2DArray);

--- a/src/layaAir/laya/webgl/shader/d2/value/GraphicsShaderInfo.ts
+++ b/src/layaAir/laya/webgl/shader/d2/value/GraphicsShaderInfo.ts
@@ -21,6 +21,7 @@ export class GraphicsShaderInfo {
    private _clipMatDir: Vector4 = null;
    private _clipMatPos: Vector4 = null;
    private _texRange: Vector4 = null;
+   private _texTrimRect: Vector4 = null;
    private _vertexSize: Vector4 = null;
    private _isTextrueReadGamma: boolean = false;
    private _bitmap: Texture2D | Texture2DArray;
@@ -171,6 +172,13 @@ export class GraphicsShaderInfo {
       this._texRange = value;
       this.shaderData.setVector(ShaderDefines2D.UNIFORM_TEXRANGE, value);
    }
+   public get u_TexTrimRect(): Vector4 {
+      return this._texTrimRect;
+   }
+   public set u_TexTrimRect(value: Vector4) {
+      this._texTrimRect = value;
+      this.shaderData.setVector(ShaderDefines2D.UNIFORM_TEXTRIMRECT, value);
+   }
    public set fillTexture(value: boolean) {
       if (value == this._fillTexture) return;
       this._fillTexture = value;
@@ -214,6 +222,7 @@ export class GraphicsShaderInfo {
       if (fill) {
          shaderData.addDefine(ShaderDefines2D.FILLTEXTURE);
          shaderData.setVector(ShaderDefines2D.UNIFORM_TEXRANGE, this.u_TexRange);
+         shaderData.setVector(ShaderDefines2D.UNIFORM_TEXTRIMRECT, this.u_TexTrimRect);
       } else {
          shaderData.removeDefine(ShaderDefines2D.FILLTEXTURE);
       }


### PR DESCRIPTION
修复论坛反馈 https://ask.layaair.com/d/55486-filltexture-shi-yong-kai-qi-tou-ming-cai-qie-de-tu-ji-zi-wen-li-shi-ping-pu-zhou-qi-hu-lue-yuan-shi-chi-cun-yu-tou-ming-bian-ju-dao-zhi-bian-ji-qi-he-yu-lan-yun-xing-biao-xian-bu-yi-zhi