### PR TITLE
fix(media): restart WeChat video from beginning（修复微信视频从头重播）

### DIFF
--- a/src/layaAir/platforms/weixin/WxVideoTexture.ts
+++ b/src/layaAir/platforms/weixin/WxVideoTexture.ts
@@ -11,6 +11,7 @@ export class WxVideoTexture extends VideoTexture {
     private _ended: boolean = false;
     private _waitFirstFrame: boolean = false;
     private _startOption: any;
+    private _restartPromise: Promise<any>;
 
     constructor() {
         super();
@@ -56,17 +57,47 @@ export class WxVideoTexture extends VideoTexture {
 
     set currentTime(value: number) {
         this._ended = false;
+        if (value === 0 && this._loaded) {
+            this.restartDecoder();
+            return;
+        }
         this.decoder.seek(value * 1000).then(() => {
-            if (this._playing) {
+            if (this._playing)
                 (<any>this.decoder).wait(false);
-            }
         }).catch(err => {
             console.warn("MgVideoTexture seek: " + err.message);
         });
     }
 
+    private restartDecoder(): void {
+        if (this._restartPromise)
+            return;
+        this._waitFirstFrame = true;
+        const promise = this._restartPromise = this.decoder.stop().then(() => {
+            if (this._restartPromise !== promise)
+                return null;
+            return this.decoder.start(this._startOption);
+        });
+        promise.then(() => {
+            if (this._restartPromise !== promise)
+                return;
+            this._restartPromise = null;
+            if (this._playing)
+                (<any>this.decoder).wait(false);
+        }).catch(err => {
+            if (this._restartPromise === promise) {
+                this._restartPromise = null;
+                this._waitFirstFrame = false;
+                if (this._playing)
+                    this.pause();
+            }
+            console.warn("MgVideoTexture restart: " + err.message);
+        });
+    }
+
     protected onLoad(url: string): void {
         let src = this._source;
+        this._restartPromise = null;
         this._ended = false;
         this._waitFirstFrame = false;
         if (this._loaded)
@@ -91,8 +122,8 @@ export class WxVideoTexture extends VideoTexture {
     }
 
     protected onPlay(): void {
-        //@ts-ignore
-        this.decoder.wait(false);
+        if (!this._restartPromise)
+            (<any>this.decoder).wait(false);
     }
 
     protected onPause(): void {
@@ -118,6 +149,7 @@ export class WxVideoTexture extends VideoTexture {
     }
 
     protected onDestroy(): void {
+        this._restartPromise = null;
         this.decoder.remove();
     }
 }


### PR DESCRIPTION
## 问题

微信小游戏真机中，视频播放中或暂停后设置 `currentTime = 0` 并调用 `play()`，解码器仍可能从原位置继续播放。

## 原因

`wemedia` 解码器在当前状态下执行 `seek(0)` 不能稳定回到视频起点；播放过程中再次调用 `play()` 也会因引擎已处于播放状态而直接返回。

## 修改

- 已加载视频设置到 0 秒时，通过 `stop()` 和 `start()` 重启解码器
- 重启期间延迟恢复播放，并合并重复的重播请求
- 换源或销毁时使未完成的重启任务失效
- 重启失败时清理状态并恢复暂停
- 非零时间定位保持原有 `seek()` 逻辑

## 验证

- 微信真机播放中重复播放验证通过
- 微信真机暂停后重复播放验证通过
- 微信真机播放结束后重复播放验证通过
- TypeScript 编译检查通过
- JavaScript 语法检查通过