### PR TITLE
fix(forum-55506): move animation update before callLateUpdate so scripts can override bone positions

### DIFF
--- a/src/layaAir/laya/d3/core/scene/Scene3D.ts
+++ b/src/layaAir/laya/d3/core/scene/Scene3D.ts
@@ -826,9 +826,6 @@ export class Scene3D extends Sprite {
         this._componentDriver.callStart();
         this._componentDriver.callUpdate();
 
-        this._componentDriver.callLateUpdate();
-        this._componentDriver.callDestroy();
-
         if (this._volumeManager.needreCaculateAllRenderObjects())
             this._volumeManager.reCaculateAllRenderObjects(this._sceneRenderManager.list);
         else
@@ -837,6 +834,9 @@ export class Scene3D extends Sprite {
         this.componentElementMap.forEach((value) => {
             value.update(delta);
         });
+
+        this._componentDriver.callLateUpdate();
+        this._componentDriver.callDestroy();
         //this._sceneRenderManager.updateMotionObjects();
         this._sceneRenderManager.renderUpdate();
         this.skyRenderer.renderUpdate(RenderContext3D._instance);


### PR DESCRIPTION
修复论坛反馈 https://ask.layaair.com/d/55506-layaair-340zheng-shi-ban-she-zhi-gen-gu-ge-wu-xiao-wei-zhi-qiang-zhi-bei-gu-ge-dong-hua-suo-ding