### PR TITLE
perf: cut per-frame allocations and redundant GPU uploads

### DIFF
--- a/src/layaAir/laya/RenderDriver/DriverCommon/RenderListQueue.ts
+++ b/src/layaAir/laya/RenderDriver/DriverCommon/RenderListQueue.ts
@@ -80,7 +80,7 @@ export class RenderListQueue {
      * 清空队列
      */
     clear() {
-        this._elements.elements.fill(null); //避免引用js对象导致无法gc
+        this._elements.elements.fill(null, 0, this._elements.length); //避免引用js对象导致无法gc
         this._elements.length = 0;
         this.batchModule.length = 0;
     }

--- a/src/layaAir/laya/RenderDriver/RenderModuleData/WebModuleData/WebDefineDatas.ts
+++ b/src/layaAir/laya/RenderDriver/RenderModuleData/WebModuleData/WebDefineDatas.ts
@@ -162,9 +162,10 @@ export class WebDefineDatas implements IDefineDatas {
 
     private _notifyChangeFlag() {
         if (this._changeFlags.size > 0) {
-            this._changeFlags.forEach(value => {
-                value.setValue(Stat.loopCount, LayaGL.renderEngine._framePassCount)
-            });
+            const framePassCount = LayaGL.renderEngine._framePassCount;
+            for (const value of this._changeFlags) {
+                value.setValue(Stat.loopCount, framePassCount);
+            }
         }
     }
 

--- a/src/layaAir/laya/d3/core/scene/Scene3D.ts
+++ b/src/layaAir/laya/d3/core/scene/Scene3D.ts
@@ -1433,9 +1433,9 @@ if (Profiler.enabled) {
 
         profileZone = Profiler.start("scene/component_elements_update");
         try {
-            this.componentElementMap.forEach((value: IElementComponentManager) => {
-                value.update(delta);
-            });
+            for (let i = 0, n = this._componentElementList.length; i < n; i++) {
+                this._componentElementList[i].update(delta);
+            }
             this._componentDriver.callAfterSceneUpdate();
         } finally {
             Profiler.end(profileZone);

--- a/src/layaAir/laya/d3/core/scene/Scene3D.ts
+++ b/src/layaAir/laya/d3/core/scene/Scene3D.ts
@@ -391,6 +391,7 @@ export class Scene3D extends Sprite {
     _sceneModuleData: ISceneNodeData;
     /** @internal */
     componentElementMap: Map<string, IElementComponentManager> = new Map();
+    private _componentElementList: IElementComponentManager[] = [];
 
     /** @internal */
     private _componentElementDatasMap: any = {};
@@ -764,7 +765,9 @@ export class Scene3D extends Sprite {
         this.ambientColor = new Color(0.212, 0.227, 0.259);
 
         Scene3D.componentManagerMap.forEach((val, key) => {
-            this.componentElementMap.set(key, new val());
+            let manager = new val();
+            this.componentElementMap.set(key, manager);
+            this._componentElementList.push(manager);
         });
     }
 
@@ -836,9 +839,9 @@ export class Scene3D extends Sprite {
         else
             this._volumeManager.handleMotionlist();
 
-        this.componentElementMap.forEach((value) => {
-            value.update(delta);
-        });
+        for (let i = 0, n = this._componentElementList.length; i < n; i++) {
+            this._componentElementList[i].update(delta);
+        }
         this._componentDriver.callAfterSceneUpdate();
         //this._sceneRenderManager.updateMotionObjects();
         this._sceneRenderManager.renderUpdate();

--- a/src/layaAir/laya/tilemap/TileMapChunkData.ts
+++ b/src/layaAir/laya/tilemap/TileMapChunkData.ts
@@ -24,6 +24,8 @@ interface ITileMapRenderElement {
     maxCell: number;
     cacheData: Array<Float32Array>;
     updateFlag: Array<boolean>;
+    updateMin: Array<number>;
+    updateMax: Array<number>;
 }
 
 export interface IMergeCellInfo {
@@ -373,6 +375,21 @@ export class TileMapChunkData {
         }
     }
 
+    private _markBufferDirty(element: ITileMapRenderElement, bufferIndex: number, floatOffset: number) {
+        let end = floatOffset + 4;
+        if (!element.updateFlag[bufferIndex]) {
+            element.updateFlag[bufferIndex] = true;
+            element.updateMin[bufferIndex] = floatOffset;
+            element.updateMax[bufferIndex] = end;
+            return;
+        }
+
+        if (floatOffset < element.updateMin[bufferIndex])
+            element.updateMin[bufferIndex] = floatOffset;
+        if (end > element.updateMax[bufferIndex])
+            element.updateMax[bufferIndex] = end;
+    }
+
     private _updateRenderData() {
 
         if (this._reCreateRenderData) {
@@ -447,10 +464,10 @@ export class TileMapChunkData {
                             let tilemapRenderElementInfo = this._renderElementArray[chuckCellinfo._renderElementIndex];
                             if (value & TileMapDirtyFlag.CELL_CHANGE || (value & TileMapDirtyFlag.CELL_QUAD)) {
                                 let data = tilemapRenderElementInfo.cacheData[TileMapChunkData.instanceposScalBufferIndex];
-                                tilemapRenderElementInfo.updateFlag[TileMapChunkData.instanceposScalBufferIndex] = true;
                                 this._getCellPos(chuckCellinfo, pos);
                                 let posOffset = cellData.texture_origin;
                                 let dataoffset = chuckCellinfo._cellPosInRenderData * 4;
+                                this._markBufferDirty(tilemapRenderElementInfo, TileMapChunkData.instanceposScalBufferIndex, dataoffset);
                                 data[dataoffset] = pos.x + posOffset.x;
                                 data[dataoffset + 1] = pos.y + posOffset.y;
                                 let uvSize = nativesData._getRegionSize();
@@ -461,8 +478,8 @@ export class TileMapChunkData {
                             if ((value & TileMapDirtyFlag.CELL_CHANGE) || (value & TileMapDirtyFlag.CELL_QUADUV)) {
                                 //cell uv /Animation
                                 let data = tilemapRenderElementInfo.cacheData[TileMapChunkData.instanceuvOriScalBufferIndex];
-                                tilemapRenderElementInfo.updateFlag[TileMapChunkData.instanceuvOriScalBufferIndex] = true;
                                 let dataoffset = chuckCellinfo._cellPosInRenderData * 4;
+                                this._markBufferDirty(tilemapRenderElementInfo, TileMapChunkData.instanceuvOriScalBufferIndex, dataoffset);
                                 let uvOri = nativesData._getTextureUVOri();
                                 let uvextend = nativesData._getTextureUVExtends();
                                 data[dataoffset] = uvOri.x;
@@ -474,8 +491,8 @@ export class TileMapChunkData {
                             if ((value & TileMapDirtyFlag.CELL_CHANGE) || (value & TileMapDirtyFlag.CELL_COLOR)) {
                                 //cellColor
                                 let data = tilemapRenderElementInfo.cacheData[TileMapChunkData.instanceColorBufferIndex];
-                                tilemapRenderElementInfo.updateFlag[TileMapChunkData.instanceColorBufferIndex] = true;
                                 let dataoffset = chuckCellinfo._cellPosInRenderData * 4;
+                                this._markBufferDirty(tilemapRenderElementInfo, TileMapChunkData.instanceColorBufferIndex, dataoffset);
                                 let color = cellData.colorModulate;
                                 data[dataoffset] = color.r;
                                 data[dataoffset + 1] = color.g;
@@ -486,8 +503,8 @@ export class TileMapChunkData {
                             if (chuckCellinfo.updateTransFlag || (value & TileMapDirtyFlag.CELL_UVTRAN) || (value & TileMapDirtyFlag.CELL_CHANGE)) {
                                 chuckCellinfo.updateTransFlag = false;
                                 let data = tilemapRenderElementInfo.cacheData[TileMapChunkData.instanceuvTransBufferIndex];
-                                tilemapRenderElementInfo.updateFlag[TileMapChunkData.instanceuvTransBufferIndex] = true;
                                 let dataoffset = chuckCellinfo._cellPosInRenderData * 4;
+                                this._markBufferDirty(tilemapRenderElementInfo, TileMapChunkData.instanceuvTransBufferIndex, dataoffset);
                                 let transData = TileMapUtils.parseTransFlag(this._gridShape, chuckCellinfo._transFlag, cellData);
                                 data[dataoffset] = transData.x;
                                 data[dataoffset + 1] = transData.y;
@@ -504,7 +521,9 @@ export class TileMapChunkData {
                         if (element.updateFlag[updateindex]) {
                             let data = element.cacheData[updateindex];
                             let verBuffer = element.renderElement.geometry.bufferState._vertexBuffers[updateindex + 1];//第一个Buffer是BaseBuffer
-                            verBuffer.setData(data.buffer as ArrayBuffer, 0, 0, data.byteLength);
+                            let byteOffset = element.updateMin[updateindex] * 4;
+                            let byteLength = element.updateMax[updateindex] * 4 - byteOffset;
+                            verBuffer.setData(data.buffer as ArrayBuffer, byteOffset, byteOffset, byteLength);
                             element.updateFlag[updateindex] = false;
                         }
                     }
@@ -1218,6 +1237,8 @@ class TileChunkPool {
                 renderElement,
                 cacheData: null,
                 updateFlag: [false, false, false, false],
+                updateMin: [0, 0, 0, 0],
+                updateMax: [0, 0, 0, 0],
                 maxCell: 0
             }
         }

--- a/src/layaAir/laya/vfx/VFXRenderer.ts
+++ b/src/layaAir/laya/vfx/VFXRenderer.ts
@@ -1205,6 +1205,15 @@ function applyBlendMode(mat: Material, mode: string): void {
     }
 }
 
+function setVector2IfChanged(mat: Material, name: string, x: number, y: number): void {
+    const cur = mat.getVector2(name);
+    if (cur && cur.x === x && cur.y === y) {
+        return;
+    }
+
+    mat.setVector2(name, new Vector2(x, y));
+}
+
 /**
  * 按 softFade 值开启/关闭材质的 Soft Particle 效果
  *   softFade > 0：开启 SOFT_PARTICLE define，并设 u_SoftParticleFactor.x = softFade
@@ -1216,7 +1225,7 @@ function applySoftParticle(mat: Material, softFade: number): void {
     const sd = (mat as any)._shaderValues as ShaderData;
     if (softFade > 0) {
         if (sd && def) sd.addDefine(def);
-        mat.setVector2("u_SoftParticleFactor", new Vector2(softFade, 0));
+        setVector2IfChanged(mat, "u_SoftParticleFactor", softFade, 0);
     } else {
         if (sd && def) sd.removeDefine(def);
     }
@@ -1244,7 +1253,7 @@ function applyFlipbook(mat: Material, uvMode: string, flipbookSize: Vector2): vo
     }
     const cols = (flipbookSize && flipbookSize.x) || 4;
     const rows = (flipbookSize && flipbookSize.y) || 4;
-    mat.setVector2("u_FlipbookSize", new Vector2(cols, rows));
+    setVector2IfChanged(mat, "u_FlipbookSize", cols, rows);
 }
 
 function applySubpixelAA(mat: Material, enabled: boolean): void {

--- a/src/layaAir/laya/vfx/VFXRenderer.ts
+++ b/src/layaAir/laya/vfx/VFXRenderer.ts
@@ -1205,13 +1205,16 @@ function applyBlendMode(mat: Material, mode: string): void {
     }
 }
 
-function setVector2IfChanged(mat: Material, name: string, x: number, y: number): void {
-    const cur = mat.getVector2(name);
+let _idSoftParticleFactor: number = -1;
+let _idFlipbookSize: number = -1;
+
+function setVector2IfChanged(mat: Material, uniformIndex: number, x: number, y: number): void {
+    const cur = mat.getVector2ByIndex(uniformIndex);
     if (cur && cur.x === x && cur.y === y) {
         return;
     }
 
-    mat.setVector2(name, new Vector2(x, y));
+    mat.setVector2ByIndex(uniformIndex, new Vector2(x, y));
 }
 
 /**
@@ -1225,7 +1228,10 @@ function applySoftParticle(mat: Material, softFade: number): void {
     const sd = (mat as any)._shaderValues as ShaderData;
     if (softFade > 0) {
         if (sd && def) sd.addDefine(def);
-        setVector2IfChanged(mat, "u_SoftParticleFactor", softFade, 0);
+        if (_idSoftParticleFactor < 0) {
+            _idSoftParticleFactor = Shader3D.propertyNameToID("u_SoftParticleFactor");
+        }
+        setVector2IfChanged(mat, _idSoftParticleFactor, softFade, 0);
     } else {
         if (sd && def) sd.removeDefine(def);
     }
@@ -1253,7 +1259,10 @@ function applyFlipbook(mat: Material, uvMode: string, flipbookSize: Vector2): vo
     }
     const cols = (flipbookSize && flipbookSize.x) || 4;
     const rows = (flipbookSize && flipbookSize.y) || 4;
-    setVector2IfChanged(mat, "u_FlipbookSize", cols, rows);
+    if (_idFlipbookSize < 0) {
+        _idFlipbookSize = Shader3D.propertyNameToID("u_FlipbookSize");
+    }
+    setVector2IfChanged(mat, _idFlipbookSize, cols, rows);
 }
 
 function applySubpixelAA(mat: Material, enabled: boolean): void {

--- a/src/layaAir/laya/vfx/systems/VFXParticleSystem.ts
+++ b/src/layaAir/laya/vfx/systems/VFXParticleSystem.ts
@@ -605,13 +605,10 @@ export class VFXParticleSystem extends VFXSystem {
         this._lastSystemSeed = state.systemSeed;
         this._constantsWrittenCount = allDatas.length;
 
+        // 设置 emitter 矩阵到所有阶段（空间变换需要）
         for (const sd of allDatas) {
             sd.setNumber(ID.u_DeltaTime, state.deltaTime);
             sd.setNumber(ID.u_TotalTime, state.totalTime);
-        }
-
-        // 设置 emitter 矩阵到所有阶段（空间变换需要）
-        for (const sd of allDatas) {
             sd.setMatrix4x4(ID.u_EmitterWorldMatrix, state.emitterWorldMatrix);
             sd.setMatrix4x4(ID.u_InvEmitterWorldMatrix, state.invEmitterWorldMatrix);
         }

--- a/src/layaAir/laya/vfx/systems/VFXParticleSystem.ts
+++ b/src/layaAir/laya/vfx/systems/VFXParticleSystem.ts
@@ -560,6 +560,11 @@ export class VFXParticleSystem extends VFXSystem {
      * 设置各阶段共享的 uniform（每帧调用一次，赋值给所有 shaderData）
      */
     private _allShaderDatas: ShaderData[];
+    private _constantsWrittenCount: number = 0;
+    private _lastCapacity: number = -1;
+    private _lastParticlePerStrip: number = -1;
+    private _lastStripCapacity: number = -1;
+    private _lastSystemSeed: number = -1;
 
     getAllShaderDatas(): ShaderData[] {
         // Multi-Output: extras 是 VisualEffect.onAwake 之后 push 进 this.extraOutputs 的，
@@ -579,14 +584,30 @@ export class VFXParticleSystem extends VFXSystem {
 
     setCommonUniforms(state: VFXState, camera: Camera): void {
         const allDatas = this.getAllShaderDatas();
-        for (const sd of allDatas) {
+
+        const constantsChanged = this._lastCapacity !== this.capacity
+            || this._lastParticlePerStrip !== this.particlePerStripCount
+            || this._lastStripCapacity !== this.stripCapacity
+            || this._lastSystemSeed !== state.systemSeed;
+
+        for (let i = constantsChanged ? 0 : this._constantsWrittenCount, n = allDatas.length; i < n; i++) {
+            const sd = allDatas[i];
             sd.setInt(ID.u_Capacity, this.capacity);
-            sd.setNumber(ID.u_DeltaTime, state.deltaTime);
-            sd.setNumber(ID.u_TotalTime, state.totalTime);
             sd.setInt(ID.u_SystemSeed, state.systemSeed);
             sd.setInt(ID.u_MaxSpawnCount, this.capacity);
             sd.setInt(ID.u_ParticlePerStrip, this.particlePerStripCount);
             sd.setInt(ID.u_StripCapacity, this.stripCapacity);
+        }
+
+        this._lastCapacity = this.capacity;
+        this._lastParticlePerStrip = this.particlePerStripCount;
+        this._lastStripCapacity = this.stripCapacity;
+        this._lastSystemSeed = state.systemSeed;
+        this._constantsWrittenCount = allDatas.length;
+
+        for (const sd of allDatas) {
+            sd.setNumber(ID.u_DeltaTime, state.deltaTime);
+            sd.setNumber(ID.u_TotalTime, state.totalTime);
         }
 
         // 设置 emitter 矩阵到所有阶段（空间变换需要）


### PR DESCRIPTION
Performance fixes -

**Redundant uniform writes** — every `setInt`/`setVector2` marks its
property dirty and queues the owning uniform block for re-upload, which
on WebGPU becomes a staging-path `writeBuffer` after the frame's first
submit. Three commits skip writes whose value did not change: the five
invariant VFX particle constants (capacity, spawn count, strip sizes,
seed), and the VFX material `u_SoftParticleFactor` / `u_FlipbookSize`
pair. A fourth resolves those two property ids once instead of doing two
string lookups per call.

**Tilemap uploads** — `TileMapChunkData._updateRenderData` wrote changed
cells at known offsets, then uploaded the whole chunk buffer. One
animated tile re-sent every tile in its chunk across all four instance
buffers. Now tracks a min/max dirty span and uploads only that, matching
what the 2D whole-buffer path already does.

**Render list clear** — `RenderListQueue.clear` nulled the whole backing
array. `SingletonList` never shrinks, so a camera that once faced a
crowded scene paid that peak on every later frame. Bounded to the used
range.

**Per-frame closures** — `Scene3D._update` (both the plain and the
Profiler-wrapped copy) and `WebDefineDatas._notifyChangeFlag` allocated
a callback per call via `Map.forEach` / `Set.forEach`. Replaced with
indexed and `for-of` loops over the same data.

Typechecks clean with `tsc --noEmit -p src/layaAir` (remaining errors in
that run are pre-existing on the base branch).
