### PR TITLE
fix: defer animator transform events until batch completes

### DIFF
--- a/src/layaAir/laya/RenderDriver/LayaXDriver/RenderModuleData/LayaXTransform3D.ts
+++ b/src/layaAir/laya/RenderDriver/LayaXDriver/RenderModuleData/LayaXTransform3D.ts
@@ -121,9 +121,6 @@ export class LayaXTransform3D extends Transform3D {
     /** @internal */
     _nativeObj: any;
 
-    /**@internal RTAnimatorFactory._notifyJsTransformChanged 的帧去重标记，整数比对替代 Set 去重 */
-    _notifyFrame: number = 0;
-
     // ---- 本 slot 零拷贝视图（createEntity 后由 _bindViews 填充）----
     /** @internal 是否已绑定 chunk 零拷贝视图（路径①/②任一成功） */
     private _viewsBound: boolean = false;
@@ -372,14 +369,6 @@ export class LayaXTransform3D extends Transform3D {
         return this._nativeObj.isEntityValid();
     }
 
-    /**
-     * @internal
-     * RTAnimatorFactory 派发 TRANSFORM_CHANGED 时读取的脏标志（flag 在共享 flag 内存里）。
-     */
-    get _RTtransformFlag(): number {
-        return this._getTransformChangeFlag();
-    }
-
     // ChangeFlag 私有化(方案 Phase 2b,性能模型驱动提前):flag 回归基类 JS 私有字段。
     // 跨语言判据已不依赖共享 ChangeFlag —— C++ tier-1 改为 slotClean+祖先链 slot 校验
     // (任何 JS 写含 setWorldMatrix 都置 slot 脏);动画方向由 SyncFlag+syncEpoch 覆盖。
@@ -559,8 +548,7 @@ export class LayaXTransform3D extends Transform3D {
     private _markChainDirtyAll(): void {
         if ((this._getTransformChangeFlag() & ALL_WORLD_FLAGS) !== ALL_WORLD_FLAGS) {
             this._setTransformFlag(ALL_WORLD_FLAGS, true);
-            if (this._hasTransformChangedListener)
-                this.event(Event.TRANSFORM_CHANGED, this._getTransformChangeFlag());
+            this._notifyTransformChanged();
         }
     }
 
@@ -832,8 +820,7 @@ export class LayaXTransform3D extends Transform3D {
         if (!this._viewsBound) { super._onWorldPositionTransform(); return; }
         if (!this._getTransformFlag(Transform3D.TRANSFORM_WORLDMATRIX) || !this._getTransformFlag(Transform3D.TRANSFORM_WORLDPOSITION)) {
             this._setTransformFlag(Transform3D.TRANSFORM_WORLDMATRIX | Transform3D.TRANSFORM_WORLDPOSITION, true);
-            if (this._hasTransformChangedListener)
-                this.event(Event.TRANSFORM_CHANGED, this._getTransformChangeFlag());
+            this._notifyTransformChanged();
         }
         this._notifySubscribedChildren(0);
     }
@@ -842,8 +829,7 @@ export class LayaXTransform3D extends Transform3D {
         if (!this._viewsBound) { super._onWorldRotationTransform(); return; }
         if (!this._getTransformFlag(Transform3D.TRANSFORM_WORLDMATRIX) || !this._getTransformFlag(Transform3D.TRANSFORM_WORLDQUATERNION) || !this._getTransformFlag(Transform3D.TRANSFORM_WORLDEULER)) {
             this._setTransformFlag(Transform3D.TRANSFORM_WORLDMATRIX | Transform3D.TRANSFORM_WORLDQUATERNION | Transform3D.TRANSFORM_WORLDEULER, true);
-            if (this._hasTransformChangedListener)
-                this.event(Event.TRANSFORM_CHANGED, this._getTransformChangeFlag());
+            this._notifyTransformChanged();
         }
         this._notifySubscribedChildren(1);
     }
@@ -852,8 +838,7 @@ export class LayaXTransform3D extends Transform3D {
         if (!this._viewsBound) { super._onWorldScaleTransform(); return; }
         if (!this._getTransformFlag(Transform3D.TRANSFORM_WORLDMATRIX) || !this._getTransformFlag(Transform3D.TRANSFORM_WORLDSCALE)) {
             this._setTransformFlag(Transform3D.TRANSFORM_WORLDMATRIX | Transform3D.TRANSFORM_WORLDSCALE, true);
-            if (this._hasTransformChangedListener)
-                this.event(Event.TRANSFORM_CHANGED, this._getTransformChangeFlag());
+            this._notifyTransformChanged();
         }
         this._notifySubscribedChildren(2);
     }
@@ -862,8 +847,7 @@ export class LayaXTransform3D extends Transform3D {
         if (!this._viewsBound) { super._onWorldPositionRotationTransform(); return; }
         if (!this._getTransformFlag(Transform3D.TRANSFORM_WORLDMATRIX) || !this._getTransformFlag(Transform3D.TRANSFORM_WORLDPOSITION) || !this._getTransformFlag(Transform3D.TRANSFORM_WORLDQUATERNION) || !this._getTransformFlag(Transform3D.TRANSFORM_WORLDEULER)) {
             this._setTransformFlag(Transform3D.TRANSFORM_WORLDMATRIX | Transform3D.TRANSFORM_WORLDPOSITION | Transform3D.TRANSFORM_WORLDQUATERNION | Transform3D.TRANSFORM_WORLDEULER, true);
-            if (this._hasTransformChangedListener)
-                this.event(Event.TRANSFORM_CHANGED, this._getTransformChangeFlag());
+            this._notifyTransformChanged();
         }
         this._notifySubscribedChildren(1);
     }
@@ -872,8 +856,7 @@ export class LayaXTransform3D extends Transform3D {
         if (!this._viewsBound) { super._onWorldPositionScaleTransform(); return; }
         if (!this._getTransformFlag(Transform3D.TRANSFORM_WORLDMATRIX) || !this._getTransformFlag(Transform3D.TRANSFORM_WORLDPOSITION) || !this._getTransformFlag(Transform3D.TRANSFORM_WORLDSCALE)) {
             this._setTransformFlag(Transform3D.TRANSFORM_WORLDMATRIX | Transform3D.TRANSFORM_WORLDPOSITION | Transform3D.TRANSFORM_WORLDSCALE, true);
-            if (this._hasTransformChangedListener)
-                this.event(Event.TRANSFORM_CHANGED, this._getTransformChangeFlag());
+            this._notifyTransformChanged();
         }
         this._notifySubscribedChildren(2);
     }
@@ -882,8 +865,7 @@ export class LayaXTransform3D extends Transform3D {
         if (!this._viewsBound) { super._onWorldTransform(); return; }
         if (!this._getTransformFlag(Transform3D.TRANSFORM_WORLDMATRIX) || !this._getTransformFlag(Transform3D.TRANSFORM_WORLDPOSITION) || !this._getTransformFlag(Transform3D.TRANSFORM_WORLDQUATERNION) || !this._getTransformFlag(Transform3D.TRANSFORM_WORLDEULER) || !this._getTransformFlag(Transform3D.TRANSFORM_WORLDSCALE)) {
             this._setTransformFlag(ALL_WORLD_FLAGS, true);
-            if (this._hasTransformChangedListener)
-                this.event(Event.TRANSFORM_CHANGED, this._getTransformChangeFlag());
+            this._notifyTransformChanged();
         }
         this._notifySubscribedChildren(3);
     }

--- a/src/layaAir/laya/RenderDriver/RenderModuleData/RuntimeModuleData/3D/RTTransform3D.ts
+++ b/src/layaAir/laya/RenderDriver/RenderModuleData/RuntimeModuleData/3D/RTTransform3D.ts
@@ -63,9 +63,6 @@ export class RTTransform3D extends Transform3D {
     /**@internal runtime同步标记*/
     _rtSyncFlag: number = 0;
 
-    /**@internal RTAnimatorFactory._notifyJsTransformChanged 的帧去重标记，整数比对替代 Set 去重 */
-    _notifyFrame: number = 0;
-
     /**@internal 是否挂了 TRANSFORM_CHANGED 监听者，由 onStartListeningToType 维护；无监听者时 _dispatchTransformEvent 跳过 event 调用 */
     _hasTransformChangedListener: boolean = false;
 
@@ -159,10 +156,6 @@ export class RTTransform3D extends Transform3D {
         else
             flag &= ~type;
         this._nativeUInt32Buffer[RTTransform3D.TRANSFORM_RT_SYNC_FLAG_DATAOFFSET] = flag;
-    }
-
-    get _RTtransformFlag() {
-        return this._getTransformChangeFlag();
     }
 
     /**
@@ -487,8 +480,7 @@ export class RTTransform3D extends Transform3D {
     protected _onWorldPositionRotationTransform(): void {
         if (!this._getTransformFlag(Transform3D.TRANSFORM_WORLDMATRIX) || !this._getTransformFlag(Transform3D.TRANSFORM_WORLDPOSITION) || !this._getTransformFlag(Transform3D.TRANSFORM_WORLDQUATERNION) || !this._getTransformFlag(Transform3D.TRANSFORM_WORLDEULER)) {
             this._setTransformFlag(Transform3D.TRANSFORM_WORLDMATRIX | Transform3D.TRANSFORM_WORLDPOSITION | Transform3D.TRANSFORM_WORLDQUATERNION | Transform3D.TRANSFORM_WORLDEULER, true);
-            if (this._hasTransformChangedListener)
-                this.event(Event.TRANSFORM_CHANGED, this._getTransformChangeFlag());
+            this._notifyTransformChanged();
         }
         for (var i: number = 0, n: number = this._children!.length; i < n; i++)
             (this._children[i] as RTTransform3D)._onWorldPositionRotationTransform();
@@ -500,8 +492,7 @@ export class RTTransform3D extends Transform3D {
     protected _onWorldPositionScaleTransform(): void {
         if (!this._getTransformFlag(Transform3D.TRANSFORM_WORLDMATRIX) || !this._getTransformFlag(Transform3D.TRANSFORM_WORLDPOSITION) || !this._getTransformFlag(Transform3D.TRANSFORM_WORLDSCALE)) {
             this._setTransformFlag(Transform3D.TRANSFORM_WORLDMATRIX | Transform3D.TRANSFORM_WORLDPOSITION | Transform3D.TRANSFORM_WORLDSCALE, true);
-            if (this._hasTransformChangedListener)
-                this.event(Event.TRANSFORM_CHANGED, this._getTransformChangeFlag());
+            this._notifyTransformChanged();
         }
         for (var i: number = 0, n: number = this._children!.length; i < n; i++)
             (this._children[i] as RTTransform3D)._onWorldPositionScaleTransform();
@@ -513,8 +504,7 @@ export class RTTransform3D extends Transform3D {
     protected _onWorldPositionTransform(): void {
         if (!this._getTransformFlag(Transform3D.TRANSFORM_WORLDMATRIX) || !this._getTransformFlag(Transform3D.TRANSFORM_WORLDPOSITION)) {
             this._setTransformFlag(Transform3D.TRANSFORM_WORLDMATRIX | Transform3D.TRANSFORM_WORLDPOSITION, true);
-            if (this._hasTransformChangedListener)
-                this.event(Event.TRANSFORM_CHANGED, this._getTransformChangeFlag());
+            this._notifyTransformChanged();
         }
         if (Transform3D._inAnimatorBatch) {
             if (this._lastAnimatorFrame === Transform3D._currentAnimatorFrame) return;
@@ -533,8 +523,7 @@ export class RTTransform3D extends Transform3D {
     protected _onWorldRotationTransform(): void {
         if (!this._getTransformFlag(Transform3D.TRANSFORM_WORLDMATRIX) || !this._getTransformFlag(Transform3D.TRANSFORM_WORLDQUATERNION) || !this._getTransformFlag(Transform3D.TRANSFORM_WORLDEULER)) {
             this._setTransformFlag(Transform3D.TRANSFORM_WORLDMATRIX | Transform3D.TRANSFORM_WORLDQUATERNION | Transform3D.TRANSFORM_WORLDEULER, true);
-            if (this._hasTransformChangedListener)
-                this.event(Event.TRANSFORM_CHANGED, this._getTransformChangeFlag());
+            this._notifyTransformChanged();
         }
         if (Transform3D._inAnimatorBatch) {
             if (this._lastAnimatorFrame === Transform3D._currentAnimatorFrame) return;
@@ -553,8 +542,7 @@ export class RTTransform3D extends Transform3D {
     protected _onWorldScaleTransform(): void {
         if (!this._getTransformFlag(Transform3D.TRANSFORM_WORLDMATRIX) || !this._getTransformFlag(Transform3D.TRANSFORM_WORLDSCALE)) {
             this._setTransformFlag(Transform3D.TRANSFORM_WORLDMATRIX | Transform3D.TRANSFORM_WORLDSCALE, true);
-            if (this._hasTransformChangedListener)
-                this.event(Event.TRANSFORM_CHANGED, this._getTransformChangeFlag());
+            this._notifyTransformChanged();
         }
         if (Transform3D._inAnimatorBatch) {
             if (this._lastAnimatorFrame === Transform3D._currentAnimatorFrame) return;
@@ -573,8 +561,7 @@ export class RTTransform3D extends Transform3D {
     _onWorldTransform(): void {
         if (!this._getTransformFlag(Transform3D.TRANSFORM_WORLDMATRIX) || !this._getTransformFlag(Transform3D.TRANSFORM_WORLDPOSITION) || !this._getTransformFlag(Transform3D.TRANSFORM_WORLDQUATERNION) || !this._getTransformFlag(Transform3D.TRANSFORM_WORLDEULER) || !this._getTransformFlag(Transform3D.TRANSFORM_WORLDSCALE)) {
             this._setTransformFlag(Transform3D.TRANSFORM_WORLDMATRIX | Transform3D.TRANSFORM_WORLDPOSITION | Transform3D.TRANSFORM_WORLDQUATERNION | Transform3D.TRANSFORM_WORLDEULER | Transform3D.TRANSFORM_WORLDSCALE, true);
-            if (this._hasTransformChangedListener)
-                this.event(Event.TRANSFORM_CHANGED, this._getTransformChangeFlag());
+            this._notifyTransformChanged();
         }
         if (Transform3D._inAnimatorBatch) {
             if (this._lastAnimatorFrame === Transform3D._currentAnimatorFrame) return;

--- a/src/layaAir/laya/d3/component/Animator/factory/AnimatorTransformEventDispatcher.ts
+++ b/src/layaAir/laya/d3/component/Animator/factory/AnimatorTransformEventDispatcher.ts
@@ -1,0 +1,163 @@
+import { FastSinglelist } from "../../../../utils/SingletonList";
+import { Transform3D, IAnimatorTransformEventCollector } from "../../../core/Transform3D";
+import { AnimatorState } from "../AnimatorState";
+import { KeyframeNodeOwner } from "../KeyframeNodeOwner";
+import { AnimatorBindContext } from "./AnimatorBindContext";
+import { isTransformType } from "./isTransformType";
+import { LayerTaskType, TaskSlot } from "./TaskSlot";
+
+interface EventBuffer {
+    frame: number;
+    transforms: FastSinglelist<Transform3D>;
+    flags: FastSinglelist<number>;
+}
+
+/** 所有 dispatcher 共用通知序号，避免 Transform 跨 Scene/Factory 后帧号碰撞。 */
+let _notifyFrame: number = 0;
+
+/**
+ * @internal Web/Native 共用的 Animator Transform 事件事务。
+ * Web 在原标脏遍历中直接收集；Native 在回写后从动画根递归收集；最终统一快照派发。
+ */
+export class AnimatorTransformEventDispatcher implements IAnimatorTransformEventCollector {
+    private readonly _stateTransformOwnersCache: WeakMap<AnimatorState, FastSinglelist<Transform3D>> = new WeakMap();
+    private readonly _nodeOwnersStateMap: WeakMap<KeyframeNodeOwner[], AnimatorState> = new WeakMap();
+    private readonly _buffers: EventBuffer[] = [{ frame: 0, transforms: new FastSinglelist<Transform3D>(), flags: new FastSinglelist<number>() }];
+    /** 纯 Web 路径直接在置脏遍历中收集，不创建 Native 子树扫描缓存。 */
+    private _trackStateOwners: boolean = false;
+    private _depth: number = 0;
+
+    registerState(state: AnimatorState): void {
+        if (!this._trackStateOwners) return;
+        this._nodeOwnersStateMap.set(state._nodeOwners, state);
+        this.rebuildState(state);
+    }
+
+    rebuildContext(ctx: AnimatorBindContext): void {
+        if (!this._trackStateOwners) return;
+        const layers = ctx.layers;
+        for (let i = 0, n = layers.length; i < n; i++) {
+            const states = layers[i]._states;
+            for (let j = 0, m = states.length; j < m; j++)
+                this.registerState(states[j]);
+        }
+    }
+
+    rebuildByNodeOwners(nodeOwners: KeyframeNodeOwner[]): void {
+        if (!this._trackStateOwners) return;
+        const state = this._nodeOwnersStateMap.get(nodeOwners);
+        if (state) this.rebuildState(state);
+    }
+
+    rebuildState(state: AnimatorState): void {
+        const owners = state._nodeOwners;
+        const seen = new Set<Transform3D>();
+        let transforms = this._stateTransformOwnersCache.get(state);
+        if (transforms) transforms.clear();
+        else transforms = new FastSinglelist<Transform3D>();
+        for (let i = 0, n = owners.length; i < n; i++) {
+            const owner = owners[i];
+            if (!owner || !isTransformType(owner.type)) continue;
+            const transform = owner.propertyOwner as Transform3D;
+            if (transform && !seen.has(transform)) {
+                seen.add(transform);
+                transforms.add(transform);
+            }
+        }
+        this._stateTransformOwnersCache.set(state, transforms);
+    }
+
+    begin(): void {
+        const buffer = this._getBuffer();
+        buffer.frame = ++_notifyFrame;
+        buffer.transforms.clear();
+        buffer.flags.clear();
+    }
+
+    abort(): void {
+        const buffer = this._getBuffer();
+        buffer.transforms.clear();
+        buffer.flags.clear();
+    }
+
+    _addAnimatorTransformEvent(transform: Transform3D, changeFlag: number): void {
+        const buffer = this._getBuffer();
+        if (transform._lastAnimatorNotifyFrame === buffer.frame) {
+            const index = transform._animatorNotifyIndex;
+            if (index >= 0) {
+                buffer.flags.elements[index] |= changeFlag;
+                return;
+            }
+        } else {
+            transform._lastAnimatorNotifyFrame = buffer.frame;
+        }
+        transform._animatorNotifyIndex = buffer.transforms.length;
+        buffer.transforms.add(transform);
+        buffer.flags.add(changeFlag);
+    }
+
+    /** Native 回写完成后，从 active state 的动画根收集并派发。 */
+    notifyActiveSlots(activeList: FastSinglelist<TaskSlot>): void {
+        if (activeList.length === 0) return;
+        this._trackStateOwners = true;
+        this.begin();
+        const buffer = this._getBuffer();
+        const slots = activeList.elements;
+        for (let i = 0, n = activeList.length; i < n; i++) {
+            const layers = slots[i]._layers;
+            for (let j = 0, m = layers.length; j < m; j++) {
+                const layer = layers[j];
+                if (layer.type === LayerTaskType.Idle) continue;
+                if (layer.state) this._collectStateSubtrees(layer.state, buffer);
+                if (layer.destState) this._collectStateSubtrees(layer.destState, buffer);
+            }
+        }
+        this.flush();
+    }
+
+    flush(): void {
+        const buffer = this._getBuffer();
+        this._depth++;
+        try {
+            for (let i = 0, n = buffer.transforms.length; i < n; i++)
+                buffer.transforms.elements[i]._dispatchAnimatorTransformChanged(buffer.flags.elements[i]);
+        } finally {
+            this._depth--;
+            buffer.transforms.clear();
+            buffer.flags.clear();
+        }
+    }
+
+    private _collectStateSubtrees(state: AnimatorState, buffer: EventBuffer): void {
+        let owners = this._stateTransformOwnersCache.get(state);
+        if (!owners) {
+            this.registerState(state);
+            owners = this._stateTransformOwnersCache.get(state)!;
+        }
+        for (let i = 0, n = owners.length; i < n; i++)
+            this._collectSubtree(owners.elements[i], buffer);
+    }
+
+    private _collectSubtree(transform: Transform3D, buffer: EventBuffer): void {
+        if (transform._lastAnimatorNotifyFrame === buffer.frame) return;
+        transform._lastAnimatorNotifyFrame = buffer.frame;
+        transform._animatorNotifyIndex = -1;
+        if (transform._hasTransformChangedListener) {
+            transform._animatorNotifyIndex = buffer.transforms.length;
+            buffer.transforms.add(transform);
+            buffer.flags.add(transform._getAnimatorTransformChangeFlag());
+        }
+        const children = transform._children;
+        if (children) for (let i = 0, n = children.length; i < n; i++)
+            this._collectSubtree(children[i], buffer);
+    }
+
+    private _getBuffer(): EventBuffer {
+        let buffer = this._buffers[this._depth];
+        if (!buffer) {
+            buffer = { frame: 0, transforms: new FastSinglelist<Transform3D>(), flags: new FastSinglelist<number>() };
+            this._buffers[this._depth] = buffer;
+        }
+        return buffer;
+    }
+}

--- a/src/layaAir/laya/d3/component/Animator/factory/runtime/RTAnimatorFactory.ts
+++ b/src/layaAir/laya/d3/component/Animator/factory/runtime/RTAnimatorFactory.ts
@@ -7,7 +7,7 @@ import { AnimatorState } from "../../AnimatorState";
 import { AnimatorControllerLayer } from "../../AnimatorControllerLayer";
 import { AvatarMask } from "../../AvatarMask";
 import { KeyFrameValueType, KeyframeNodeOwner } from "../../KeyframeNodeOwner";
-import { ITaskSlot, LayerTaskType, TaskSlot } from "../TaskSlot";
+import { ITaskSlot, TaskSlot } from "../TaskSlot";
 import { WebAnimatorFactory } from "../web/WebAnimatorFactory";
 import { isTransformType } from "../isTransformType";
 import { IOwnerData, PlainOwnerData, registerOwnerDataCreator, registerClipDestroyCallback } from "../data/IAnimatorData";
@@ -101,11 +101,6 @@ export class RTAnimatorFactory implements IAnimatorFactory {
 
     /** Transform backend 嗅探结果。LayaX → 'layax'；OpenGLES → 'jsrt'；缺失则跳过 transform 绑定。 */
     private readonly _transformBackend: 'layax' | 'jsrt' | null;
-
-    /** state → 该 state 内 Transform-typed owner 的 propertyOwner 去重列表，_notifyJsTransformChanged 每帧消费。 */
-    private readonly _statePropertyOwnersCache: WeakMap<AnimatorState, any[]> = new WeakMap();
-    /** _notifyJsTransformChanged 的帧序号，每次调用自增；与 transform 上的 _notifyFrame 比对做整数去重。 */
-    private _notifyFrame: number = 0;
 
     /** 批量同步 buffer，仅在 _nativeEvaluator 存在时初始化。 */
     private _syncBuffer: RTBatchSyncBuffer | null = null;
@@ -231,7 +226,7 @@ export class RTAnimatorFactory implements IAnimatorFactory {
      * 步骤：
      *   1) Web 端 prepareStateOwners 填好 state._nodeOwners；
      *   2) 若 preparer 存在：上传 clip → 把 Transform 类 owner 补传 native → 建立 (ctx,state) 的 binding；
-     *   3) 若 applier 存在：重建该 state 的 propertyOwners 缓存（_notifyJsTransformChanged 用）。
+     *   3) WebFactory 同步维护 Web/Native 共用的 Transform 事件 owner 缓存。
      */
     prepareStateOwners(ctx: AnimatorBindContext, state: AnimatorState): void {
         this._web.prepareStateOwners(ctx, state);
@@ -243,9 +238,6 @@ export class RTAnimatorFactory implements IAnimatorFactory {
             const clipHandle = this._ensureClipUploaded(clip);
             this._syncOwnersToNative(ctx, state);
             this._ensureBindingUploaded(ctx, state, clipHandle);
-        }
-        if (this._nativeApplier) {
-            this._rebuildStateTransformPropertyOwners(state);
         }
     }
 
@@ -472,8 +464,8 @@ export class RTAnimatorFactory implements IAnimatorFactory {
     }
 
     /**
-     * sprite link/unlink 后同步 native owner 列表与 propertyOwners 缓存。
-     * 步骤：Web 端处理 link/unlink → 遍历本 ctx 已建 binding 的所有 state，逐个补传新 owner / 重建缓存。
+     * sprite link/unlink 后同步 native owner 列表。
+     * WebFactory 已统一重建事件 owner 缓存；这里只补传 Native owner。
      */
     handleSpriteOwnersBySprite(ctx: AnimatorBindContext, isLink: boolean, path: string[], sprite: Sprite3D): void {
         this._web.handleSpriteOwnersBySprite(ctx, isLink, path, sprite);
@@ -482,7 +474,6 @@ export class RTAnimatorFactory implements IAnimatorFactory {
         if (stateMap) {
             for (const state of stateMap.keys()) {
                 if (this._nativePreparer) this._syncOwnersToNative(ctx, state);
-                if (this._nativeApplier) this._rebuildStateTransformPropertyOwners(state);
             }
         }
     }
@@ -632,7 +623,7 @@ export class RTAnimatorFactory implements IAnimatorFactory {
     /**
      * 一帧回写入口。
      * 步骤：native applier flush 写完 Transform（并在 C++ 侧设好 WORLD 脏标志）→
-     * _notifyJsTransformChanged 派发 JS 端 TRANSFORM_CHANGED 事件 →
+     * WebFactory 公共通知器派发 JS 端 TRANSFORM_CHANGED 事件 →
      * Web 端 flushApply 处理 non-transform 类型，并清 dirtyList。
      *
      * WORLD 脏标志由 native applier 在 C++ 里设：_setTransformFlag 是虚函数，JSRTTransform
@@ -643,76 +634,10 @@ export class RTAnimatorFactory implements IAnimatorFactory {
     flushApply(): void {
         if (this._nativeApplier) {
             this._nativeApplier.flush();
-            // C++ 回写后 JS 侧补派发 TRANSFORM_CHANGED（Native 化后唯一留在 JS 的逐帧事件开销）。
-            this._notifyJsTransformChanged();
+            // C++ 回写后复用 WebFactory 的统一通知器派发 TRANSFORM_CHANGED。
+            this._web._notifyAnimatorTransformChanged();
         }
         this._web.flushApply();
-    }
-
-    /**
-     * 派发 JS 端 TRANSFORM_CHANGED 事件，驱动 SkinnedMeshRenderer / BaseRender 的 bounds 失效。
-     * 扫 active slot 内非 Idle layer 的 propertyOwner 列表，逐个 _dispatchTransformEvent 递归派发。
-     *
-     * 去重用 transform 上的 _notifyFrame 帧标记（整数比对，比 Set hash 去重快得多）：派发过即标记
-     * 为本帧序号，再遇到直接跳过；且因 _dispatchTransformEvent 返回时保证整棵子树都已派发，命中
-     * 标记时连子节点一起跳过。WORLD 脏标志已由 native applier 在 C++ 侧设好，此处只补事件派发。
-     */
-    private _notifyJsTransformChanged(): void {
-        const active = (this._web as any)._activeList as { length: number; elements: TaskSlot[] };
-        if (active.length === 0) return;
-
-        const frame = ++this._notifyFrame;
-        const cache = this._statePropertyOwnersCache;
-
-        for (let i = 0, n = active.length; i < n; i++) {
-            const slot = active.elements[i];
-            const layers = slot._layers;
-            for (let j = 0, m = layers.length; j < m; j++) {
-                const lt = layers[j];
-                if (lt.type === LayerTaskType.Idle) continue;
-                if (lt.state) {
-                    const list = cache.get(lt.state);
-                    if (list) for (let k = 0, kn = list.length; k < kn; k++) this._dispatchTransformEvent(list[k], frame);
-                }
-                if (lt.destState) {
-                    const list = cache.get(lt.destState);
-                    if (list) for (let k = 0, kn = list.length; k < kn; k++) this._dispatchTransformEvent(list[k], frame);
-                }
-            }
-        }
-    }
-
-    /**
-     * 递归派发 TRANSFORM_CHANGED：_notifyFrame 命中本帧 frame 即返回（它和整棵子树都派过了）；
-     * 否则标记本帧、派发事件、递归子节点。无 TRANSFORM_CHANGED 监听者的 transform 跳过 event
-     * 调用（_hasTransformChangedListener=false），但仍递归——子孙可能有监听者。
-     */
-    private _dispatchTransformEvent(pro: any, frame: number): void {
-        if (pro._notifyFrame === frame) return;
-        pro._notifyFrame = frame;
-        if (pro._hasTransformChangedListener) pro.event(Event.TRANSFORM_CHANGED, pro._RTtransformFlag);
-        const children = pro._children;
-        if (children) for (let i = 0, n = children.length; i < n; i++) {
-            this._dispatchTransformEvent(children[i], frame);
-        }
-    }
-
-    /** 重建一个 state 的 Transform-typed propertyOwner 去重列表到 _statePropertyOwnersCache（冷路径）。 */
-    private _rebuildStateTransformPropertyOwners(state: AnimatorState): void {
-        const owners = (state as any)._nodeOwners as KeyframeNodeOwner[] | undefined;
-        if (!owners) {
-            this._statePropertyOwnersCache.delete(state);
-            return;
-        }
-        const seen = new Set<any>();
-        const result: any[] = [];
-        for (let i = 0, n = owners.length; i < n; i++) {
-            const o = owners[i];
-            if (!o || !isTransformType(o.type)) continue;
-            const pro = o.propertyOwner;
-            if (pro && !seen.has(pro)) { seen.add(pro); result.push(pro); }
-        }
-        this._statePropertyOwnersCache.set(state, result);
     }
 
     // ==================== 冷路径 ====================

--- a/src/layaAir/laya/d3/component/Animator/factory/web/WebAnimatorApplier.ts
+++ b/src/layaAir/laya/d3/component/Animator/factory/web/WebAnimatorApplier.ts
@@ -12,8 +12,18 @@ import { Utils3D } from "../../../../utils/Utils3D";
 import { isTransformType } from "../isTransformType";
 import { LayerTask } from "../TaskSlot";
 
-/** RT 路径下复用 Web applier 时，'non-transform-only' 跳过 Transform 类型让 Native 处理。 */
-export type WebAnimatorApplierScope = 'all' | 'non-transform-only';
+/** Web 分阶段回写；RT 路径使用 'non-transform-only' 跳过已由 Native 处理的 Transform。 */
+export type WebAnimatorApplierScope = 'all' | 'transform-only' | 'non-transform-only';
+
+interface ApplyIndices {
+    transform: Int32Array;
+    nonTransform: Int32Array;
+}
+
+interface CrossApplyIndices extends ApplyIndices {
+    crossMark: number;
+    ownerCount: number;
+}
 
 const _tempVector31: Vector3 = new Vector3();
 const _tempColor: Color = new Color();
@@ -34,45 +44,87 @@ export class WebAnimatorApplier {
      * revertDefaultKeyframeNodes 用桶替代「全表扫描 + 内层 isTransformType 判断」。
      * Clip 是只读资源，桶一次构建后稳定。'all' 路径不使用桶。
      */
-    private _nonTransformIdxCache: WeakMap<AnimationClip, Int32Array> = new WeakMap();
+    private _applyIndicesCache: WeakMap<AnimationClip, ApplyIndices> = new WeakMap();
 
-    /** 取 clip 的非 Transform 索引桶，缺则按 clip._nodes 构建并缓存。 */
-    private _getNonTransformIndices(clip: AnimationClip): Int32Array {
-        let cached = this._nonTransformIdxCache.get(clip);
+    /** Cross owner 列表只在转场切换时重建，按 crossMark 缓存两类索引。 */
+    private _crossApplyIndicesCache: WeakMap<AnimatorControllerLayer, CrossApplyIndices> = new WeakMap();
+
+    /** 取 clip 的 Transform/非 Transform 索引桶，缺则构建并缓存。 */
+    private _getApplyIndices(clip: AnimationClip): ApplyIndices {
+        let cached = this._applyIndicesCache.get(clip);
         if (cached) return cached;
+        const transform: number[] = [];
+        const nonTransform: number[] = [];
+        let transformCount = 0;
+        let nonTransformCount = 0;
         const nodes = (clip as any)._nodes;
-        if (!nodes) {
-            cached = new Int32Array(0);
-        } else {
+        if (nodes) {
             const count = nodes.count;
-            const tmp: number[] = [];
             for (let i = 0; i < count; i++) {
-                if (!isTransformType(nodes.getNodeByIndex(i).type)) tmp.push(i);
+                if (isTransformType(nodes.getNodeByIndex(i).type)) transform[transformCount++] = i;
+                else nonTransform[nonTransformCount++] = i;
             }
-            cached = new Int32Array(tmp);
         }
-        this._nonTransformIdxCache.set(clip, cached);
+        cached = {
+            transform: new Int32Array(transform),
+            nonTransform: new Int32Array(nonTransform)
+        };
+        this._applyIndicesCache.set(clip, cached);
         return cached;
     }
 
-    applyNormal(layerTask: LayerTask, controllerLayer: AnimatorControllerLayer, isFirstLayer: boolean, updateMark: number): void {
-        this._applyNormal(controllerLayer, layerTask.state!, /*additive*/controllerLayer.blendingMode !== AnimatorControllerLayer.BLENDINGMODE_OVERRIDE, layerTask.weight, isFirstLayer, updateMark, this._scope === 'non-transform-only');
+    /** 取当前 scope 对应的 clip 索引；all 保持原全量路径。 */
+    private _getScopedIndices(clip: AnimationClip, scope: WebAnimatorApplierScope): Int32Array | null {
+        if (scope === 'all') return null;
+        const indices = this._getApplyIndices(clip);
+        return scope === 'transform-only' ? indices.transform : indices.nonTransform;
     }
 
-    applyCross(layerTask: LayerTask, controllerLayer: AnimatorControllerLayer, isFirstLayer: boolean, updateMark: number): void {
-        this._applyCross(controllerLayer, layerTask.state!, layerTask.destState!, layerTask.crossWeight, isFirstLayer, updateMark, this._scope === 'non-transform-only');
+    /** 取 CrossFade 当前 scope 对应的索引。 */
+    private _getCrossScopedIndices(controllerLayer: AnimatorControllerLayer, scope: WebAnimatorApplierScope): Int32Array | null {
+        if (scope === 'all') return null;
+        const ownerCount = controllerLayer._crossNodesOwnersCount;
+        let cached = this._crossApplyIndicesCache.get(controllerLayer);
+        if (!cached || cached.crossMark !== controllerLayer._crossMark || cached.ownerCount !== ownerCount) {
+            const transform: number[] = [];
+            const nonTransform: number[] = [];
+            let transformCount = 0;
+            let nonTransformCount = 0;
+            const owners = controllerLayer._crossNodesOwners;
+            for (let i = 0; i < ownerCount; i++) {
+                const owner = owners[i];
+                if (owner && isTransformType(owner.type)) transform[transformCount++] = i;
+                else nonTransform[nonTransformCount++] = i;
+            }
+            cached = {
+                crossMark: controllerLayer._crossMark,
+                ownerCount,
+                transform: new Int32Array(transform),
+                nonTransform: new Int32Array(nonTransform)
+            };
+            this._crossApplyIndicesCache.set(controllerLayer, cached);
+        }
+        return scope === 'transform-only' ? cached.transform : cached.nonTransform;
     }
 
-    applyFixedCross(layerTask: LayerTask, controllerLayer: AnimatorControllerLayer, isFirstLayer: boolean, updateMark: number): void {
-        this._applyFixedCross(controllerLayer, layerTask.destState!, layerTask.crossWeight, isFirstLayer, updateMark, this._scope === 'non-transform-only');
+    applyNormal(layerTask: LayerTask, controllerLayer: AnimatorControllerLayer, isFirstLayer: boolean, updateMark: number, scope: WebAnimatorApplierScope = this._scope): void {
+        this._applyNormal(controllerLayer, layerTask.state!, /*additive*/controllerLayer.blendingMode !== AnimatorControllerLayer.BLENDINGMODE_OVERRIDE, layerTask.weight, isFirstLayer, updateMark, scope);
+    }
+
+    applyCross(layerTask: LayerTask, controllerLayer: AnimatorControllerLayer, isFirstLayer: boolean, updateMark: number, scope: WebAnimatorApplierScope = this._scope): void {
+        this._applyCross(controllerLayer, layerTask.state!, layerTask.destState!, layerTask.crossWeight, isFirstLayer, updateMark, scope);
+    }
+
+    applyFixedCross(layerTask: LayerTask, controllerLayer: AnimatorControllerLayer, isFirstLayer: boolean, updateMark: number, scope: WebAnimatorApplierScope = this._scope): void {
+        this._applyFixedCross(controllerLayer, layerTask.destState!, layerTask.crossWeight, isFirstLayer, updateMark, scope);
     }
 
     updateDefaultValues(owners: KeyframeNodeOwner[]): void {
-        const skipTransform = this._scope === 'non-transform-only';
         for (let i = 0, n = owners.length; i < n; i++) {
             const nodeOwner = owners[i];
             if (!nodeOwner || !nodeOwner.propertyOwner || !nodeOwner.property) continue;
-            if (skipTransform && isTransformType(nodeOwner.type)) continue;
+            const transformType = isTransformType(nodeOwner.type);
+            if (this._scope === 'transform-only' ? !transformType : this._scope === 'non-transform-only' && transformType) continue;
 
             let pro = nodeOwner.propertyOwner;
 
@@ -136,17 +188,18 @@ export class WebAnimatorApplier {
     }
 
     revertDefaultKeyframeNodes(state: AnimatorState): void {
-        const skipTransform = this._scope === 'non-transform-only';
         const nodeOwners: KeyframeNodeOwner[] = state._nodeOwners;
         const clip = state._clip;
-        // skipTransform 且 clip 在 → 用桶；clip 缺失走原全量 + 内层 isTransformType 兜底
-        const indices: Int32Array | null = (skipTransform && clip) ? this._getNonTransformIndices(clip) : null;
+        const indices: Int32Array | null = clip ? this._getScopedIndices(clip, this._scope) : null;
         const loopCount = indices !== null ? indices.length : nodeOwners.length;
         for (let k = 0; k < loopCount; k++) {
             const i = indices !== null ? indices[k] : k;
             const nodeOwner = nodeOwners[i];
             if (!nodeOwner) continue;
-            if (skipTransform && indices === null && isTransformType(nodeOwner.type)) continue;
+            if (indices === null && this._scope !== 'all') {
+                const transformType = isTransformType(nodeOwner.type);
+                if (this._scope === 'transform-only' ? !transformType : transformType) continue;
+            }
             let pro: any = nodeOwner.propertyOwner;
             let value: string;
             if (!pro) continue;
@@ -293,15 +346,14 @@ export class WebAnimatorApplier {
         weight: number,
         isFirstLayer: boolean,
         updateMark: number,
-        skipTransform: boolean
+        scope: WebAnimatorApplierScope
     ): void {
         this._currentUpdateMark = updateMark;
         const realtimeDatas = stateInfo._realtimeDatas;
         const clip = stateInfo._clip!;
         const nodes = clip._nodes!;
         const nodeOwners: KeyframeNodeOwner[] = stateInfo._nodeOwners;
-        // skipTransform 走非 Transform 索引桶替代全表扫描；scope='all' 走原全量循环
-        const indices: Int32Array | null = skipTransform ? this._getNonTransformIndices(clip) : null;
+        const indices: Int32Array | null = this._getScopedIndices(clip, scope);
         const loopCount = indices !== null ? indices.length : nodes.count;
         for (let k = 0; k < loopCount; k++) {
             const i = indices !== null ? indices[k] : k;
@@ -476,7 +528,7 @@ export class WebAnimatorApplier {
         crossWeight: number,
         isFirstLayer: boolean,
         updateMark: number,
-        skipTransform: boolean
+        scope: WebAnimatorApplierScope
     ): void {
         this._currentUpdateMark = updateMark;
         const nodeOwners: KeyframeNodeOwner[] = controllerLayer._crossNodesOwners;
@@ -491,10 +543,12 @@ export class WebAnimatorApplier {
         const srcDataIndices: number[] = controllerLayer._srcCrossClipNodeIndices;
         const srcNodeOwners: KeyframeNodeOwner[] = srcState._nodeOwners;
 
-        for (let i: number = 0; i < ownerCount; i++) {
+        const indices = this._getCrossScopedIndices(controllerLayer, scope);
+        const loopCount = indices !== null ? indices.length : ownerCount;
+        for (let k: number = 0; k < loopCount; k++) {
+            const i = indices !== null ? indices[k] : k;
             const nodeOwner: KeyframeNodeOwner = nodeOwners[i];
             if (!nodeOwner) continue;
-            if (skipTransform && isTransformType(nodeOwner.type)) continue;
             const srcIndex: number = srcDataIndices[i];
             const destIndex: number = destDataIndices[i];
             if (-1 == srcIndex && -1 == destIndex) continue;
@@ -517,7 +571,7 @@ export class WebAnimatorApplier {
         crossWeight: number,
         isFirstLayer: boolean,
         updateMark: number,
-        skipTransform: boolean
+        scope: WebAnimatorApplierScope
     ): void {
         this._currentUpdateMark = updateMark;
         const nodeOwners: KeyframeNodeOwner[] = controllerLayer._crossNodesOwners;
@@ -527,10 +581,12 @@ export class WebAnimatorApplier {
         const destRealtimeDatas = destState._realtimeDatas;
         const destDataIndices: number[] = controllerLayer._destCrossClipNodeIndices;
 
-        for (let i: number = 0; i < ownerCount; i++) {
+        const indices = this._getCrossScopedIndices(controllerLayer, scope);
+        const loopCount = indices !== null ? indices.length : ownerCount;
+        for (let k: number = 0; k < loopCount; k++) {
+            const i = indices !== null ? indices[k] : k;
             const nodeOwner: KeyframeNodeOwner = nodeOwners[i];
             if (!nodeOwner) continue;
-            if (skipTransform && isTransformType(nodeOwner.type)) continue;
             const destIndex: number = destDataIndices[i];
             const srcValue: any = nodeOwner.crossFixedValue;
             let desValue;

--- a/src/layaAir/laya/d3/component/Animator/factory/web/WebAnimatorFactory.ts
+++ b/src/layaAir/laya/d3/component/Animator/factory/web/WebAnimatorFactory.ts
@@ -1,4 +1,5 @@
 import { Sprite3D } from "../../../../core/Sprite3D";
+import { Transform3D } from "../../../../core/Transform3D";
 import { KeyframeNode } from "../../../../animation/KeyframeNode";
 import { FastSinglelist } from "../../../../../utils/SingletonList";
 import { IAnimatorFactory } from "../IAnimatorFactory";
@@ -7,9 +8,10 @@ import { AnimatorState } from "../../AnimatorState";
 import { KeyframeNodeOwner } from "../../KeyframeNodeOwner";
 import { ITaskSlot, LayerTaskType, TaskSlot } from "../TaskSlot";
 import { WebAnimatorEvaluator } from "./WebAnimatorEvaluator";
-import { WebAnimatorApplier } from "./WebAnimatorApplier";
+import { WebAnimatorApplier, WebAnimatorApplierScope } from "./WebAnimatorApplier";
 import * as Preparer from "./WebAnimatorPreparer";
 import { PlainOwnerData, registerOwnerDataCreator } from "../data/IAnimatorData";
+import { AnimatorTransformEventDispatcher } from "../AnimatorTransformEventDispatcher";
 
 /**
  * IAnimatorFactory 的 Web 默认实现，每 Scene3D 一个实例。
@@ -29,6 +31,7 @@ export class WebAnimatorFactory implements IAnimatorFactory {
     _dirtyList: FastSinglelist<TaskSlot> = new FastSinglelist();
 
     private readonly _slotMap: WeakMap<AnimatorBindContext, TaskSlot> = new WeakMap();
+    private readonly _transformEventDispatcher: AnimatorTransformEventDispatcher = new AnimatorTransformEventDispatcher();
 
     constructor() {
         // KeyframeNodeOwner 在 preparer 里 new，没有 factory 引用，靠 module-level register 注入。
@@ -64,18 +67,22 @@ export class WebAnimatorFactory implements IAnimatorFactory {
 
     prepareStateOwners(ctx: AnimatorBindContext, state: AnimatorState): void {
         Preparer.prepareStateOwners(ctx, state);
+        this._transformEventDispatcher.registerState(state);
     }
 
     handleSpriteOwnersBySprite(ctx: AnimatorBindContext, isLink: boolean, path: string[], sprite: Sprite3D): void {
         Preparer.handleSpriteOwnersBySprite(ctx, isLink, path, sprite);
+        this._transformEventDispatcher.rebuildContext(ctx);
     }
 
     addKeyframeNodeOwner(ctx: AnimatorBindContext, clipOwners: KeyframeNodeOwner[], node: KeyframeNode, propertyOwner: any): void {
         Preparer.addKeyframeNodeOwner(ctx, clipOwners, node, propertyOwner);
+        this._transformEventDispatcher.rebuildByNodeOwners(clipOwners);
     }
 
     removeKeyframeNodeOwner(ctx: AnimatorBindContext, nodeOwners: (KeyframeNodeOwner | null)[], node: KeyframeNode): void {
         Preparer.removeKeyframeNodeOwner(ctx, nodeOwners, node);
+        this._transformEventDispatcher.rebuildByNodeOwners(nodeOwners as KeyframeNodeOwner[]);
     }
 
     // ==================== 一帧两阶段批处理 ====================
@@ -97,10 +104,8 @@ export class WebAnimatorFactory implements IAnimatorFactory {
         }
     }
 
-    /**
-     * 遍历 activeList，按 LayerTask.type 分派到 applier.applyNormal/applyCross/applyFixedCross，末尾清 dirtyList。
-     */
-    flushApply(): void {
+    /** 遍历 activeList，按 LayerTask.type 分派当前 scope 的回写。 */
+    private _flushApplyScope(scope: WebAnimatorApplierScope): void {
         const slots = this._activeList.elements;
         const applier = this._applier;
         for (let i = 0, n = this._activeList.length; i < n; i++) {
@@ -115,18 +120,56 @@ export class WebAnimatorFactory implements IAnimatorFactory {
                 const isFirstLayer = j === 0;
                 switch (lt.type) {
                     case LayerTaskType.Normal:
-                        applier.applyNormal(lt, cl, isFirstLayer, updateMark);
+                        applier.applyNormal(lt, cl, isFirstLayer, updateMark, scope);
                         break;
                     case LayerTaskType.Cross:
-                        applier.applyCross(lt, cl, isFirstLayer, updateMark);
+                        applier.applyCross(lt, cl, isFirstLayer, updateMark, scope);
                         break;
                     case LayerTaskType.FixedCross:
-                        applier.applyFixedCross(lt, cl, isFirstLayer, updateMark);
+                        applier.applyFixedCross(lt, cl, isFirstLayer, updateMark, scope);
                         break;
                 }
             }
         }
+    }
+
+    /**
+     * Web 先批量回写全部 Transform，关闭 batch 后统一派发事件，再处理非 Transform 属性。
+     * RT 复用实例的 scope 为 non-transform-only，保持单阶段处理。
+     */
+    flushApply(): void {
+        const applier = this._applier;
+        const originalScope = applier._scope;
+        if (originalScope !== 'all') {
+            this._flushApplyScope(originalScope);
+            this._clearDirty();
+            return;
+        }
+
+        const eventDispatcher = this._transformEventDispatcher;
+        let transformApplyCompleted = false;
+        eventDispatcher.begin();
+        Transform3D._beginAnimatorBatch(eventDispatcher);
+        try {
+            this._flushApplyScope('transform-only');
+            transformApplyCompleted = true;
+        } finally {
+            Transform3D._endAnimatorBatch();
+            if (!transformApplyCompleted) eventDispatcher.abort();
+        }
+
+        eventDispatcher.flush();
+
+        this._flushApplyScope('non-transform-only');
         this._clearDirty();
+    }
+
+    /**
+     * @internal Web/Native 共用的 Animator Transform 事件提交点。
+     * 先完整收集节点与 flag 快照，再派发事件，避免回调修改层级或读取缓存影响后续通知。
+     */
+    _notifyAnimatorTransformChanged(): void {
+        this._transformEventDispatcher.notifyActiveSlots(this._activeList);
     }
 
     private _clearDirty(): void {

--- a/src/layaAir/laya/d3/component/Animator/manager/AnimatorManager.ts
+++ b/src/layaAir/laya/d3/component/Animator/manager/AnimatorManager.ts
@@ -4,7 +4,6 @@ import { NodeFlags } from "../../../../Const";
 import { Stat } from "../../../../utils/Stat";
 import { AnimationEvent } from "../../../animation/AnimationEvent";
 import { Scene3D } from "../../../core/scene/Scene3D";
-import { Transform3D } from "../../../core/Transform3D";
 import { Animator } from "../Animator";
 import { AnimatorControllerLayer } from "../AnimatorControllerLayer";
 import { AnimatorPlayState } from "../AnimatorPlayState";
@@ -71,11 +70,8 @@ export class AnimatorManager implements IElementComponentManager {
         // ── 阶段2：曲线解析（采样）──
         this._factory.flushEvaluate();
 
-        // ── 阶段3：数据回写 ──（开 batch mode：同一 transform 同帧多次 set 时跳过重复 walk children）
-        Transform3D._currentAnimatorFrame++;
-        Transform3D._inAnimatorBatch = true;
+        // ── 阶段3：数据回写（各后端自行管理 Transform 批次与事件时序）──
         this._factory.flushApply();
-        Transform3D._inAnimatorBatch = false;
 
         // 收尾（crossFade 切换 / LateUpdate 事件）归入状态机阶段
         this._drainPendingSwitches();

--- a/src/layaAir/laya/d3/core/Transform3D.ts
+++ b/src/layaAir/laya/d3/core/Transform3D.ts
@@ -8,6 +8,11 @@ import { Quaternion } from "../../maths/Quaternion";
 import { Vector3 } from "../../maths/Vector3";
 import { Sprite3D } from "./Sprite3D";
 
+/** @internal Animator batch 收集 Transform 事件的窄接口，避免 core 依赖 Animator 实现。 */
+export interface IAnimatorTransformEventCollector {
+    _addAnimatorTransformEvent(transform: Transform3D, changeFlag: number): void;
+}
+
 /**
  * @en The `Transform3D` class is used to implement 3D transformations.
  * @zh `Transform3D` 类用于实现3D变换。
@@ -43,6 +48,8 @@ export class Transform3D extends EventDispatcher {
      * 只 walk children 一次（同帧二次以后只更新本节点 flag，跳过递归子树脏标记）。
      */
     static _inAnimatorBatch: boolean = false;
+    /** @internal 当前 Animator batch 的事件收集器。 */
+    private static _animatorEventCollector: IAnimatorTransformEventCollector | null = null;
     /**
      * @internal
      * Animator 批次帧计数器；每个 flushApply 开始时自增 1。
@@ -55,6 +62,11 @@ export class Transform3D extends EventDispatcher {
      * 后续同帧 set 跳过 walk children。
      */
     _lastAnimatorFrame: number = -1;
+
+    /** @internal Animator 统一派发 TRANSFORM_CHANGED 时的帧去重标记。 */
+    _lastAnimatorNotifyFrame: number = -1;
+    /** @internal 当前通知帧在公共通知队列中的索引。 */
+    _animatorNotifyIndex: number = -1;
 
     /** @internal */
     protected _owner: Sprite3D;
@@ -106,6 +118,41 @@ export class Transform3D extends EventDispatcher {
      */
     protected onStartListeningToType(type: string): void {
         if (type === Event.TRANSFORM_CHANGED) this._hasTransformChangedListener = true;
+    }
+
+    /** @internal */
+    static _beginAnimatorBatch(eventCollector: IAnimatorTransformEventCollector): void {
+        this._currentAnimatorFrame++;
+        this._animatorEventCollector = eventCollector;
+        this._inAnimatorBatch = true;
+    }
+
+    /** @internal */
+    static _endAnimatorBatch(): void {
+        this._inAnimatorBatch = false;
+        this._animatorEventCollector = null;
+    }
+
+    /** Animator batch 内抑制即时事件；普通 Transform 写入仍同步派发。 */
+    protected _notifyTransformChanged(): void {
+        if (!this._hasTransformChangedListener) return;
+        const changeFlag = this._getTransformChangeFlag();
+        if (Transform3D._inAnimatorBatch) {
+            Transform3D._animatorEventCollector?._addAnimatorTransformEvent(this, changeFlag);
+        } else {
+            this.event(Event.TRANSFORM_CHANGED, changeFlag);
+        }
+    }
+
+    /** @internal 供 Animator 公共通知器在回写完成后捕获最终 change flag。 */
+    _getAnimatorTransformChangeFlag(): number {
+        return this._getTransformChangeFlag();
+    }
+
+    /** @internal 供 Animator 公共通知器派发已捕获的 change flag。 */
+    _dispatchAnimatorTransformChanged(changeFlag: number): void {
+        if (this._hasTransformChangedListener)
+            this.event(Event.TRANSFORM_CHANGED, changeFlag);
     }
 
 
@@ -651,8 +698,7 @@ export class Transform3D extends EventDispatcher {
     protected _onWorldPositionRotationTransform(): void {
         if (!this._getTransformFlag(Transform3D.TRANSFORM_WORLDMATRIX) || !this._getTransformFlag(Transform3D.TRANSFORM_WORLDPOSITION) || !this._getTransformFlag(Transform3D.TRANSFORM_WORLDQUATERNION) || !this._getTransformFlag(Transform3D.TRANSFORM_WORLDEULER)) {
             this._setTransformFlag(Transform3D.TRANSFORM_WORLDMATRIX | Transform3D.TRANSFORM_WORLDPOSITION | Transform3D.TRANSFORM_WORLDQUATERNION | Transform3D.TRANSFORM_WORLDEULER, true);
-            if (this._hasTransformChangedListener)
-                this.event(Event.TRANSFORM_CHANGED, this._getTransformChangeFlag());
+            this._notifyTransformChanged();
         }
         for (var i: number = 0, n: number = this._children!.length; i < n; i++)
             this._children![i]._onWorldPositionRotationTransform();
@@ -664,8 +710,7 @@ export class Transform3D extends EventDispatcher {
     protected _onWorldPositionScaleTransform(): void {
         if (!this._getTransformFlag(Transform3D.TRANSFORM_WORLDMATRIX) || !this._getTransformFlag(Transform3D.TRANSFORM_WORLDPOSITION) || !this._getTransformFlag(Transform3D.TRANSFORM_WORLDSCALE)) {
             this._setTransformFlag(Transform3D.TRANSFORM_WORLDMATRIX | Transform3D.TRANSFORM_WORLDPOSITION | Transform3D.TRANSFORM_WORLDSCALE, true);
-            if (this._hasTransformChangedListener)
-                this.event(Event.TRANSFORM_CHANGED, this._getTransformChangeFlag());
+            this._notifyTransformChanged();
         }
         for (var i: number = 0, n: number = this._children!.length; i < n; i++)
             this._children![i]._onWorldPositionScaleTransform();
@@ -677,8 +722,7 @@ export class Transform3D extends EventDispatcher {
     protected _onWorldPositionTransform(): void {
         if (!this._getTransformFlag(Transform3D.TRANSFORM_WORLDMATRIX) || !this._getTransformFlag(Transform3D.TRANSFORM_WORLDPOSITION)) {
             this._setTransformFlag(Transform3D.TRANSFORM_WORLDMATRIX | Transform3D.TRANSFORM_WORLDPOSITION, true);
-            if (this._hasTransformChangedListener)
-                this.event(Event.TRANSFORM_CHANGED, this._getTransformChangeFlag());
+            this._notifyTransformChanged();
         }
         if (Transform3D._inAnimatorBatch) {
             if (this._lastAnimatorFrame === Transform3D._currentAnimatorFrame) return;
@@ -697,8 +741,7 @@ export class Transform3D extends EventDispatcher {
     protected _onWorldRotationTransform(): void {
         if (!this._getTransformFlag(Transform3D.TRANSFORM_WORLDMATRIX) || !this._getTransformFlag(Transform3D.TRANSFORM_WORLDQUATERNION) || !this._getTransformFlag(Transform3D.TRANSFORM_WORLDEULER)) {
             this._setTransformFlag(Transform3D.TRANSFORM_WORLDMATRIX | Transform3D.TRANSFORM_WORLDQUATERNION | Transform3D.TRANSFORM_WORLDEULER, true);
-            if (this._hasTransformChangedListener)
-                this.event(Event.TRANSFORM_CHANGED, this._getTransformChangeFlag());
+            this._notifyTransformChanged();
         }
         if (Transform3D._inAnimatorBatch) {
             if (this._lastAnimatorFrame === Transform3D._currentAnimatorFrame) return;
@@ -717,8 +760,7 @@ export class Transform3D extends EventDispatcher {
     protected _onWorldScaleTransform(): void {
         if (!this._getTransformFlag(Transform3D.TRANSFORM_WORLDMATRIX) || !this._getTransformFlag(Transform3D.TRANSFORM_WORLDSCALE)) {
             this._setTransformFlag(Transform3D.TRANSFORM_WORLDMATRIX | Transform3D.TRANSFORM_WORLDSCALE, true);
-            if (this._hasTransformChangedListener)
-                this.event(Event.TRANSFORM_CHANGED, this._getTransformChangeFlag());
+            this._notifyTransformChanged();
         }
         if (Transform3D._inAnimatorBatch) {
             if (this._lastAnimatorFrame === Transform3D._currentAnimatorFrame) return;
@@ -737,8 +779,7 @@ export class Transform3D extends EventDispatcher {
     _onWorldTransform(): void {
         if (!this._getTransformFlag(Transform3D.TRANSFORM_WORLDMATRIX) || !this._getTransformFlag(Transform3D.TRANSFORM_WORLDPOSITION) || !this._getTransformFlag(Transform3D.TRANSFORM_WORLDQUATERNION) || !this._getTransformFlag(Transform3D.TRANSFORM_WORLDEULER) || !this._getTransformFlag(Transform3D.TRANSFORM_WORLDSCALE)) {
             this._setTransformFlag(Transform3D.TRANSFORM_WORLDMATRIX | Transform3D.TRANSFORM_WORLDPOSITION | Transform3D.TRANSFORM_WORLDQUATERNION | Transform3D.TRANSFORM_WORLDEULER | Transform3D.TRANSFORM_WORLDSCALE, true);
-            if (this._hasTransformChangedListener)
-                this.event(Event.TRANSFORM_CHANGED, this._getTransformChangeFlag());
+            this._notifyTransformChanged();
         }
         if (Transform3D._inAnimatorBatch) {
             if (this._lastAnimatorFrame === Transform3D._currentAnimatorFrame) return;


### PR DESCRIPTION
## Summary

- batch Web Animator Transform writes before dispatching `TRANSFORM_CHANGED`
- share one Transform event dispatcher across Web, JSRT, and LayaX paths
- split Web apply scopes for normal, cross-fade, and fixed-cross tasks while keeping Native non-Transform fallback behavior
- move Transform batch lifecycle ownership from `AnimatorManager` into each backend factory

## Problem

A synchronous `TRANSFORM_CHANGED` listener can read `worldMatrix` during Animator curve application and clear the child's dirty flag. A later write to the same animated parent in the same batch can then skip the repeated subtree walk, leaving the child with a stale world matrix.

## Validation

- `npm test -- tests/unit/animator-transform-batch-invalidation.test.ts` in the sidecar test repository: 5 passed, 1 expected failure
- `npm test` in the sidecar test repository: 18 passed, 1 expected failure
- `npm run typecheck` in the sidecar test repository: passed

The expected failure documents the existing `PathPoint` classification gap: it writes Transform properties through the Web fallback but is not currently classified as a Transform curve. The standard Position, Rotation, Scale, RotationEuler, CrossFade, and FixedCross paths are covered and pass.
