### PR TITLE
fix(media): restore WeChat video replay（修复微信视频重复播放）

### DIFF
--- a/src/layaAir/platforms/weixin/WxVideoTexture.ts
+++ b/src/layaAir/platforms/weixin/WxVideoTexture.ts
@@ -35,6 +35,7 @@ export class WxVideoTexture extends VideoTexture {
             if (this._loop)
                 this.decoder.stop().then(() => this.decoder.start(this._startOption));
             else {
+                this.pause();
                 this._ended = true;
                 this.event("ended");
             }
@@ -54,7 +55,14 @@ export class WxVideoTexture extends VideoTexture {
     }
 
     set currentTime(value: number) {
-        this.decoder.seek(value * 1000);
+        this._ended = false;
+        this.decoder.seek(value * 1000).then(() => {
+            if (this._playing) {
+                (<any>this.decoder).wait(false);
+            }
+        }).catch(err => {
+            console.warn("MgVideoTexture seek: " + err.message);
+        });
     }
 
     protected onLoad(url: string): void {


### PR DESCRIPTION
## 问题

微信小游戏真机中，视频首次播放正常，但设置 currentTime = 0 后再次调用 play() 无法重复播放。

## 原因

视频自然结束后，VideoTexture 的播放状态没有同步为暂停；同时 VideoDecoder.seek() 是异步操作，play() 可能在 seek 完成前被忽略。

## 修改

- 视频结束时同步暂停状态
- seek 时重置结束状态
- seek 完成后按当前播放状态恢复解码

## 验证

- 微信真机重复播放验证通过
- TypeScript 编译检查通过
- 引擎完整构建通过